### PR TITLE
prepare 0.4.0 release

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,15 @@ vmware.vmware_rest Release Notes
 .. contents:: Topics
 
 
+v0.4.0
+======
+
+Minor Changes
+-------------
+
+- The format of the output of the Modules is now documented in the RETURN block.
+- vcenter_rest_log_file - this optional parameter can be used to point on the log file where all the HTTP interaction will be record.
+
 v0.3.0
 ======
 

--- a/changelogs/changelog.yaml
+++ b/changelogs/changelog.yaml
@@ -46,3 +46,13 @@ releases:
     - drop_vcenter_vm_tools_installer.yaml
     - new_modules.yaml
     release_date: '2020-09-25'
+  0.4.0:
+    changes:
+      minor_changes:
+      - The format of the output of the Modules is now documented in the RETURN block.
+      - vcenter_rest_log_file - this optional parameter can be used to point on the
+        log file where all the HTTP interaction will be record.
+    fragments:
+    - add_RETURN_block_to_modules.yaml
+    - add_vcenter_rest_log_file_parameter.yaml
+    release_date: '2020-09-30'

--- a/changelogs/fragments/add_vcenter_rest_log_file_parameter.yaml
+++ b/changelogs/fragments/add_vcenter_rest_log_file_parameter.yaml
@@ -1,3 +1,0 @@
----
-minor_changes:
-- vcenter_rest_log_file - this optional parameter can be used to point on the log file where all the HTTP interaction will be record.


### PR DESCRIPTION
Minor Changes
-------------

- The format of the output of the Modules is now documented in the RETURN
  block.
- vcenter_rest_log_file - this optional parameter can be used to point on the
  log file where all the HTTP interaction will be record.