### PR TITLE
tests: add coverage for vm_hardware_memory

### DIFF
--- a/tests/integration/targets/vcenter_vm_scenario1/tasks/vm_hardware_memory.yaml
+++ b/tests/integration/targets/vcenter_vm_scenario1/tasks/vm_hardware_memory.yaml
@@ -1,0 +1,19 @@
+---
+- name: Retrieve the memory information from the VM
+  vcenter_vm_hardware_memory_info:
+    vm: '{{ test_vm1_info.id }}'
+  register: _result
+
+- debug: var=_result
+
+- name: Increase the memory of a VM
+  vcenter_vm_hardware_memory:
+    vm: '{{ test_vm1_info.id }}'
+    size_MiB: 1080
+  register: _result
+
+- debug: var=_result
+
+- assert:
+    that:
+      - _result is changed

--- a/tests/integration/targets/vcenter_vm_scenario1/tasks/vm_info.yaml
+++ b/tests/integration/targets/vcenter_vm_scenario1/tasks/vm_info.yaml
@@ -13,3 +13,11 @@
   register: test_vm1_info
 
 - debug: var=test_vm1_info
+
+
+- name: Collect the hardware information
+  vcenter_vm_hardware_info:
+    vm: '{{ search_result.value[0].vm }}'
+  register: my_vm1_hardware_info
+
+- debug: var=my_vm1_hardware_info


### PR DESCRIPTION
Depends-On: https://github.com/ansible-collections/vmware.vmware_rest/pull/92
Depends-On: https://github.com/ansible-collections/vmware.vmware_rest/pull/88

Add coverage for:

- `vcenter_vm_hardware_memory`
- `vcenter_vm_hardware_memory_info`
- `vcenter_vm_hardware_info`