### PR TITLE
Remove old changelog fragments

### DIFF
--- a/changelogs/config.yaml
+++ b/changelogs/config.yaml
@@ -2,7 +2,7 @@ changelog_filename_template: ../CHANGELOG.rst
 changelog_filename_version_depth: 0
 changes_file: changelog.yaml
 changes_format: combined
-keep_fragments: true
+keep_fragments: false
 mention_ancestor: true
 new_plugins_after_name: removed_features
 notesdir: fragments

--- a/changelogs/fragments/2.1.3-changelog.yaml
+++ b/changelogs/fragments/2.1.3-changelog.yaml
@@ -1,8 +1,0 @@
----
-minor_changes:
-- add some missing example blocks.
-bugfixes:
-- >
-  "remove the following modules vcenter_vm_guest_environment_info vcenter_vm_guest_environment_info "
-  "vcenter_vm_guest_filesystemy vcenter_vm_guest_filesystem_files vcenter_vm_guest_filesystem_files_info "
-  "vcenter_vm_guest_processes vcenter_vm_guest_processes_info because they don't work as expected."

--- a/changelogs/fragments/2.1.3-module_utils.yaml
+++ b/changelogs/fragments/2.1.3-module_utils.yaml
@@ -1,3 +1,0 @@
----
-minor_changes:
-- "The module_utils/vmware.py is licensed under BSD." 

--- a/changelogs/fragments/allow_space_in_search_filters.yaml
+++ b/changelogs/fragments/allow_space_in_search_filters.yaml
@@ -1,3 +1,0 @@
----
-bugfixes:
-  - "Allow filters with the space (See: https://github.com/ansible-collections/vmware.vmware_rest/issues/362)."

--- a/changelogs/fragments/cloud.common-bump.yaml
+++ b/changelogs/fragments/cloud.common-bump.yaml
@@ -1,3 +1,0 @@
----
-bugfixes:
-- Adjust the cloud.common dependency to require 2.0.4 or greater (https://github.com/ansible-collections/vmware.vmware_rest/pull/315).

--- a/changelogs/fragments/lookup-handle-special-chars.yml
+++ b/changelogs/fragments/lookup-handle-special-chars.yml
@@ -1,3 +1,0 @@
----
-bugfixes:
-  - "Handle spaces and special characters in resource names for lookup plugins (See: https://github.com/ansible-collections/vmware.vmware_rest/issues/356)."

--- a/changelogs/fragments/remove_old_changelog_fragments.yaml
+++ b/changelogs/fragments/remove_old_changelog_fragments.yaml
@@ -1,0 +1,3 @@
+---
+trivial:
+- "Remove old changelog fragments."

--- a/changelogs/fragments/set_default_galaxy_version.yaml
+++ b/changelogs/fragments/set_default_galaxy_version.yaml
@@ -1,3 +1,0 @@
----
-minor_changes:
-- "set version in galaxy.yml to allow install from git repo"

--- a/changelogs/fragments/use-FQCN-in-create_vm.yaml.yaml
+++ b/changelogs/fragments/use-FQCN-in-create_vm.yaml.yaml
@@ -1,3 +1,0 @@
----
-minor_changes:
-- "``content_subscribedlibrary`` - use FQCN in the example."

--- a/changelogs/fragments/vcenter_network_info-dvs-example.yaml
+++ b/changelogs/fragments/vcenter_network_info-dvs-example.yaml
@@ -1,3 +1,0 @@
----
-minor_changes:
-- "``vcenter_network_info`` - add an example with a Distributed Virtual Switch, a.k.a dvswitch (https://github.com/ansible-collections/vmware.vmware_rest/pull/316)."

--- a/changelogs/fragments/version_added.yaml
+++ b/changelogs/fragments/version_added.yaml
@@ -1,3 +1,0 @@
----
-minor_changes:
-- "Adjust the release version of the lookup plugins fro, 2.0.1 to 2.1.0." 

--- a/changelogs/fragments/vm_template_library.yaml
+++ b/changelogs/fragments/vm_template_library.yaml
@@ -1,3 +1,0 @@
----
-minor_changes:
-- documentation - clarify that the VMware vCenter API doesn't allow the cloning of template if there are not if Library. 


### PR DESCRIPTION
##### SUMMARY
There are some old changelog fragments still around that I think should be removed. I also think changelog fragments should be automatically removed when a new changelog is created.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
changelogs/config.yaml

##### ADDITIONAL INFORMATION
I wanted to propose a new major release, but I ran into so many issues in #429 that I decided to split those changes into several PRs.
