### PR TITLE
bump the default timeout to 600s

### DIFF
--- a/changelogs/fragments/bump_timeout.yaml
+++ b/changelogs/fragments/bump_timeout.yaml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+- bump the default timeout to 600s to give more time to the slow operations.

--- a/plugins/module_utils/vmware_rest.py
+++ b/plugins/module_utils/vmware_rest.py
@@ -85,6 +85,7 @@ async def open_session(
 
     session_id = json["value"]
     session = aiohttp.ClientSession(
+        timeout=aiohttp.ClientTimeout(total=600),
         connector=connector,
         headers={
             "vmware-api-session-id": session_id,


### PR DESCRIPTION
##### SUMMARY

Bump the client timeout to 600s. It was 300s before.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request