### PR TITLE
prepare_lab: wait till the library backend is ready

### DIFF
--- a/tests/integration/targets/prepare_lab/tasks/purge_libraries.yaml
+++ b/tests/integration/targets/prepare_lab/tasks/purge_libraries.yaml
@@ -2,6 +2,9 @@
 - name: Build a list of local libraries
   vmware.vmware_rest.content_locallibrary_info:
   register: result
+  retries: 100
+  delay: 3
+  until: result is not failed
 
 - name: Delete all the local libraries
   vmware.vmware_rest.content_locallibrary:


### PR DESCRIPTION
With vSphere 7.0.3, we've got to wait a bit for the library backend.
