### PR TITLE
tox: add refresh_modules and refresh_examples target

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -19,13 +19,16 @@ deps = git+https://github.com/ansible-network/collection_prep
 commands = collection_prep_add_docs -p .
 
 [testenv:refresh_modules]
-deps = git+https://github.com/ansible-collections/vmware_rest_code_generator
-commands = vmware_rest_code_generator_refresh_modules --target-dir .
-
-[testenv:refresh_examples]
-deps = git+https://github.com/ansible-collections/vmware_rest_code_generator
-commands = vmware_rest_code_generator_refresh_examples --target-dir .
-
+deps =
+  git+https://github.com/ansible-collections/vmware_rest_code_generator
+  black==19.10b0 
+commands =
+  vmware_rest_code_generator_refresh_modules --target-dir .
+  vmware_rest_code_generator_refresh_examples --target-dir .
+  black {toxinidir}/plugins {toxinidir}/tests
+  echo "now you can update the RETURN block, see https://github.com/ansible-collections/vmware_rest_code_generator#how-to-refresh-the-vmwarevmware_rest-content"
+allowlist_externals =
+  echo
 
 [testenv:build_manual]
 deps = sphinx


### PR DESCRIPTION
Update the `refresh_modules` target to use the following new commnads:

- vmware_rest_code_generator_refresh_modules
- vmware_rest_code_generator_refresh_examples