### PR TITLE
Add bindep.txt for execution environments

### DIFF
--- a/bindep.txt
+++ b/bindep.txt
@@ -1,0 +1,4 @@
+# This is a cross-platform list tracking distribution packages needed by tests;
+# see https://docs.openstack.org/infra/bindep/ for additional information.
+
+gcc [compile platform:centos-8 platform:rhel-8]


### PR DESCRIPTION
Depends-On: https://github.com/ansible-collections/vmware.vmware_rest/pull/185

Because we need to build aiohttp, some dependencies require gcc to
compile those python packages.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>