### PR TITLE
vmware_cluster_drs: rename enable_drs

### DIFF
--- a/tests/integration/targets/prepare_lab/tasks/prepare_cluster.yaml
+++ b/tests/integration/targets/prepare_lab/tasks/prepare_cluster.yaml
@@ -10,7 +10,7 @@
   community.vmware.vmware_cluster_drs:
     datacenter_name: my_dc
     cluster_name: my_cluster
-    enable_drs: yes
+    enable: yes
   delegate_to: localhost
 
 - name: get all the clusters called my_cluster


### PR DESCRIPTION
Depends-On: https://github.com/ansible/ansible-zuul-jobs/pull/1275

The key is deprecated with community.vmware 2.0.0.
