### PR TITLE
shutdown VM two times

### DIFF
--- a/plugins/module_utils/vmware_rest.py
+++ b/plugins/module_utils/vmware_rest.py
@@ -181,7 +181,10 @@ async def update_changed_flag(data, status, operation):
     elif data.get("type") == "com.vmware.vapi.std.errors.already_exists":
         data["failed"] = False
         data["changed"] = False
-    elif data.get("value", {}).get("error_type") == "ALREADY_EXISTS":
+    elif data.get("value", {}).get("error_type") in [
+        "ALREADY_EXISTS",
+        "ALREADY_IN_DESIRED_STATE",
+    ]:
         data["failed"] = False
         data["changed"] = False
     elif data.get("type") == "com.vmware.vapi.std.errors.resource_in_use":


### PR DESCRIPTION
Depends-On: https://github.com/ansible-collections/vmware.vmware_rest/pull/192

If we shutdown a VM two times in a row, the second call raises an
`ALREADY_IN_DESIRED_STATE` that we can ignore.