### PR TITLE
gen_args: fix elements concatenation 

### DIFF
--- a/plugins/module_utils/vmware_rest.py
+++ b/plugins/module_utils/vmware_rest.py
@@ -112,7 +112,10 @@ def gen_args(params, in_query_parameter):
             args += "&"
         if isinstance(v, list):
             for j in v:
-                args += (i + "=") + j
+                if j == v[-1]:
+                    args += (i + "=") + j
+                else:
+                    args += (i + "=") + j + '&'
         elif isinstance(v, bool) and v:
             args += i + "=true"
         else:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
`gen_args` does not concatenate as as expected.

Fixes: https://github.com/ansible-collections/vmware.vmware_rest/issues/198

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
module_utils/vmware_rest.py