### PR TITLE
tests: add coverage for parallel port

### DIFF
--- a/tests/integration/targets/vcenter_vm_scenario1/tasks/vm_hardware_parallel.yaml
+++ b/tests/integration/targets/vcenter_vm_scenario1/tasks/vm_hardware_parallel.yaml
@@ -1,0 +1,18 @@
+---
+- name: Retrieve the parallel port information from the VM
+  vcenter_vm_hardware_parallel_info:
+    vm: '{{ test_vm1_info.id }}'
+  register: _result
+
+- debug: var=_result
+
+- vcenter_vm_hardware_parallel:
+    vm: '{{ test_vm1_info.id }}'
+    allow_guest_control: true
+  register: _result
+
+- debug: var=_result
+
+- assert:
+    that:
+      - _result is changed


### PR DESCRIPTION
Depends-On: https://github.com/ansible-collections/vmware.vmware_rest/pull/88

Add coverage for the following modules:
- `vcenter_vm_hardware_parallel`
- `vcenter_vm_hardware_parallel_info`