### PR TITLE
set version in galaxy.yml to allow install from git repo

### DIFF
--- a/changelogs/fragments/set_default_galaxy_version.yaml
+++ b/changelogs/fragments/set_default_galaxy_version.yaml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+- "set version in galaxy.yml to allow install from git repo"

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -1,6 +1,7 @@
 namespace: vmware
 name: vmware_rest
 readme: README.md
+version: null
 authors:
 - Ansible (https://github.com/ansible)
 description:


### PR DESCRIPTION
##### SUMMARY

set galaxy version to null to ensure that install via git is possible

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME

galaxy
