### PR TITLE
vcenter_vm_scenario1/tests: don't boot an version 13 VM

### DIFF
--- a/tests/integration/targets/vcenter_vm_scenario1/tasks/vm_hardware.yaml
+++ b/tests/integration/targets/vcenter_vm_scenario1/tasks/vm_hardware.yaml
@@ -3,7 +3,7 @@
   vmware.vmware_rest.vcenter_vm_hardware:
     upgrade_policy: AFTER_CLEAN_SHUTDOWN
     upgrade_version: VMX_13
-    vm: '{{ test_vm1_info.id }}'
+    vm: "{{ lookup('vmware.vmware_rest.vm_moid', '/my_dc/vm/my_vm_from_ovf') }}"
   register: _result
 
 - debug: var=_result
@@ -15,7 +15,7 @@
   vmware.vmware_rest.vcenter_vm_hardware:
     upgrade_policy: AFTER_CLEAN_SHUTDOWN
     upgrade_version: VMX_13
-    vm: '{{ test_vm1_info.id }}'
+    vm: "{{ lookup('vmware.vmware_rest.vm_moid', '/my_dc/vm/my_vm_from_ovf') }}"
   register: _result
 
 - debug: var=_result


### PR DESCRIPTION
VM with version greater than VMX_11 cannot boot properly in the VM.
Upgrade to VMX_13 the my_vm_from_ovf VM because we won't boot it.
