### PR TITLE
lookup: use the FQCN in examples

### DIFF
--- a/plugins/lookup/cluster_moid.py
+++ b/plugins/lookup/cluster_moid.py
@@ -27,17 +27,17 @@ extends_documentation_fragment:
 EXAMPLES = r"""
 # lookup sample
 - name: set connection info
-  set_fact:
+  ansible.builtin.set_fact:
     connection_args:
         vcenter_hostname: "vcenter.test"
         vcenter_username: "administrator@vsphere.local"
         vcenter_password: "1234"
 
 - name: lookup MoID of the object
-  debug: msg="{{ lookup('vmware.vmware_rest.cluster_moid', '/my_dc/host/my_cluster', **connection_args) }}"
+  ansible.builtin.debug: msg="{{ lookup('vmware.vmware_rest.cluster_moid', '/my_dc/host/my_cluster', **connection_args) }}"
 
 - name: lookup MoID of the object inside the path
-  debug: msg="{{ lookup('vmware.vmware_rest.cluster_moid', '/my_dc/host/') }}"
+  ansible.builtin.debug: msg="{{ lookup('vmware.vmware_rest.cluster_moid', '/my_dc/host/') }}"
 """
 
 

--- a/plugins/lookup/datacenter_moid.py
+++ b/plugins/lookup/datacenter_moid.py
@@ -27,17 +27,17 @@ extends_documentation_fragment:
 EXAMPLES = r"""
 # lookup sample
 - name: set connection info
-  set_fact:
+  ansible.builtin.set_fact:
     connection_args:
         vcenter_hostname: "vcenter.test"
         vcenter_username: "administrator@vsphere.local"
         vcenter_password: "1234"
 
 - name: lookup MoID of the object
-  debug: msg="{{ lookup('vmware.vmware_rest.datacenter_moid', '/my_dc', **connection_args) }}"
+  ansible.builtin.debug: msg="{{ lookup('vmware.vmware_rest.datacenter_moid', '/my_dc', **connection_args) }}"
 
 - name: lookup MoID of the object inside the path
-  debug: msg="{{ lookup('vmware.vmware_rest.datacenter_moid', '/my_folder/') }}"
+  ansible.builtin.debug: msg="{{ lookup('vmware.vmware_rest.datacenter_moid', '/my_folder/') }}"
 """
 
 

--- a/plugins/lookup/datastore_moid.py
+++ b/plugins/lookup/datastore_moid.py
@@ -27,17 +27,17 @@ extends_documentation_fragment:
 EXAMPLES = r"""
 # lookup sample
 - name: set connection info
-  set_fact:
+  ansible.builtin.set_fact:
     connection_args:
         vcenter_hostname: "vcenter.test"
         vcenter_username: "administrator@vsphere.local"
         vcenter_password: "1234"
 
 - name: lookup MoID of the object
-  debug: msg="{{ lookup('vmware.vmware_rest.datastore_moid', '/my_dc/host/my_cluster/esxi1.test/ro_datastore', **connection_args) }}"
+  ansible.builtin.debug: msg="{{ lookup('vmware.vmware_rest.datastore_moid', '/my_dc/host/my_cluster/esxi1.test/ro_datastore', **connection_args) }}"
 
 - name: lookup MoID of the object inside the path
-  debug: msg="{{ lookup('vmware.vmware_rest.datastore_moid', '/my_dc/datastore/') }}"
+  ansible.builtin.debug: msg="{{ lookup('vmware.vmware_rest.datastore_moid', '/my_dc/datastore/') }}"
 """
 
 

--- a/plugins/lookup/folder_moid.py
+++ b/plugins/lookup/folder_moid.py
@@ -27,17 +27,17 @@ extends_documentation_fragment:
 EXAMPLES = r"""
 # lookup sample
 - name: set connection info
-  set_fact:
+  ansible.builtin.set_fact:
     connection_args:
         vcenter_hostname: "vcenter.test"
         vcenter_username: "administrator@vsphere.local"
         vcenter_password: "1234"
 
 - name: lookup MoID of the object
-  debug: msg="{{ lookup('vmware.vmware_rest.folder_moid', '/my_dc/vm/foo/bar', **connection_args) }}"
+  ansible.builtin.debug: msg="{{ lookup('vmware.vmware_rest.folder_moid', '/my_dc/vm/foo/bar', **connection_args) }}"
 
 - name: lookup MoID of the object inside the path
-  debug: msg="{{ lookup('vmware.vmware_rest.folder_moid', '/my_dc/vm/foo/') }}"
+  ansible.builtin.debug: msg="{{ lookup('vmware.vmware_rest.folder_moid', '/my_dc/vm/foo/') }}"
 """
 
 

--- a/plugins/lookup/host_moid.py
+++ b/plugins/lookup/host_moid.py
@@ -27,17 +27,17 @@ extends_documentation_fragment:
 EXAMPLES = r"""
 # lookup sample
 - name: set connection info
-  set_fact:
+  ansible.builtin.set_fact:
     connection_args:
         vcenter_hostname: "vcenter.test"
         vcenter_username: "administrator@vsphere.local"
         vcenter_password: "1234"
 
 - name: lookup MoID of the object
-  debug: msg="{{ lookup('vmware.vmware_rest.host_moid', '/my_dc/host/my_cluster/esxi1.test', **connection_args) }}"
+  ansible.builtin.debug: msg="{{ lookup('vmware.vmware_rest.host_moid', '/my_dc/host/my_cluster/esxi1.test', **connection_args) }}"
 
 - name: lookup MoID of the object inside the path
-  debug: msg="{{ lookup('vmware.vmware_rest.host_moid', '/my_dc/host/my_cluster/') }}"
+  ansible.builtin.debug: msg="{{ lookup('vmware.vmware_rest.host_moid', '/my_dc/host/my_cluster/') }}"
 """
 
 

--- a/plugins/lookup/network_moid.py
+++ b/plugins/lookup/network_moid.py
@@ -27,17 +27,17 @@ extends_documentation_fragment:
 EXAMPLES = r"""
 # lookup sample
 - name: set connection info
-  set_fact:
+  ansible.builtin.set_fact:
     connection_args:
         vcenter_hostname: "vcenter.test"
         vcenter_username: "administrator@vsphere.local"
         vcenter_password: "1234"
 
 - name: lookup MoID of the object
-  debug: msg="{{ lookup('vmware.vmware_rest.network_moid', '/my_dc/network/test_network', **connection_args) }}"
+  ansible.builtin.debug: msg="{{ lookup('vmware.vmware_rest.network_moid', '/my_dc/network/test_network', **connection_args) }}"
 
 - name: lookup MoID of the object inside the path
-  debug: msg="{{ lookup('vmware.vmware_rest.network_moid', '/my_dc/network/') }}"
+  ansible.builtin.debug: msg="{{ lookup('vmware.vmware_rest.network_moid', '/my_dc/network/') }}"
 """
 
 

--- a/plugins/lookup/resource_pool_moid.py
+++ b/plugins/lookup/resource_pool_moid.py
@@ -27,17 +27,17 @@ extends_documentation_fragment:
 EXAMPLES = r"""
 # lookup sample
 - name: set connection info
-  set_fact:
+  ansible.builtin.set_fact:
     connection_args:
         vcenter_hostname: "vcenter.test"
         vcenter_username: "administrator@vsphere.local"
         vcenter_password: "1234"
 
 - name: lookup MoID of the object
-  debug: msg="{{ lookup('vmware.vmware_rest.resource_pool_moid', '/my_dc/host/my_cluster/Resources/my_resource_pool', **connection_args) }}"
+  ansible.builtin.debug: msg="{{ lookup('vmware.vmware_rest.resource_pool_moid', '/my_dc/host/my_cluster/Resources/my_resource_pool', **connection_args) }}"
 
 - name: lookup MoID of the object inside the path
-  debug: msg="{{ lookup('vmware.vmware_rest.resource_pool_moid', '/my_dc/host/my_cluster/Resources/') }}"
+  ansible.builtin.debug: msg="{{ lookup('vmware.vmware_rest.resource_pool_moid', '/my_dc/host/my_cluster/Resources/') }}"
 """
 
 

--- a/plugins/lookup/vm_moid.py
+++ b/plugins/lookup/vm_moid.py
@@ -27,17 +27,17 @@ extends_documentation_fragment:
 EXAMPLES = r"""
 # lookup sample
 - name: set connection info
-  set_fact:
+  ansible.builtin.set_fact:
     connection_args:
         vcenter_hostname: "vcenter.test"
         vcenter_username: "administrator@vsphere.local"
         vcenter_password: "1234"
 
 - name: lookup MoID of the object
-  debug: msg="{{ lookup('vmware.vmware_rest.vm_moid', '/my_dc/host/my_cluster/esxi1.test/test_vm1', **connection_args) }}"
+  ansible.builtin.debug: msg="{{ lookup('vmware.vmware_rest.vm_moid', '/my_dc/host/my_cluster/esxi1.test/test_vm1', **connection_args) }}"
 
 - name: lookup MoID of the object inside the path
-  debug: msg="{{ lookup('vmware.vmware_rest.vm_moid', '/my_dc/vm/') }}"
+  ansible.builtin.debug: msg="{{ lookup('vmware.vmware_rest.vm_moid', '/my_dc/vm/') }}"
 """
 
 


### PR DESCRIPTION
Use the FQCN of the built-in modules.

See: https://github.com/ansible-collections/ansible-inclusion/discussions/24
