### PR TITLE
appliance/test: fix DNS and proxy

### DIFF
--- a/manual/source/vmware_rest_scenarios/appliance/network.rst
+++ b/manual/source/vmware_rest_scenarios/appliance/network.rst
@@ -79,6 +79,7 @@ The appliance_networking_dns_servers can be used to set a different name server.
     vmware.vmware_rest.appliance_networking_dns_servers:
       servers:
         - 192.168.123.1
+      mode: is_static
 
 You can test a list of servers if you set ``state=test``:
 
@@ -153,9 +154,9 @@ In this example, we will set up a proxy and configure the ``noproxy`` for ``redh
   - name: Set the HTTP proxy configuration
     vmware.vmware_rest.appliance_networking_proxy:
       enabled: true
-      server: http://47.244.50.194
-      port: 8081
-      protocol: http
+      server: https://datastore.test
+      port: 3128
+      protocol: https
   - name: Set HTTP noproxy configuration
     vmware.vmware_rest.appliance_networking_noproxy:
       servers:

--- a/tests/integration/targets/appliance/tasks/appliance_networking_dns_servers.yaml
+++ b/tests/integration/targets/appliance/tasks/appliance_networking_dns_servers.yaml
@@ -3,17 +3,55 @@
   register: result
 - debug: var=result
 
-- name: Set the DNS servers
+- name: Set static DNS servers
   vmware.vmware_rest.appliance_networking_dns_servers:
     servers:
       - 1.1.1.1
+    mode: is_static
+    state: set
   register: result
 - debug: var=result
+
+- assert:
+    that:
+      - result.value.servers == ["1.1.1.1"]
+
+- pause:
+    seconds: 10
+
 
 - name: _Set the DNS servers (again)
   vmware.vmware_rest.appliance_networking_dns_servers:
     servers:
       - 1.1.1.1
+    mode: is_static
+    state: set
+  register: result
+- debug: var=result
+
+- pause:
+    seconds: 10
+
+
+- name: Add another DNS server
+  vmware.vmware_rest.appliance_networking_dns_servers:
+    server: 8.8.4.4
+    state: add
+  register: result
+- debug: var=result
+
+- assert:
+    that:
+      - result.value.servers == ["1.1.1.1", "8.8.4.4"]
+
+- pause:
+    seconds: 10
+
+- name: Use the DNS servers from the DHCP
+  vmware.vmware_rest.appliance_networking_dns_servers:
+    mode: dhcp
+    servers: []
+    state: set
   register: result
 - debug: var=result
 
@@ -21,6 +59,6 @@
   vmware.vmware_rest.appliance_networking_dns_servers:
     state: test
     servers:
-      - var
+      - google.com
   register: result
 - debug: var=result

--- a/tests/integration/targets/appliance/tasks/appliance_networking_proxy.yaml
+++ b/tests/integration/targets/appliance/tasks/appliance_networking_proxy.yaml
@@ -6,19 +6,18 @@
 - name: Set the HTTP proxy configuration
   vmware.vmware_rest.appliance_networking_proxy:
     enabled: true
-    server: http://47.244.50.194
-    port: 8081
+    server: http://datastore.test
+    port: 3128
     protocol: http
   register: result
-
 - debug: var=result
 
 
 - name: _Set the HTTP proxy configuration (again)
   vmware.vmware_rest.appliance_networking_proxy:
     enabled: true
-    server: http://47.244.50.194
-    port: 8081
+    server: http://datastore.test
+    port: 3128
     protocol: http
   register: result
 


### PR DESCRIPTION
Depends-On: https://github.com/ansible/ansible-zuul-jobs/pull/1112

- dns: give 10s to the service to apply the configuration
- proxy: use a proxy on the datastore host for testing