### PR TITLE
tests: don't record the idempotency check in EXAMPLES

### DIFF
--- a/tests/integration/targets/vcenter_vm_scenario1/tasks/create_vm.yaml
+++ b/tests/integration/targets/vcenter_vm_scenario1/tasks/create_vm.yaml
@@ -18,7 +18,7 @@
     that:
       - _result is changed
 
-- name: Create a VM (again)
+- name: _Create a VM (again)
   vcenter_vm:
     placement:
       cluster: "{{ all_the_clusters.value[0].cluster }}"

--- a/tests/integration/targets/vcenter_vm_scenario1/tasks/prepare_datacenter.yaml
+++ b/tests/integration/targets/vcenter_vm_scenario1/tasks/prepare_datacenter.yaml
@@ -16,7 +16,7 @@
     that:
       - _result is changed
 
-- name: Create datacenter my_dc (again)
+- name: _Create datacenter my_dc (again)
   vcenter_datacenter:
     name: my_dc
     folder: "{{ my_datacenter_folder.folder }}"

--- a/tests/integration/targets/vcenter_vm_scenario1/tasks/vm_hardware.yaml
+++ b/tests/integration/targets/vcenter_vm_scenario1/tasks/vm_hardware.yaml
@@ -11,7 +11,7 @@
     that:
       - _result is changed
 
-- name: Upgrade the VM hardware version (again)
+- name: _Upgrade the VM hardware version (again)
   vcenter_vm_hardware:
     upgrade_policy: AFTER_CLEAN_SHUTDOWN
     upgrade_version: VMX_13

--- a/tests/integration/targets/vcenter_vm_scenario1/tasks/vm_hardware_boot.yaml
+++ b/tests/integration/targets/vcenter_vm_scenario1/tasks/vm_hardware_boot.yaml
@@ -13,7 +13,7 @@
     that:
       - _result is changed
 
-- name: Change a VM boot parameters (again)
+- name: _Change a VM boot parameters (again)
   vcenter_vm_hardware_boot:
     vm: '{{ test_vm1_info.id }}'
     efi_legacy_boot: True

--- a/tests/integration/targets/vcenter_vm_scenario1/tasks/vm_hardware_cdrom.yaml
+++ b/tests/integration/targets/vcenter_vm_scenario1/tasks/vm_hardware_cdrom.yaml
@@ -55,7 +55,7 @@
       - _result is changed
 
 
-- name: Get boot device info (again)
+- name: _Get boot device info (again)
   vcenter_vm_hardware_boot_device_info:
     vm: '{{ test_vm1_info.id }}'
   register: _result

--- a/tests/integration/targets/vcenter_vm_scenario1/tasks/vm_hardware_disk.yaml
+++ b/tests/integration/targets/vcenter_vm_scenario1/tasks/vm_hardware_disk.yaml
@@ -102,7 +102,8 @@
 - assert:
     that: _result is changed
 
-- vcenter_vm_hardware_adapter_sata:
+- name: Remove SATA adapter at PCI slot 34
+  vcenter_vm_hardware_adapter_sata:
     vm: '{{ test_vm1_info.id }}'
     pci_slot_number: 34
     state: absent


### PR DESCRIPTION
By using the `_` prefix, we ensure these tasks won't be injected
in the EXAMPLES/RETURN blocks.