### PR TITLE
init.{sh,fish}: also configure govc

### DIFF
--- a/tests/integration/targets/init.fish
+++ b/tests/integration/targets/init.fish
@@ -20,3 +20,8 @@ set -x ESXI2_USERNAME (sed 's,^esxi2_username=\(.*\),\1,;t;d' $INVENTORY_PATH)
 set -x ESXI2_PASSWORD (sed 's,^esxi2_password=\(.*\),\1,;t;d' $INVENTORY_PATH)
 set -x VMWARE_VALIDATE_CERTS no
 set -x ANSIBLE_ROLES_PATH (realpath (status dirname))
+set -x GOVC_PASSWORD $VMWARE_PASSWORD
+set -x GOVC_HOST $VMWARE_HOST
+set -x GOVC_USERNAME $VMWARE_USER
+set -x GOVC_URL https://$VMWARE_HOST/sdk
+set -x GOVC_INSECURE 1

--- a/tests/integration/targets/init.sh
+++ b/tests/integration/targets/init.sh
@@ -30,3 +30,8 @@ export ESXI2_USERNAME=$(sed 's,^esxi2_username=\(.*\),\1,;t;d' ${INVENTORY_PATH}
 export ESXI2_PASSWORD=$(sed 's,^esxi2_password=\(.*\),\1,;t;d' ${INVENTORY_PATH})
 export VMWARE_VALIDATE_CERTS=no
 export ANSIBLE_ROLES_PATH=${BASE_DIR}
+export GOVC_PASSWORD=$VMWARE_PASSWORD
+export GOVC_HOST=$VMWARE_HOST
+export GOVC_USERNAME=$VMWARE_USER
+export GOVC_URL="https://${VMWARE_HOST}/sdk"
+export GOVC_INSECURE=1


### PR DESCRIPTION
The goal is to have one single script to initialize the environment.