### PR TITLE
Fix typo of the password environment variable

### DIFF
--- a/manual/source/vmware_rest_scenarios/vcenter/1_authentication.rst
+++ b/manual/source/vmware_rest_scenarios/vcenter/1_authentication.rst
@@ -21,7 +21,7 @@ You need to export some environment variables in your shell before you call the 
 
     $ export VMWARE_HOST=vcenter.test
     $ export VMWARE_USER=myvcenter-user
-    $ export VMWARE_password=mypassword
+    $ export VMWARE_PASSWORD=mypassword
     $ ansible-playbook my-playbook.yaml
 
 Module parameters


### PR DESCRIPTION
##### SUMMARY

This PR is to fix the password environment variable typo.  
The password string should be the uppercase letter.  

If the PR place for fixing documentation is wrong, please tell me about the right place?

##### ISSUE TYPE

- Docs Pull Request

##### COMPONENT NAME

manual/source/vmware_rest_scenarios/vcenter/1_authentication.rst

##### ADDITIONAL INFORMATION
