### PR TITLE
CI: disable vcenter_library_and_ovf_clone

### DIFF
--- a/tests/integration/targets/vcenter_library_and_ovf_clone/aliases
+++ b/tests/integration/targets/vcenter_library_and_ovf_clone/aliases
@@ -1,2 +1,3 @@
 network/vmware_rest
 zuul/vmware/vcenter_1esxi_with_nested
+disabled


### PR DESCRIPTION
Need a bit of work before we can turn it on again.
