### PR TITLE
integration: share the same disk image between targets

### DIFF
--- a/tests/integration/targets/vcenter_vm_customize/tasks/main.yaml
+++ b/tests/integration/targets/vcenter_vm_customize/tasks/main.yaml
@@ -4,11 +4,12 @@
 - name: Fetch the root disk
   ansible.builtin.get_url:
     url: "https://s3.us-east-2.amazonaws.com/ansible-team-cloud-images/{{ disk_name }}.vmdk-4"
-    dest: .
+    dest: "../{{ disk_name }}.vmdk-4"
+    checksum: sha256:e28616764ae9eb7e302f4642cace10f1596d8c7c254e2b9c4038c4cd726262ff
 
 - name: Copy the disk on the ESXi local datastore
   ansible.builtin.copy:
-    src: "{{ disk_name }}.vmdk-4"
+    src: "../{{ disk_name }}.vmdk-4"
     dest: "/vmfs/volumes/local/{{ disk_name }}.vmdk-4"
   delegate_to: esxi1.test
   vars:


### PR DESCRIPTION
Avoid the need to redownload the RHEL image in every test. Right
now the image is only used in the vcenter_vm_customize test.
