### PR TITLE
tests: ignore the outputs of the idempotency tests

### DIFF
--- a/tests/integration/targets/appliance/tasks/appliance_localaccounts.yaml
+++ b/tests/integration/targets/appliance/tasks/appliance_localaccounts.yaml
@@ -8,7 +8,7 @@
   vmware.vmware_rest.appliance_localaccounts_globalpolicy:
     warn_days: 5
 
-- name: Update the global policy of the local accounts (idempotency)
+- name: _Update the global policy of the local accounts (idempotency)
   vmware.vmware_rest.appliance_localaccounts_globalpolicy:
     warn_days: 5
   register: result
@@ -46,7 +46,7 @@
   register: result
 - debug: var=result
 
-- name: Add a local accounts (idempotency)
+- name: _Add a local accounts (idempotency)
   vmware.vmware_rest.appliance_localaccounts:
     username: foobar
     config:

--- a/tests/integration/targets/appliance/tasks/appliance_networking_dns_domains.yaml
+++ b/tests/integration/targets/appliance/tasks/appliance_networking_dns_domains.yaml
@@ -12,7 +12,7 @@
 
 - debug: var=result
 
-- name: Update the domain configuration (again)
+- name: _Update the domain configuration (again)
   vmware.vmware_rest.appliance_networking_dns_domains:
     domains:
       - foobar

--- a/tests/integration/targets/appliance/tasks/appliance_networking_dns_servers.yaml
+++ b/tests/integration/targets/appliance/tasks/appliance_networking_dns_servers.yaml
@@ -12,7 +12,7 @@
   ignore_errors: True  # May be failing because of the CI set-up
 - debug: var=result
 
-- name: Set the DNS servers (again)
+- name: _Set the DNS servers (again)
   vmware.vmware_rest.appliance_networking_dns_servers:
     servers:
       - 1.1.1.1

--- a/tests/integration/targets/appliance/tasks/appliance_networking_proxy.yaml
+++ b/tests/integration/targets/appliance/tasks/appliance_networking_proxy.yaml
@@ -14,7 +14,7 @@
 - debug: var=result
 
 
-- name: Set the HTTP proxy configuration (again)
+- name: _Set the HTTP proxy configuration (again)
   vmware.vmware_rest.appliance_networking_proxy:
     enabled: true
     server: http://47.244.50.194
@@ -44,7 +44,7 @@
   register: result
 - debug: var=result
 
-- name: Set HTTP noproxy configuration (again)
+- name: _Set HTTP noproxy configuration (again)
   vmware.vmware_rest.appliance_networking_noproxy:
     servers:
       - redhat.com

--- a/tests/integration/targets/appliance/tasks/appliance_ntp.yaml
+++ b/tests/integration/targets/appliance/tasks/appliance_ntp.yaml
@@ -6,7 +6,7 @@
     servers:
       - time.google.com
 
-- name: Adjust the NTP configuration (again)
+- name: _Adjust the NTP configuration (again)
   vmware.vmware_rest.appliance_ntp:
     servers:
       - time.google.com

--- a/tests/integration/targets/appliance/tasks/appliance_shutdown.yaml
+++ b/tests/integration/targets/appliance/tasks/appliance_shutdown.yaml
@@ -41,7 +41,7 @@
       - result.changed
   ignore_errors: True
 
-- name: Abort the reboot (again)
+- name: _Abort the reboot (again)
   vmware.vmware_rest.appliance_shutdown:
     state: cancel
   register: result


### PR DESCRIPTION
No need to include these tests in the EXAMPLES blocks.