### PR TITLE
tests: adjust vcenter_vm_hardware_ethernet idempotency

### DIFF
--- a/tests/integration/targets/vcenter_vm_scenario1/tasks/vm_hardware_ethernet.yaml
+++ b/tests/integration/targets/vcenter_vm_scenario1/tasks/vm_hardware_ethernet.yaml
@@ -16,6 +16,19 @@
     start_connected: true
     vm: '{{ test_vm1_info.id }}'
 
+- name: _Turn the NIC's start_connected flag on (again)
+  vmware.vmware_rest.vcenter_vm_hardware_ethernet:
+    nic: '{{ vm_hardware_ethernet_1.id }}'
+    start_connected: true
+    vm: '{{ test_vm1_info.id }}'
+  register: _result
+
+- debug: var=_result
+
+- assert:
+    that:
+      - not(_result is changed)
+
 - name: _Attach a VM to a dvswitch (again)
   vmware.vmware_rest.vcenter_vm_hardware_ethernet:
     vm: '{{ test_vm1_info.id }}'
@@ -31,19 +44,6 @@
 - name: Validate idempotency
   assert:
     that: vm_hardware_ethernet_1.id == _vm_hardware_ethernet_2.id
-
-- name: _Turn the NIC's start_connected flag on (again)
-  vmware.vmware_rest.vcenter_vm_hardware_ethernet:
-    nic: 4000
-    start_connected: true
-    vm: '{{ test_vm1_info.id }}'
-  register: _result
-
-- debug: var=_result
-
-- assert:
-    that:
-      - not(_result is changed)
 
 - name: Collect a list of the NIC for a given VM
   vmware.vmware_rest.vcenter_vm_hardware_ethernet_info:


### PR DESCRIPTION
- don't hardcode the device id
- move the blocks to get a more logical execution flow