### PR TITLE
tox: refresh_modules accept posargs

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -23,7 +23,7 @@ deps =
   git+https://github.com/ansible-collections/vmware_rest_code_generator
   black==19.10b0 
 commands =
-  vmware_rest_code_generator_refresh_modules --target-dir .
+  vmware_rest_code_generator_refresh_modules --target-dir . {posargs}
   vmware_rest_code_generator_refresh_examples --target-dir .
   black {toxinidir}/plugins {toxinidir}/tests
   echo "now you can update the RETURN block, see https://github.com/ansible-collections/vmware_rest_code_generator#how-to-refresh-the-vmwarevmware_rest-content"


### PR DESCRIPTION
This way we can specify the `--next-version` parameter.