### PR TITLE
update cloud.common requirements

### DIFF
--- a/changelogs/fragments/cloud.common-bump.yaml
+++ b/changelogs/fragments/cloud.common-bump.yaml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+- Adjust the cloud.common dependency to require 2.0.4 or greater (https://github.com/ansible-collections/vmware.vmware_rest/pull/315).

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -11,7 +11,7 @@ tags:
 - vmware
 - virtualization
 dependencies:
-  cloud.common: '>=2.0.0,<3.0.0'
+  cloud.common: '>=2.0.4,<3.0.0'
 repository: https://github.com/ansible-collections/vmware.vmware_rest.git
 homepage: https://github.com/ansible-collections/vmware.vmware_rest
 issues: https://github.com/ansible-collections/vmware.vmware_rest/issues?q=is%3Aissue+is%3Aopen+sort%3Aupdated-desc


### PR DESCRIPTION
Depends-On: https://github.com/ansible-collections/community.vmware/pull/1296

##### SUMMARY
Update the cloud.common version required for this collection to run

##### ISSUE TYPE
- Bugfix Pull Request


##### COMPONENT NAME
Moudles and plugins

##### ADDITIONAL INFORMATION
The galaxy file for this collection says it supports cloud.common 2.0.0 however most of the plugins use the line
```
from ansible_collections.cloud.common.plugins.module_utils.turbo.module import 
```
However the folder, and the turbo module were not added until 2.0.4
as referenced here
https://github.com/ansible-collections/cloud.common/tree/2.0.4/plugins
vs here:
https://github.com/ansible-collections/cloud.common/tree/2.0.3/plugins

This update should account for that and remove issues for users running out of date collections or building execution environments such as the 
ansible-automation-platform-21/ee-supported-rhel8:1.0.1-36
which is running cloud.common 2.0.3
