### PR TITLE
tox: antsibull-lint is deprecated

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -63,12 +63,12 @@ deps =
   click==8.0.2
   flake8
   antsibull-changelog
-  antsibull
+  antsibull-docs
 commands =
   black -v --check {toxinidir}/plugins {toxinidir}/tests
   flake8 {posargs} {toxinidir}/plugins {toxinidir}/tests
-  antsibull-changelog lint
-  antsibull-lint collection-docs .
+  antsibull-changelog lint-changelog-yaml changelogs/changelog.yaml
+  antsibull-docs lint-collection-docs .
 
 [testenv:antsibull-changelog]
 deps =


### PR DESCRIPTION
Use `antsibull-changelog` and `antsibull-docs` now.
