### PR TITLE
tests: one single health play

### DIFF
--- a/tests/integration/targets/appliance/tasks/appliance_health.yaml
+++ b/tests/integration/targets/appliance/tasks/appliance_health.yaml
@@ -47,7 +47,17 @@
 
 - debug: var=result
 
-# returns an err500
+- name: Get the health state of applmgmt
+  vmware.vmware_rest.appliance_health_applmgmt_info:
+  register: result
+
+- debug: var=result
+
+- debug: var=result
+- assert:
+    that:
+      result.value == "green"
+  # returns an err500
 #- name: Get the health state of system last_check
 #  vmware.vmware_rest.appliance_health_system_lastcheck:
 #  register: result

--- a/tests/integration/targets/appliance/tasks/appliance_health_applmgmt.yaml
+++ b/tests/integration/targets/appliance/tasks/appliance_health_applmgmt.yaml
@@ -1,8 +1,0 @@
-- name: Get the health state of applmgmt
-  vmware.vmware_rest.appliance_health_applmgmt_info:
-  register: result
-
-- debug: var=result
-- assert:
-    that:
-      result.value == "green"


### PR DESCRIPTION
Depends-On: https://github.com/ansible-collections/vmware.vmware_rest/pull/192

Move the `appliance_health_applmgmt_info` in the main heath play.