### PR TITLE
rst: ignore temp dir and rstcheck config file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -390,3 +390,5 @@ changelogs/.plugin-cache.yaml
 manual/source/vmware_rest_scenarios/task_outputs
 commit_message
 tests/integration/inventory.networking
+manual/rst
+manual/build

--- a/manual/source/.rstcheck.cfg
+++ b/manual/source/.rstcheck.cfg
@@ -1,0 +1,2 @@
+[rstcheck]
+ignore_directives=ansible-task,ansible-tasks


### PR DESCRIPTION
Add a configuration file for `rstcheck` and extends the .gitignore
to ignore some temp directories.