### PR TITLE
Fix GHA sanity tests

### DIFF
--- a/.github/workflows/ansible-test.yml
+++ b/.github/workflows/ansible-test.yml
@@ -78,6 +78,7 @@ jobs:
           - stable-2.13
           - stable-2.14
           - stable-2.15
+        # - stable-2.16
         # - devel
         # - milestone
     # Ansible-test on various stable branches does not yet work well with cgroups v2.
@@ -105,10 +106,12 @@ jobs:
           # test-deps: >-
           #   ansible.netcommon
           #   ansible.utils
+          test-deps: >-
+            cloud.common
           # OPTIONAL If set to true, will test only against changed files,
           # which should improve CI performance. See limitations on
           # https://github.com/ansible-community/ansible-test-gh-action#pull-request-change-detection
-          pull-request-change-detection: true
+          pull-request-change-detection: false
 
   check:  # This job does nothing and is only used for the branch protection
           # or multi-stage CI jobs, like making sure that all tests pass before

--- a/changelogs/fragments/fix_gha_sanity_tests.yaml
+++ b/changelogs/fragments/fix_gha_sanity_tests.yaml
@@ -1,0 +1,3 @@
+---
+trivial:
+- "Fix GHA sanity tests."

--- a/plugins/modules/appliance_access_consolecli.py
+++ b/plugins/modules/appliance_access_consolecli.py
@@ -102,8 +102,6 @@ PAYLOAD_FORMAT = {
     "set": {"query": {}, "body": {"enabled": "enabled"}, "path": {}}
 }  # pylint: disable=line-too-long
 
-import json
-import socket
 from ansible.module_utils.basic import env_fallback
 
 try:
@@ -118,12 +116,9 @@ try:
 except ImportError:
     from ansible.module_utils.basic import AnsibleModule
 from ansible_collections.vmware.vmware_rest.plugins.module_utils.vmware_rest import (
-    build_full_device_list,
     exists,
     gen_args,
-    get_device_info,
     get_subdevice_type,
-    list_devices,
     open_session,
     prepare_payload,
     update_changed_flag,

--- a/plugins/modules/appliance_access_consolecli_info.py
+++ b/plugins/modules/appliance_access_consolecli_info.py
@@ -90,8 +90,6 @@ PAYLOAD_FORMAT = {
     "get": {"query": {}, "body": {}, "path": {}}
 }  # pylint: disable=line-too-long
 
-import json
-import socket
 from ansible.module_utils.basic import env_fallback
 
 try:
@@ -106,14 +104,8 @@ try:
 except ImportError:
     from ansible.module_utils.basic import AnsibleModule
 from ansible_collections.vmware.vmware_rest.plugins.module_utils.vmware_rest import (
-    build_full_device_list,
-    exists,
     gen_args,
-    get_device_info,
-    get_subdevice_type,
-    list_devices,
     open_session,
-    prepare_payload,
     update_changed_flag,
     session_timeout,
 )

--- a/plugins/modules/appliance_access_dcui.py
+++ b/plugins/modules/appliance_access_dcui.py
@@ -102,8 +102,6 @@ PAYLOAD_FORMAT = {
     "set": {"query": {}, "body": {"enabled": "enabled"}, "path": {}}
 }  # pylint: disable=line-too-long
 
-import json
-import socket
 from ansible.module_utils.basic import env_fallback
 
 try:
@@ -118,12 +116,9 @@ try:
 except ImportError:
     from ansible.module_utils.basic import AnsibleModule
 from ansible_collections.vmware.vmware_rest.plugins.module_utils.vmware_rest import (
-    build_full_device_list,
     exists,
     gen_args,
-    get_device_info,
     get_subdevice_type,
-    list_devices,
     open_session,
     prepare_payload,
     update_changed_flag,

--- a/plugins/modules/appliance_access_dcui_info.py
+++ b/plugins/modules/appliance_access_dcui_info.py
@@ -90,8 +90,6 @@ PAYLOAD_FORMAT = {
     "get": {"query": {}, "body": {}, "path": {}}
 }  # pylint: disable=line-too-long
 
-import json
-import socket
 from ansible.module_utils.basic import env_fallback
 
 try:
@@ -106,14 +104,8 @@ try:
 except ImportError:
     from ansible.module_utils.basic import AnsibleModule
 from ansible_collections.vmware.vmware_rest.plugins.module_utils.vmware_rest import (
-    build_full_device_list,
-    exists,
     gen_args,
-    get_device_info,
-    get_subdevice_type,
-    list_devices,
     open_session,
-    prepare_payload,
     update_changed_flag,
     session_timeout,
 )

--- a/plugins/modules/appliance_access_shell.py
+++ b/plugins/modules/appliance_access_shell.py
@@ -123,8 +123,6 @@ PAYLOAD_FORMAT = {
     }
 }  # pylint: disable=line-too-long
 
-import json
-import socket
 from ansible.module_utils.basic import env_fallback
 
 try:
@@ -139,12 +137,9 @@ try:
 except ImportError:
     from ansible.module_utils.basic import AnsibleModule
 from ansible_collections.vmware.vmware_rest.plugins.module_utils.vmware_rest import (
-    build_full_device_list,
     exists,
     gen_args,
-    get_device_info,
     get_subdevice_type,
-    list_devices,
     open_session,
     prepare_payload,
     update_changed_flag,

--- a/plugins/modules/appliance_access_shell_info.py
+++ b/plugins/modules/appliance_access_shell_info.py
@@ -95,8 +95,6 @@ PAYLOAD_FORMAT = {
     "get": {"query": {}, "body": {}, "path": {}}
 }  # pylint: disable=line-too-long
 
-import json
-import socket
 from ansible.module_utils.basic import env_fallback
 
 try:
@@ -111,14 +109,8 @@ try:
 except ImportError:
     from ansible.module_utils.basic import AnsibleModule
 from ansible_collections.vmware.vmware_rest.plugins.module_utils.vmware_rest import (
-    build_full_device_list,
-    exists,
     gen_args,
-    get_device_info,
-    get_subdevice_type,
-    list_devices,
     open_session,
-    prepare_payload,
     update_changed_flag,
     session_timeout,
 )

--- a/plugins/modules/appliance_access_ssh.py
+++ b/plugins/modules/appliance_access_ssh.py
@@ -103,8 +103,6 @@ PAYLOAD_FORMAT = {
     "set": {"query": {}, "body": {"enabled": "enabled"}, "path": {}}
 }  # pylint: disable=line-too-long
 
-import json
-import socket
 from ansible.module_utils.basic import env_fallback
 
 try:
@@ -119,12 +117,9 @@ try:
 except ImportError:
     from ansible.module_utils.basic import AnsibleModule
 from ansible_collections.vmware.vmware_rest.plugins.module_utils.vmware_rest import (
-    build_full_device_list,
     exists,
     gen_args,
-    get_device_info,
     get_subdevice_type,
-    list_devices,
     open_session,
     prepare_payload,
     update_changed_flag,

--- a/plugins/modules/appliance_access_ssh_info.py
+++ b/plugins/modules/appliance_access_ssh_info.py
@@ -91,8 +91,6 @@ PAYLOAD_FORMAT = {
     "get": {"query": {}, "body": {}, "path": {}}
 }  # pylint: disable=line-too-long
 
-import json
-import socket
 from ansible.module_utils.basic import env_fallback
 
 try:
@@ -107,14 +105,8 @@ try:
 except ImportError:
     from ansible.module_utils.basic import AnsibleModule
 from ansible_collections.vmware.vmware_rest.plugins.module_utils.vmware_rest import (
-    build_full_device_list,
-    exists,
     gen_args,
-    get_device_info,
-    get_subdevice_type,
-    list_devices,
     open_session,
-    prepare_payload,
     update_changed_flag,
     session_timeout,
 )

--- a/plugins/modules/appliance_health_applmgmt_info.py
+++ b/plugins/modules/appliance_health_applmgmt_info.py
@@ -91,8 +91,6 @@ PAYLOAD_FORMAT = {
     "get": {"query": {}, "body": {}, "path": {}}
 }  # pylint: disable=line-too-long
 
-import json
-import socket
 from ansible.module_utils.basic import env_fallback
 
 try:
@@ -107,14 +105,8 @@ try:
 except ImportError:
     from ansible.module_utils.basic import AnsibleModule
 from ansible_collections.vmware.vmware_rest.plugins.module_utils.vmware_rest import (
-    build_full_device_list,
-    exists,
     gen_args,
-    get_device_info,
-    get_subdevice_type,
-    list_devices,
     open_session,
-    prepare_payload,
     update_changed_flag,
     session_timeout,
 )

--- a/plugins/modules/appliance_health_database_info.py
+++ b/plugins/modules/appliance_health_database_info.py
@@ -85,8 +85,6 @@ PAYLOAD_FORMAT = {
     "get": {"query": {}, "body": {}, "path": {}}
 }  # pylint: disable=line-too-long
 
-import json
-import socket
 from ansible.module_utils.basic import env_fallback
 
 try:
@@ -101,14 +99,8 @@ try:
 except ImportError:
     from ansible.module_utils.basic import AnsibleModule
 from ansible_collections.vmware.vmware_rest.plugins.module_utils.vmware_rest import (
-    build_full_device_list,
-    exists,
     gen_args,
-    get_device_info,
-    get_subdevice_type,
-    list_devices,
     open_session,
-    prepare_payload,
     update_changed_flag,
     session_timeout,
 )

--- a/plugins/modules/appliance_health_databasestorage_info.py
+++ b/plugins/modules/appliance_health_databasestorage_info.py
@@ -91,8 +91,6 @@ PAYLOAD_FORMAT = {
     "get": {"query": {}, "body": {}, "path": {}}
 }  # pylint: disable=line-too-long
 
-import json
-import socket
 from ansible.module_utils.basic import env_fallback
 
 try:
@@ -107,14 +105,8 @@ try:
 except ImportError:
     from ansible.module_utils.basic import AnsibleModule
 from ansible_collections.vmware.vmware_rest.plugins.module_utils.vmware_rest import (
-    build_full_device_list,
-    exists,
     gen_args,
-    get_device_info,
-    get_subdevice_type,
-    list_devices,
     open_session,
-    prepare_payload,
     update_changed_flag,
     session_timeout,
 )

--- a/plugins/modules/appliance_health_load_info.py
+++ b/plugins/modules/appliance_health_load_info.py
@@ -91,8 +91,6 @@ PAYLOAD_FORMAT = {
     "get": {"query": {}, "body": {}, "path": {}}
 }  # pylint: disable=line-too-long
 
-import json
-import socket
 from ansible.module_utils.basic import env_fallback
 
 try:
@@ -107,14 +105,8 @@ try:
 except ImportError:
     from ansible.module_utils.basic import AnsibleModule
 from ansible_collections.vmware.vmware_rest.plugins.module_utils.vmware_rest import (
-    build_full_device_list,
-    exists,
     gen_args,
-    get_device_info,
-    get_subdevice_type,
-    list_devices,
     open_session,
-    prepare_payload,
     update_changed_flag,
     session_timeout,
 )

--- a/plugins/modules/appliance_health_mem_info.py
+++ b/plugins/modules/appliance_health_mem_info.py
@@ -91,8 +91,6 @@ PAYLOAD_FORMAT = {
     "get": {"query": {}, "body": {}, "path": {}}
 }  # pylint: disable=line-too-long
 
-import json
-import socket
 from ansible.module_utils.basic import env_fallback
 
 try:
@@ -107,14 +105,8 @@ try:
 except ImportError:
     from ansible.module_utils.basic import AnsibleModule
 from ansible_collections.vmware.vmware_rest.plugins.module_utils.vmware_rest import (
-    build_full_device_list,
-    exists,
     gen_args,
-    get_device_info,
-    get_subdevice_type,
-    list_devices,
     open_session,
-    prepare_payload,
     update_changed_flag,
     session_timeout,
 )

--- a/plugins/modules/appliance_health_softwarepackages_info.py
+++ b/plugins/modules/appliance_health_softwarepackages_info.py
@@ -96,8 +96,6 @@ PAYLOAD_FORMAT = {
     "get": {"query": {}, "body": {}, "path": {}}
 }  # pylint: disable=line-too-long
 
-import json
-import socket
 from ansible.module_utils.basic import env_fallback
 
 try:
@@ -112,14 +110,8 @@ try:
 except ImportError:
     from ansible.module_utils.basic import AnsibleModule
 from ansible_collections.vmware.vmware_rest.plugins.module_utils.vmware_rest import (
-    build_full_device_list,
-    exists,
     gen_args,
-    get_device_info,
-    get_subdevice_type,
-    list_devices,
     open_session,
-    prepare_payload,
     update_changed_flag,
     session_timeout,
 )

--- a/plugins/modules/appliance_health_storage_info.py
+++ b/plugins/modules/appliance_health_storage_info.py
@@ -91,8 +91,6 @@ PAYLOAD_FORMAT = {
     "get": {"query": {}, "body": {}, "path": {}}
 }  # pylint: disable=line-too-long
 
-import json
-import socket
 from ansible.module_utils.basic import env_fallback
 
 try:
@@ -107,14 +105,8 @@ try:
 except ImportError:
     from ansible.module_utils.basic import AnsibleModule
 from ansible_collections.vmware.vmware_rest.plugins.module_utils.vmware_rest import (
-    build_full_device_list,
-    exists,
     gen_args,
-    get_device_info,
-    get_subdevice_type,
-    list_devices,
     open_session,
-    prepare_payload,
     update_changed_flag,
     session_timeout,
 )

--- a/plugins/modules/appliance_health_swap_info.py
+++ b/plugins/modules/appliance_health_swap_info.py
@@ -91,8 +91,6 @@ PAYLOAD_FORMAT = {
     "get": {"query": {}, "body": {}, "path": {}}
 }  # pylint: disable=line-too-long
 
-import json
-import socket
 from ansible.module_utils.basic import env_fallback
 
 try:
@@ -107,14 +105,8 @@ try:
 except ImportError:
     from ansible.module_utils.basic import AnsibleModule
 from ansible_collections.vmware.vmware_rest.plugins.module_utils.vmware_rest import (
-    build_full_device_list,
-    exists,
     gen_args,
-    get_device_info,
-    get_subdevice_type,
-    list_devices,
     open_session,
-    prepare_payload,
     update_changed_flag,
     session_timeout,
 )

--- a/plugins/modules/appliance_health_system_info.py
+++ b/plugins/modules/appliance_health_system_info.py
@@ -91,8 +91,6 @@ PAYLOAD_FORMAT = {
     "get": {"query": {}, "body": {}, "path": {}}
 }  # pylint: disable=line-too-long
 
-import json
-import socket
 from ansible.module_utils.basic import env_fallback
 
 try:
@@ -107,14 +105,8 @@ try:
 except ImportError:
     from ansible.module_utils.basic import AnsibleModule
 from ansible_collections.vmware.vmware_rest.plugins.module_utils.vmware_rest import (
-    build_full_device_list,
-    exists,
     gen_args,
-    get_device_info,
-    get_subdevice_type,
-    list_devices,
     open_session,
-    prepare_payload,
     update_changed_flag,
     session_timeout,
 )

--- a/plugins/modules/appliance_infraprofile_configs.py
+++ b/plugins/modules/appliance_infraprofile_configs.py
@@ -137,8 +137,6 @@ PAYLOAD_FORMAT = {
     }
 }  # pylint: disable=line-too-long
 
-import json
-import socket
 from ansible.module_utils.basic import env_fallback
 
 try:
@@ -153,12 +151,9 @@ try:
 except ImportError:
     from ansible.module_utils.basic import AnsibleModule
 from ansible_collections.vmware.vmware_rest.plugins.module_utils.vmware_rest import (
-    build_full_device_list,
     exists,
     gen_args,
-    get_device_info,
     get_subdevice_type,
-    list_devices,
     open_session,
     prepare_payload,
     update_changed_flag,

--- a/plugins/modules/appliance_infraprofile_configs_info.py
+++ b/plugins/modules/appliance_infraprofile_configs_info.py
@@ -97,8 +97,6 @@ PAYLOAD_FORMAT = {
     "list": {"query": {}, "body": {}, "path": {}}
 }  # pylint: disable=line-too-long
 
-import json
-import socket
 from ansible.module_utils.basic import env_fallback
 
 try:
@@ -113,14 +111,8 @@ try:
 except ImportError:
     from ansible.module_utils.basic import AnsibleModule
 from ansible_collections.vmware.vmware_rest.plugins.module_utils.vmware_rest import (
-    build_full_device_list,
-    exists,
     gen_args,
-    get_device_info,
-    get_subdevice_type,
-    list_devices,
     open_session,
-    prepare_payload,
     update_changed_flag,
     session_timeout,
 )

--- a/plugins/modules/appliance_localaccounts_globalpolicy.py
+++ b/plugins/modules/appliance_localaccounts_globalpolicy.py
@@ -120,8 +120,6 @@ PAYLOAD_FORMAT = {
     }
 }  # pylint: disable=line-too-long
 
-import json
-import socket
 from ansible.module_utils.basic import env_fallback
 
 try:
@@ -136,12 +134,9 @@ try:
 except ImportError:
     from ansible.module_utils.basic import AnsibleModule
 from ansible_collections.vmware.vmware_rest.plugins.module_utils.vmware_rest import (
-    build_full_device_list,
     exists,
     gen_args,
-    get_device_info,
     get_subdevice_type,
-    list_devices,
     open_session,
     prepare_payload,
     update_changed_flag,

--- a/plugins/modules/appliance_localaccounts_globalpolicy_info.py
+++ b/plugins/modules/appliance_localaccounts_globalpolicy_info.py
@@ -94,8 +94,6 @@ PAYLOAD_FORMAT = {
     "get": {"query": {}, "body": {}, "path": {}}
 }  # pylint: disable=line-too-long
 
-import json
-import socket
 from ansible.module_utils.basic import env_fallback
 
 try:
@@ -110,14 +108,8 @@ try:
 except ImportError:
     from ansible.module_utils.basic import AnsibleModule
 from ansible_collections.vmware.vmware_rest.plugins.module_utils.vmware_rest import (
-    build_full_device_list,
-    exists,
     gen_args,
-    get_device_info,
-    get_subdevice_type,
-    list_devices,
     open_session,
-    prepare_payload,
     update_changed_flag,
     session_timeout,
 )

--- a/plugins/modules/appliance_localaccounts_info.py
+++ b/plugins/modules/appliance_localaccounts_info.py
@@ -124,8 +124,6 @@ PAYLOAD_FORMAT = {
     "list": {"query": {}, "body": {}, "path": {}},
 }  # pylint: disable=line-too-long
 
-import json
-import socket
 from ansible.module_utils.basic import env_fallback
 
 try:
@@ -143,11 +141,7 @@ from ansible_collections.vmware.vmware_rest.plugins.module_utils.vmware_rest imp
     build_full_device_list,
     exists,
     gen_args,
-    get_device_info,
-    get_subdevice_type,
-    list_devices,
     open_session,
-    prepare_payload,
     update_changed_flag,
     session_timeout,
 )

--- a/plugins/modules/appliance_monitoring_info.py
+++ b/plugins/modules/appliance_monitoring_info.py
@@ -918,8 +918,6 @@ PAYLOAD_FORMAT = {
     "list": {"query": {}, "body": {}, "path": {}},
 }  # pylint: disable=line-too-long
 
-import json
-import socket
 from ansible.module_utils.basic import env_fallback
 
 try:
@@ -937,11 +935,7 @@ from ansible_collections.vmware.vmware_rest.plugins.module_utils.vmware_rest imp
     build_full_device_list,
     exists,
     gen_args,
-    get_device_info,
-    get_subdevice_type,
-    list_devices,
     open_session,
-    prepare_payload,
     update_changed_flag,
     session_timeout,
 )

--- a/plugins/modules/appliance_monitoring_query.py
+++ b/plugins/modules/appliance_monitoring_query.py
@@ -164,8 +164,6 @@ PAYLOAD_FORMAT = {
     }
 }  # pylint: disable=line-too-long
 
-import json
-import socket
 from ansible.module_utils.basic import env_fallback
 
 try:
@@ -180,12 +178,9 @@ try:
 except ImportError:
     from ansible.module_utils.basic import AnsibleModule
 from ansible_collections.vmware.vmware_rest.plugins.module_utils.vmware_rest import (
-    build_full_device_list,
     exists,
     gen_args,
-    get_device_info,
     get_subdevice_type,
-    list_devices,
     open_session,
     prepare_payload,
     update_changed_flag,

--- a/plugins/modules/appliance_networking.py
+++ b/plugins/modules/appliance_networking.py
@@ -111,8 +111,6 @@ PAYLOAD_FORMAT = {
     "update": {"query": {}, "body": {"ipv6_enabled": "ipv6_enabled"}, "path": {}},
 }  # pylint: disable=line-too-long
 
-import json
-import socket
 from ansible.module_utils.basic import env_fallback
 
 try:
@@ -127,12 +125,9 @@ try:
 except ImportError:
     from ansible.module_utils.basic import AnsibleModule
 from ansible_collections.vmware.vmware_rest.plugins.module_utils.vmware_rest import (
-    build_full_device_list,
     exists,
     gen_args,
-    get_device_info,
     get_subdevice_type,
-    list_devices,
     open_session,
     prepare_payload,
     update_changed_flag,

--- a/plugins/modules/appliance_networking_dns_domains.py
+++ b/plugins/modules/appliance_networking_dns_domains.py
@@ -116,8 +116,6 @@ PAYLOAD_FORMAT = {
     "add": {"query": {}, "body": {"domain": "domain"}, "path": {}},
 }  # pylint: disable=line-too-long
 
-import json
-import socket
 from ansible.module_utils.basic import env_fallback
 
 try:
@@ -132,12 +130,9 @@ try:
 except ImportError:
     from ansible.module_utils.basic import AnsibleModule
 from ansible_collections.vmware.vmware_rest.plugins.module_utils.vmware_rest import (
-    build_full_device_list,
     exists,
     gen_args,
-    get_device_info,
     get_subdevice_type,
-    list_devices,
     open_session,
     prepare_payload,
     update_changed_flag,

--- a/plugins/modules/appliance_networking_dns_domains_info.py
+++ b/plugins/modules/appliance_networking_dns_domains_info.py
@@ -91,8 +91,6 @@ PAYLOAD_FORMAT = {
     "list": {"query": {}, "body": {}, "path": {}}
 }  # pylint: disable=line-too-long
 
-import json
-import socket
 from ansible.module_utils.basic import env_fallback
 
 try:
@@ -107,14 +105,8 @@ try:
 except ImportError:
     from ansible.module_utils.basic import AnsibleModule
 from ansible_collections.vmware.vmware_rest.plugins.module_utils.vmware_rest import (
-    build_full_device_list,
-    exists,
     gen_args,
-    get_device_info,
-    get_subdevice_type,
-    list_devices,
     open_session,
-    prepare_payload,
     update_changed_flag,
     session_timeout,
 )

--- a/plugins/modules/appliance_networking_dns_hostname.py
+++ b/plugins/modules/appliance_networking_dns_hostname.py
@@ -110,8 +110,6 @@ PAYLOAD_FORMAT = {
     "set": {"query": {}, "body": {"name": "name"}, "path": {}},
 }  # pylint: disable=line-too-long
 
-import json
-import socket
 from ansible.module_utils.basic import env_fallback
 
 try:
@@ -126,12 +124,9 @@ try:
 except ImportError:
     from ansible.module_utils.basic import AnsibleModule
 from ansible_collections.vmware.vmware_rest.plugins.module_utils.vmware_rest import (
-    build_full_device_list,
     exists,
     gen_args,
-    get_device_info,
     get_subdevice_type,
-    list_devices,
     open_session,
     prepare_payload,
     update_changed_flag,

--- a/plugins/modules/appliance_networking_dns_hostname_info.py
+++ b/plugins/modules/appliance_networking_dns_hostname_info.py
@@ -91,8 +91,6 @@ PAYLOAD_FORMAT = {
     "get": {"query": {}, "body": {}, "path": {}}
 }  # pylint: disable=line-too-long
 
-import json
-import socket
 from ansible.module_utils.basic import env_fallback
 
 try:
@@ -107,14 +105,8 @@ try:
 except ImportError:
     from ansible.module_utils.basic import AnsibleModule
 from ansible_collections.vmware.vmware_rest.plugins.module_utils.vmware_rest import (
-    build_full_device_list,
-    exists,
     gen_args,
-    get_device_info,
-    get_subdevice_type,
-    list_devices,
     open_session,
-    prepare_payload,
     update_changed_flag,
     session_timeout,
 )

--- a/plugins/modules/appliance_networking_dns_servers.py
+++ b/plugins/modules/appliance_networking_dns_servers.py
@@ -148,8 +148,6 @@ PAYLOAD_FORMAT = {
     "add": {"query": {}, "body": {"server": "server"}, "path": {}},
 }  # pylint: disable=line-too-long
 
-import json
-import socket
 from ansible.module_utils.basic import env_fallback
 
 try:
@@ -164,12 +162,9 @@ try:
 except ImportError:
     from ansible.module_utils.basic import AnsibleModule
 from ansible_collections.vmware.vmware_rest.plugins.module_utils.vmware_rest import (
-    build_full_device_list,
     exists,
     gen_args,
-    get_device_info,
     get_subdevice_type,
-    list_devices,
     open_session,
     prepare_payload,
     update_changed_flag,

--- a/plugins/modules/appliance_networking_dns_servers_info.py
+++ b/plugins/modules/appliance_networking_dns_servers_info.py
@@ -94,8 +94,6 @@ PAYLOAD_FORMAT = {
     "get": {"query": {}, "body": {}, "path": {}}
 }  # pylint: disable=line-too-long
 
-import json
-import socket
 from ansible.module_utils.basic import env_fallback
 
 try:
@@ -110,14 +108,8 @@ try:
 except ImportError:
     from ansible.module_utils.basic import AnsibleModule
 from ansible_collections.vmware.vmware_rest.plugins.module_utils.vmware_rest import (
-    build_full_device_list,
-    exists,
     gen_args,
-    get_device_info,
-    get_subdevice_type,
-    list_devices,
     open_session,
-    prepare_payload,
     update_changed_flag,
     session_timeout,
 )

--- a/plugins/modules/appliance_networking_firewall_inbound.py
+++ b/plugins/modules/appliance_networking_firewall_inbound.py
@@ -146,8 +146,6 @@ PAYLOAD_FORMAT = {
     "set": {"query": {}, "body": {"rules": "rules"}, "path": {}}
 }  # pylint: disable=line-too-long
 
-import json
-import socket
 from ansible.module_utils.basic import env_fallback
 
 try:
@@ -162,12 +160,9 @@ try:
 except ImportError:
     from ansible.module_utils.basic import AnsibleModule
 from ansible_collections.vmware.vmware_rest.plugins.module_utils.vmware_rest import (
-    build_full_device_list,
     exists,
     gen_args,
-    get_device_info,
     get_subdevice_type,
-    list_devices,
     open_session,
     prepare_payload,
     update_changed_flag,

--- a/plugins/modules/appliance_networking_firewall_inbound_info.py
+++ b/plugins/modules/appliance_networking_firewall_inbound_info.py
@@ -94,8 +94,6 @@ PAYLOAD_FORMAT = {
     "get": {"query": {}, "body": {}, "path": {}}
 }  # pylint: disable=line-too-long
 
-import json
-import socket
 from ansible.module_utils.basic import env_fallback
 
 try:
@@ -110,14 +108,8 @@ try:
 except ImportError:
     from ansible.module_utils.basic import AnsibleModule
 from ansible_collections.vmware.vmware_rest.plugins.module_utils.vmware_rest import (
-    build_full_device_list,
-    exists,
     gen_args,
-    get_device_info,
-    get_subdevice_type,
-    list_devices,
     open_session,
-    prepare_payload,
     update_changed_flag,
     session_timeout,
 )

--- a/plugins/modules/appliance_networking_info.py
+++ b/plugins/modules/appliance_networking_info.py
@@ -118,8 +118,6 @@ PAYLOAD_FORMAT = {
     "get": {"query": {}, "body": {}, "path": {}}
 }  # pylint: disable=line-too-long
 
-import json
-import socket
 from ansible.module_utils.basic import env_fallback
 
 try:
@@ -134,14 +132,8 @@ try:
 except ImportError:
     from ansible.module_utils.basic import AnsibleModule
 from ansible_collections.vmware.vmware_rest.plugins.module_utils.vmware_rest import (
-    build_full_device_list,
-    exists,
     gen_args,
-    get_device_info,
-    get_subdevice_type,
-    list_devices,
     open_session,
-    prepare_payload,
     update_changed_flag,
     session_timeout,
 )

--- a/plugins/modules/appliance_networking_interfaces_info.py
+++ b/plugins/modules/appliance_networking_interfaces_info.py
@@ -125,8 +125,6 @@ PAYLOAD_FORMAT = {
     "list": {"query": {}, "body": {}, "path": {}},
 }  # pylint: disable=line-too-long
 
-import json
-import socket
 from ansible.module_utils.basic import env_fallback
 
 try:
@@ -144,11 +142,7 @@ from ansible_collections.vmware.vmware_rest.plugins.module_utils.vmware_rest imp
     build_full_device_list,
     exists,
     gen_args,
-    get_device_info,
-    get_subdevice_type,
-    list_devices,
     open_session,
-    prepare_payload,
     update_changed_flag,
     session_timeout,
 )

--- a/plugins/modules/appliance_networking_interfaces_ipv4.py
+++ b/plugins/modules/appliance_networking_interfaces_ipv4.py
@@ -152,8 +152,6 @@ PAYLOAD_FORMAT = {
     }
 }  # pylint: disable=line-too-long
 
-import json
-import socket
 from ansible.module_utils.basic import env_fallback
 
 try:
@@ -168,12 +166,9 @@ try:
 except ImportError:
     from ansible.module_utils.basic import AnsibleModule
 from ansible_collections.vmware.vmware_rest.plugins.module_utils.vmware_rest import (
-    build_full_device_list,
     exists,
     gen_args,
-    get_device_info,
     get_subdevice_type,
-    list_devices,
     open_session,
     prepare_payload,
     update_changed_flag,

--- a/plugins/modules/appliance_networking_interfaces_ipv4_info.py
+++ b/plugins/modules/appliance_networking_interfaces_ipv4_info.py
@@ -101,8 +101,6 @@ PAYLOAD_FORMAT = {
     "get": {"query": {}, "body": {}, "path": {"interface_name": "interface_name"}}
 }  # pylint: disable=line-too-long
 
-import json
-import socket
 from ansible.module_utils.basic import env_fallback
 
 try:
@@ -117,14 +115,8 @@ try:
 except ImportError:
     from ansible.module_utils.basic import AnsibleModule
 from ansible_collections.vmware.vmware_rest.plugins.module_utils.vmware_rest import (
-    build_full_device_list,
-    exists,
     gen_args,
-    get_device_info,
-    get_subdevice_type,
-    list_devices,
     open_session,
-    prepare_payload,
     update_changed_flag,
     session_timeout,
 )

--- a/plugins/modules/appliance_networking_interfaces_ipv6.py
+++ b/plugins/modules/appliance_networking_interfaces_ipv6.py
@@ -155,8 +155,6 @@ PAYLOAD_FORMAT = {
     }
 }  # pylint: disable=line-too-long
 
-import json
-import socket
 from ansible.module_utils.basic import env_fallback
 
 try:
@@ -171,12 +169,9 @@ try:
 except ImportError:
     from ansible.module_utils.basic import AnsibleModule
 from ansible_collections.vmware.vmware_rest.plugins.module_utils.vmware_rest import (
-    build_full_device_list,
     exists,
     gen_args,
-    get_device_info,
     get_subdevice_type,
-    list_devices,
     open_session,
     prepare_payload,
     update_changed_flag,

--- a/plugins/modules/appliance_networking_interfaces_ipv6_info.py
+++ b/plugins/modules/appliance_networking_interfaces_ipv6_info.py
@@ -105,8 +105,6 @@ PAYLOAD_FORMAT = {
     "get": {"query": {}, "body": {}, "path": {"interface_name": "interface_name"}}
 }  # pylint: disable=line-too-long
 
-import json
-import socket
 from ansible.module_utils.basic import env_fallback
 
 try:
@@ -121,14 +119,8 @@ try:
 except ImportError:
     from ansible.module_utils.basic import AnsibleModule
 from ansible_collections.vmware.vmware_rest.plugins.module_utils.vmware_rest import (
-    build_full_device_list,
-    exists,
     gen_args,
-    get_device_info,
-    get_subdevice_type,
-    list_devices,
     open_session,
-    prepare_payload,
     update_changed_flag,
     session_timeout,
 )

--- a/plugins/modules/appliance_networking_noproxy.py
+++ b/plugins/modules/appliance_networking_noproxy.py
@@ -117,8 +117,6 @@ PAYLOAD_FORMAT = {
     "set": {"query": {}, "body": {"servers": "servers"}, "path": {}}
 }  # pylint: disable=line-too-long
 
-import json
-import socket
 from ansible.module_utils.basic import env_fallback
 
 try:
@@ -133,12 +131,9 @@ try:
 except ImportError:
     from ansible.module_utils.basic import AnsibleModule
 from ansible_collections.vmware.vmware_rest.plugins.module_utils.vmware_rest import (
-    build_full_device_list,
     exists,
     gen_args,
-    get_device_info,
     get_subdevice_type,
-    list_devices,
     open_session,
     prepare_payload,
     update_changed_flag,

--- a/plugins/modules/appliance_networking_noproxy_info.py
+++ b/plugins/modules/appliance_networking_noproxy_info.py
@@ -93,8 +93,6 @@ PAYLOAD_FORMAT = {
     "get": {"query": {}, "body": {}, "path": {}}
 }  # pylint: disable=line-too-long
 
-import json
-import socket
 from ansible.module_utils.basic import env_fallback
 
 try:
@@ -109,14 +107,8 @@ try:
 except ImportError:
     from ansible.module_utils.basic import AnsibleModule
 from ansible_collections.vmware.vmware_rest.plugins.module_utils.vmware_rest import (
-    build_full_device_list,
-    exists,
     gen_args,
-    get_device_info,
-    get_subdevice_type,
-    list_devices,
     open_session,
-    prepare_payload,
     update_changed_flag,
     session_timeout,
 )

--- a/plugins/modules/appliance_networking_proxy.py
+++ b/plugins/modules/appliance_networking_proxy.py
@@ -183,8 +183,6 @@ PAYLOAD_FORMAT = {
     "delete": {"query": {}, "body": {}, "path": {"protocol": "protocol"}},
 }  # pylint: disable=line-too-long
 
-import json
-import socket
 from ansible.module_utils.basic import env_fallback
 
 try:
@@ -199,12 +197,9 @@ try:
 except ImportError:
     from ansible.module_utils.basic import AnsibleModule
 from ansible_collections.vmware.vmware_rest.plugins.module_utils.vmware_rest import (
-    build_full_device_list,
     exists,
     gen_args,
-    get_device_info,
     get_subdevice_type,
-    list_devices,
     open_session,
     prepare_payload,
     update_changed_flag,

--- a/plugins/modules/appliance_networking_proxy_info.py
+++ b/plugins/modules/appliance_networking_proxy_info.py
@@ -108,8 +108,6 @@ PAYLOAD_FORMAT = {
     "list": {"query": {}, "body": {}, "path": {}},
 }  # pylint: disable=line-too-long
 
-import json
-import socket
 from ansible.module_utils.basic import env_fallback
 
 try:
@@ -127,11 +125,7 @@ from ansible_collections.vmware.vmware_rest.plugins.module_utils.vmware_rest imp
     build_full_device_list,
     exists,
     gen_args,
-    get_device_info,
-    get_subdevice_type,
-    list_devices,
     open_session,
-    prepare_payload,
     update_changed_flag,
     session_timeout,
 )

--- a/plugins/modules/appliance_ntp.py
+++ b/plugins/modules/appliance_ntp.py
@@ -123,8 +123,6 @@ PAYLOAD_FORMAT = {
     "set": {"query": {}, "body": {"servers": "servers"}, "path": {}},
 }  # pylint: disable=line-too-long
 
-import json
-import socket
 from ansible.module_utils.basic import env_fallback
 
 try:
@@ -139,12 +137,9 @@ try:
 except ImportError:
     from ansible.module_utils.basic import AnsibleModule
 from ansible_collections.vmware.vmware_rest.plugins.module_utils.vmware_rest import (
-    build_full_device_list,
     exists,
     gen_args,
-    get_device_info,
     get_subdevice_type,
-    list_devices,
     open_session,
     prepare_payload,
     update_changed_flag,

--- a/plugins/modules/appliance_ntp_info.py
+++ b/plugins/modules/appliance_ntp_info.py
@@ -99,8 +99,6 @@ PAYLOAD_FORMAT = {
     "get": {"query": {}, "body": {}, "path": {}}
 }  # pylint: disable=line-too-long
 
-import json
-import socket
 from ansible.module_utils.basic import env_fallback
 
 try:
@@ -115,14 +113,8 @@ try:
 except ImportError:
     from ansible.module_utils.basic import AnsibleModule
 from ansible_collections.vmware.vmware_rest.plugins.module_utils.vmware_rest import (
-    build_full_device_list,
-    exists,
     gen_args,
-    get_device_info,
-    get_subdevice_type,
-    list_devices,
     open_session,
-    prepare_payload,
     update_changed_flag,
     session_timeout,
 )

--- a/plugins/modules/appliance_services.py
+++ b/plugins/modules/appliance_services.py
@@ -120,8 +120,6 @@ PAYLOAD_FORMAT = {
     "stop": {"query": {}, "body": {}, "path": {"service": "service"}},
 }  # pylint: disable=line-too-long
 
-import json
-import socket
 from ansible.module_utils.basic import env_fallback
 
 try:
@@ -136,12 +134,9 @@ try:
 except ImportError:
     from ansible.module_utils.basic import AnsibleModule
 from ansible_collections.vmware.vmware_rest.plugins.module_utils.vmware_rest import (
-    build_full_device_list,
     exists,
     gen_args,
-    get_device_info,
     get_subdevice_type,
-    list_devices,
     open_session,
     prepare_payload,
     update_changed_flag,

--- a/plugins/modules/appliance_services_info.py
+++ b/plugins/modules/appliance_services_info.py
@@ -104,8 +104,6 @@ PAYLOAD_FORMAT = {
     "list": {"query": {}, "body": {}, "path": {}},
 }  # pylint: disable=line-too-long
 
-import json
-import socket
 from ansible.module_utils.basic import env_fallback
 
 try:
@@ -123,11 +121,7 @@ from ansible_collections.vmware.vmware_rest.plugins.module_utils.vmware_rest imp
     build_full_device_list,
     exists,
     gen_args,
-    get_device_info,
-    get_subdevice_type,
-    list_devices,
     open_session,
-    prepare_payload,
     update_changed_flag,
     session_timeout,
 )

--- a/plugins/modules/appliance_shutdown.py
+++ b/plugins/modules/appliance_shutdown.py
@@ -134,8 +134,6 @@ PAYLOAD_FORMAT = {
     },
 }  # pylint: disable=line-too-long
 
-import json
-import socket
 from ansible.module_utils.basic import env_fallback
 
 try:
@@ -150,12 +148,9 @@ try:
 except ImportError:
     from ansible.module_utils.basic import AnsibleModule
 from ansible_collections.vmware.vmware_rest.plugins.module_utils.vmware_rest import (
-    build_full_device_list,
     exists,
     gen_args,
-    get_device_info,
     get_subdevice_type,
-    list_devices,
     open_session,
     prepare_payload,
     update_changed_flag,

--- a/plugins/modules/appliance_shutdown_info.py
+++ b/plugins/modules/appliance_shutdown_info.py
@@ -98,8 +98,6 @@ PAYLOAD_FORMAT = {
     "get": {"query": {}, "body": {}, "path": {}}
 }  # pylint: disable=line-too-long
 
-import json
-import socket
 from ansible.module_utils.basic import env_fallback
 
 try:
@@ -114,14 +112,8 @@ try:
 except ImportError:
     from ansible.module_utils.basic import AnsibleModule
 from ansible_collections.vmware.vmware_rest.plugins.module_utils.vmware_rest import (
-    build_full_device_list,
-    exists,
     gen_args,
-    get_device_info,
-    get_subdevice_type,
-    list_devices,
     open_session,
-    prepare_payload,
     update_changed_flag,
     session_timeout,
 )

--- a/plugins/modules/appliance_system_globalfips.py
+++ b/plugins/modules/appliance_system_globalfips.py
@@ -93,8 +93,6 @@ PAYLOAD_FORMAT = {
     "update": {"query": {}, "body": {"enabled": "enabled"}, "path": {}}
 }  # pylint: disable=line-too-long
 
-import json
-import socket
 from ansible.module_utils.basic import env_fallback
 
 try:
@@ -109,12 +107,6 @@ try:
 except ImportError:
     from ansible.module_utils.basic import AnsibleModule
 from ansible_collections.vmware.vmware_rest.plugins.module_utils.vmware_rest import (
-    build_full_device_list,
-    exists,
-    gen_args,
-    get_device_info,
-    get_subdevice_type,
-    list_devices,
     open_session,
     prepare_payload,
     update_changed_flag,

--- a/plugins/modules/appliance_system_globalfips_info.py
+++ b/plugins/modules/appliance_system_globalfips_info.py
@@ -82,8 +82,6 @@ PAYLOAD_FORMAT = {
     "get": {"query": {}, "body": {}, "path": {}}
 }  # pylint: disable=line-too-long
 
-import json
-import socket
 from ansible.module_utils.basic import env_fallback
 
 try:
@@ -98,14 +96,8 @@ try:
 except ImportError:
     from ansible.module_utils.basic import AnsibleModule
 from ansible_collections.vmware.vmware_rest.plugins.module_utils.vmware_rest import (
-    build_full_device_list,
-    exists,
     gen_args,
-    get_device_info,
-    get_subdevice_type,
-    list_devices,
     open_session,
-    prepare_payload,
     update_changed_flag,
     session_timeout,
 )

--- a/plugins/modules/appliance_system_storage.py
+++ b/plugins/modules/appliance_system_storage.py
@@ -109,8 +109,6 @@ PAYLOAD_FORMAT = {
     "resize": {"query": {}, "body": {}, "path": {}},
 }  # pylint: disable=line-too-long
 
-import json
-import socket
 from ansible.module_utils.basic import env_fallback
 
 try:
@@ -125,12 +123,9 @@ try:
 except ImportError:
     from ansible.module_utils.basic import AnsibleModule
 from ansible_collections.vmware.vmware_rest.plugins.module_utils.vmware_rest import (
-    build_full_device_list,
     exists,
     gen_args,
-    get_device_info,
     get_subdevice_type,
-    list_devices,
     open_session,
     prepare_payload,
     update_changed_flag,

--- a/plugins/modules/appliance_system_storage_info.py
+++ b/plugins/modules/appliance_system_storage_info.py
@@ -91,8 +91,6 @@ PAYLOAD_FORMAT = {
     "list": {"query": {}, "body": {}, "path": {}}
 }  # pylint: disable=line-too-long
 
-import json
-import socket
 from ansible.module_utils.basic import env_fallback
 
 try:
@@ -107,14 +105,8 @@ try:
 except ImportError:
     from ansible.module_utils.basic import AnsibleModule
 from ansible_collections.vmware.vmware_rest.plugins.module_utils.vmware_rest import (
-    build_full_device_list,
-    exists,
     gen_args,
-    get_device_info,
-    get_subdevice_type,
-    list_devices,
     open_session,
-    prepare_payload,
     update_changed_flag,
     session_timeout,
 )

--- a/plugins/modules/appliance_system_time_info.py
+++ b/plugins/modules/appliance_system_time_info.py
@@ -95,8 +95,6 @@ PAYLOAD_FORMAT = {
     "get": {"query": {}, "body": {}, "path": {}}
 }  # pylint: disable=line-too-long
 
-import json
-import socket
 from ansible.module_utils.basic import env_fallback
 
 try:
@@ -111,14 +109,8 @@ try:
 except ImportError:
     from ansible.module_utils.basic import AnsibleModule
 from ansible_collections.vmware.vmware_rest.plugins.module_utils.vmware_rest import (
-    build_full_device_list,
-    exists,
     gen_args,
-    get_device_info,
-    get_subdevice_type,
-    list_devices,
     open_session,
-    prepare_payload,
     update_changed_flag,
     session_timeout,
 )

--- a/plugins/modules/appliance_system_time_timezone.py
+++ b/plugins/modules/appliance_system_time_timezone.py
@@ -103,8 +103,6 @@ PAYLOAD_FORMAT = {
     "set": {"query": {}, "body": {"name": "name"}, "path": {}}
 }  # pylint: disable=line-too-long
 
-import json
-import socket
 from ansible.module_utils.basic import env_fallback
 
 try:
@@ -119,12 +117,9 @@ try:
 except ImportError:
     from ansible.module_utils.basic import AnsibleModule
 from ansible_collections.vmware.vmware_rest.plugins.module_utils.vmware_rest import (
-    build_full_device_list,
     exists,
     gen_args,
-    get_device_info,
     get_subdevice_type,
-    list_devices,
     open_session,
     prepare_payload,
     update_changed_flag,

--- a/plugins/modules/appliance_system_time_timezone_info.py
+++ b/plugins/modules/appliance_system_time_timezone_info.py
@@ -91,8 +91,6 @@ PAYLOAD_FORMAT = {
     "get": {"query": {}, "body": {}, "path": {}}
 }  # pylint: disable=line-too-long
 
-import json
-import socket
 from ansible.module_utils.basic import env_fallback
 
 try:
@@ -107,14 +105,8 @@ try:
 except ImportError:
     from ansible.module_utils.basic import AnsibleModule
 from ansible_collections.vmware.vmware_rest.plugins.module_utils.vmware_rest import (
-    build_full_device_list,
-    exists,
     gen_args,
-    get_device_info,
-    get_subdevice_type,
-    list_devices,
     open_session,
-    prepare_payload,
     update_changed_flag,
     session_timeout,
 )

--- a/plugins/modules/appliance_system_version_info.py
+++ b/plugins/modules/appliance_system_version_info.py
@@ -98,8 +98,6 @@ PAYLOAD_FORMAT = {
     "get": {"query": {}, "body": {}, "path": {}}
 }  # pylint: disable=line-too-long
 
-import json
-import socket
 from ansible.module_utils.basic import env_fallback
 
 try:
@@ -114,14 +112,8 @@ try:
 except ImportError:
     from ansible.module_utils.basic import AnsibleModule
 from ansible_collections.vmware.vmware_rest.plugins.module_utils.vmware_rest import (
-    build_full_device_list,
-    exists,
     gen_args,
-    get_device_info,
-    get_subdevice_type,
-    list_devices,
     open_session,
-    prepare_payload,
     update_changed_flag,
     session_timeout,
 )

--- a/plugins/modules/appliance_timesync.py
+++ b/plugins/modules/appliance_timesync.py
@@ -107,8 +107,6 @@ PAYLOAD_FORMAT = {
     "set": {"query": {}, "body": {"mode": "mode"}, "path": {}}
 }  # pylint: disable=line-too-long
 
-import json
-import socket
 from ansible.module_utils.basic import env_fallback
 
 try:
@@ -123,12 +121,9 @@ try:
 except ImportError:
     from ansible.module_utils.basic import AnsibleModule
 from ansible_collections.vmware.vmware_rest.plugins.module_utils.vmware_rest import (
-    build_full_device_list,
     exists,
     gen_args,
-    get_device_info,
     get_subdevice_type,
-    list_devices,
     open_session,
     prepare_payload,
     update_changed_flag,

--- a/plugins/modules/appliance_timesync_info.py
+++ b/plugins/modules/appliance_timesync_info.py
@@ -91,8 +91,6 @@ PAYLOAD_FORMAT = {
     "get": {"query": {}, "body": {}, "path": {}}
 }  # pylint: disable=line-too-long
 
-import json
-import socket
 from ansible.module_utils.basic import env_fallback
 
 try:
@@ -107,14 +105,8 @@ try:
 except ImportError:
     from ansible.module_utils.basic import AnsibleModule
 from ansible_collections.vmware.vmware_rest.plugins.module_utils.vmware_rest import (
-    build_full_device_list,
-    exists,
     gen_args,
-    get_device_info,
-    get_subdevice_type,
-    list_devices,
     open_session,
-    prepare_payload,
     update_changed_flag,
     session_timeout,
 )

--- a/plugins/modules/appliance_update_info.py
+++ b/plugins/modules/appliance_update_info.py
@@ -93,8 +93,6 @@ PAYLOAD_FORMAT = {
     "get": {"query": {}, "body": {}, "path": {}}
 }  # pylint: disable=line-too-long
 
-import json
-import socket
 from ansible.module_utils.basic import env_fallback
 
 try:
@@ -109,14 +107,8 @@ try:
 except ImportError:
     from ansible.module_utils.basic import AnsibleModule
 from ansible_collections.vmware.vmware_rest.plugins.module_utils.vmware_rest import (
-    build_full_device_list,
-    exists,
     gen_args,
-    get_device_info,
-    get_subdevice_type,
-    list_devices,
     open_session,
-    prepare_payload,
     update_changed_flag,
     session_timeout,
 )

--- a/plugins/modules/appliance_vmon_service.py
+++ b/plugins/modules/appliance_vmon_service.py
@@ -131,8 +131,6 @@ PAYLOAD_FORMAT = {
     "start": {"query": {}, "body": {}, "path": {"service": "service"}},
 }  # pylint: disable=line-too-long
 
-import json
-import socket
 from ansible.module_utils.basic import env_fallback
 
 try:
@@ -147,12 +145,9 @@ try:
 except ImportError:
     from ansible.module_utils.basic import AnsibleModule
 from ansible_collections.vmware.vmware_rest.plugins.module_utils.vmware_rest import (
-    build_full_device_list,
     exists,
     gen_args,
-    get_device_info,
     get_subdevice_type,
-    list_devices,
     open_session,
     prepare_payload,
     update_changed_flag,

--- a/plugins/modules/appliance_vmon_service_info.py
+++ b/plugins/modules/appliance_vmon_service_info.py
@@ -477,8 +477,6 @@ PAYLOAD_FORMAT = {
     "get": {"query": {}, "body": {}, "path": {"service": "service"}}
 }  # pylint: disable=line-too-long
 
-import json
-import socket
 from ansible.module_utils.basic import env_fallback
 
 try:
@@ -493,14 +491,8 @@ try:
 except ImportError:
     from ansible.module_utils.basic import AnsibleModule
 from ansible_collections.vmware.vmware_rest.plugins.module_utils.vmware_rest import (
-    build_full_device_list,
-    exists,
     gen_args,
-    get_device_info,
-    get_subdevice_type,
-    list_devices,
     open_session,
-    prepare_payload,
     update_changed_flag,
     session_timeout,
 )

--- a/plugins/modules/content_configuration.py
+++ b/plugins/modules/content_configuration.py
@@ -146,8 +146,6 @@ PAYLOAD_FORMAT = {
     }
 }  # pylint: disable=line-too-long
 
-import json
-import socket
 from ansible.module_utils.basic import env_fallback
 
 try:
@@ -162,12 +160,6 @@ try:
 except ImportError:
     from ansible.module_utils.basic import AnsibleModule
 from ansible_collections.vmware.vmware_rest.plugins.module_utils.vmware_rest import (
-    build_full_device_list,
-    exists,
-    gen_args,
-    get_device_info,
-    get_subdevice_type,
-    list_devices,
     open_session,
     prepare_payload,
     update_changed_flag,

--- a/plugins/modules/content_configuration_info.py
+++ b/plugins/modules/content_configuration_info.py
@@ -95,8 +95,6 @@ PAYLOAD_FORMAT = {
     "get": {"query": {}, "body": {}, "path": {}}
 }  # pylint: disable=line-too-long
 
-import json
-import socket
 from ansible.module_utils.basic import env_fallback
 
 try:
@@ -111,14 +109,8 @@ try:
 except ImportError:
     from ansible.module_utils.basic import AnsibleModule
 from ansible_collections.vmware.vmware_rest.plugins.module_utils.vmware_rest import (
-    build_full_device_list,
-    exists,
     gen_args,
-    get_device_info,
-    get_subdevice_type,
-    list_devices,
     open_session,
-    prepare_payload,
     update_changed_flag,
     session_timeout,
 )

--- a/plugins/modules/content_library_item_info.py
+++ b/plugins/modules/content_library_item_info.py
@@ -184,8 +184,6 @@ PAYLOAD_FORMAT = {
     "list": {"query": {"library_id": "library_id"}, "body": {}, "path": {}},
 }  # pylint: disable=line-too-long
 
-import json
-import socket
 from ansible.module_utils.basic import env_fallback
 
 try:
@@ -203,11 +201,7 @@ from ansible_collections.vmware.vmware_rest.plugins.module_utils.vmware_rest imp
     build_full_device_list,
     exists,
     gen_args,
-    get_device_info,
-    get_subdevice_type,
-    list_devices,
     open_session,
-    prepare_payload,
     update_changed_flag,
     session_timeout,
 )

--- a/plugins/modules/content_locallibrary.py
+++ b/plugins/modules/content_locallibrary.py
@@ -1288,8 +1288,6 @@ PAYLOAD_FORMAT = {
     },
 }  # pylint: disable=line-too-long
 
-import json
-import socket
 from ansible.module_utils.basic import env_fallback
 
 try:
@@ -1304,12 +1302,10 @@ try:
 except ImportError:
     from ansible.module_utils.basic import AnsibleModule
 from ansible_collections.vmware.vmware_rest.plugins.module_utils.vmware_rest import (
-    build_full_device_list,
     exists,
     gen_args,
     get_device_info,
     get_subdevice_type,
-    list_devices,
     open_session,
     prepare_payload,
     update_changed_flag,

--- a/plugins/modules/content_locallibrary_info.py
+++ b/plugins/modules/content_locallibrary_info.py
@@ -323,8 +323,6 @@ PAYLOAD_FORMAT = {
     "list": {"query": {}, "body": {}, "path": {}},
 }  # pylint: disable=line-too-long
 
-import json
-import socket
 from ansible.module_utils.basic import env_fallback
 
 try:
@@ -342,11 +340,7 @@ from ansible_collections.vmware.vmware_rest.plugins.module_utils.vmware_rest imp
     build_full_device_list,
     exists,
     gen_args,
-    get_device_info,
-    get_subdevice_type,
-    list_devices,
     open_session,
-    prepare_payload,
     update_changed_flag,
     session_timeout,
 )

--- a/plugins/modules/content_subscribedlibrary.py
+++ b/plugins/modules/content_subscribedlibrary.py
@@ -494,8 +494,6 @@ PAYLOAD_FORMAT = {
     "evict": {"query": {}, "body": {}, "path": {"library_id": "library_id"}},
 }  # pylint: disable=line-too-long
 
-import json
-import socket
 from ansible.module_utils.basic import env_fallback
 
 try:
@@ -510,12 +508,10 @@ try:
 except ImportError:
     from ansible.module_utils.basic import AnsibleModule
 from ansible_collections.vmware.vmware_rest.plugins.module_utils.vmware_rest import (
-    build_full_device_list,
     exists,
     gen_args,
     get_device_info,
     get_subdevice_type,
-    list_devices,
     open_session,
     prepare_payload,
     update_changed_flag,

--- a/plugins/modules/content_subscribedlibrary_info.py
+++ b/plugins/modules/content_subscribedlibrary_info.py
@@ -113,8 +113,6 @@ PAYLOAD_FORMAT = {
     "list": {"query": {}, "body": {}, "path": {}},
 }  # pylint: disable=line-too-long
 
-import json
-import socket
 from ansible.module_utils.basic import env_fallback
 
 try:
@@ -132,11 +130,7 @@ from ansible_collections.vmware.vmware_rest.plugins.module_utils.vmware_rest imp
     build_full_device_list,
     exists,
     gen_args,
-    get_device_info,
-    get_subdevice_type,
-    list_devices,
     open_session,
-    prepare_payload,
     update_changed_flag,
     session_timeout,
 )

--- a/plugins/modules/vcenter_cluster_info.py
+++ b/plugins/modules/vcenter_cluster_info.py
@@ -145,8 +145,6 @@ PAYLOAD_FORMAT = {
     },
 }  # pylint: disable=line-too-long
 
-import json
-import socket
 from ansible.module_utils.basic import env_fallback
 
 try:
@@ -164,11 +162,7 @@ from ansible_collections.vmware.vmware_rest.plugins.module_utils.vmware_rest imp
     build_full_device_list,
     exists,
     gen_args,
-    get_device_info,
-    get_subdevice_type,
-    list_devices,
     open_session,
-    prepare_payload,
     update_changed_flag,
     session_timeout,
 )

--- a/plugins/modules/vcenter_datacenter.py
+++ b/plugins/modules/vcenter_datacenter.py
@@ -164,8 +164,6 @@ PAYLOAD_FORMAT = {
     },
 }  # pylint: disable=line-too-long
 
-import json
-import socket
 from ansible.module_utils.basic import env_fallback
 
 try:
@@ -180,12 +178,10 @@ try:
 except ImportError:
     from ansible.module_utils.basic import AnsibleModule
 from ansible_collections.vmware.vmware_rest.plugins.module_utils.vmware_rest import (
-    build_full_device_list,
     exists,
     gen_args,
     get_device_info,
     get_subdevice_type,
-    list_devices,
     open_session,
     prepare_payload,
     update_changed_flag,

--- a/plugins/modules/vcenter_datacenter_info.py
+++ b/plugins/modules/vcenter_datacenter_info.py
@@ -130,8 +130,6 @@ PAYLOAD_FORMAT = {
     },
 }  # pylint: disable=line-too-long
 
-import json
-import socket
 from ansible.module_utils.basic import env_fallback
 
 try:
@@ -149,11 +147,7 @@ from ansible_collections.vmware.vmware_rest.plugins.module_utils.vmware_rest imp
     build_full_device_list,
     exists,
     gen_args,
-    get_device_info,
-    get_subdevice_type,
-    list_devices,
     open_session,
-    prepare_payload,
     update_changed_flag,
     session_timeout,
 )

--- a/plugins/modules/vcenter_datastore_info.py
+++ b/plugins/modules/vcenter_datastore_info.py
@@ -157,8 +157,6 @@ PAYLOAD_FORMAT = {
     },
 }  # pylint: disable=line-too-long
 
-import json
-import socket
 from ansible.module_utils.basic import env_fallback
 
 try:
@@ -176,11 +174,7 @@ from ansible_collections.vmware.vmware_rest.plugins.module_utils.vmware_rest imp
     build_full_device_list,
     exists,
     gen_args,
-    get_device_info,
-    get_subdevice_type,
-    list_devices,
     open_session,
-    prepare_payload,
     update_changed_flag,
     session_timeout,
 )

--- a/plugins/modules/vcenter_folder_info.py
+++ b/plugins/modules/vcenter_folder_info.py
@@ -154,8 +154,6 @@ PAYLOAD_FORMAT = {
     }
 }  # pylint: disable=line-too-long
 
-import json
-import socket
 from ansible.module_utils.basic import env_fallback
 
 try:
@@ -170,14 +168,8 @@ try:
 except ImportError:
     from ansible.module_utils.basic import AnsibleModule
 from ansible_collections.vmware.vmware_rest.plugins.module_utils.vmware_rest import (
-    build_full_device_list,
-    exists,
     gen_args,
-    get_device_info,
-    get_subdevice_type,
-    list_devices,
     open_session,
-    prepare_payload,
     update_changed_flag,
     session_timeout,
 )

--- a/plugins/modules/vcenter_host.py
+++ b/plugins/modules/vcenter_host.py
@@ -171,8 +171,6 @@ PAYLOAD_FORMAT = {
     },
 }  # pylint: disable=line-too-long
 
-import json
-import socket
 from ansible.module_utils.basic import env_fallback
 
 try:
@@ -187,12 +185,10 @@ try:
 except ImportError:
     from ansible.module_utils.basic import AnsibleModule
 from ansible_collections.vmware.vmware_rest.plugins.module_utils.vmware_rest import (
-    build_full_device_list,
     exists,
     gen_args,
     get_device_info,
     get_subdevice_type,
-    list_devices,
     open_session,
     prepare_payload,
     update_changed_flag,

--- a/plugins/modules/vcenter_host_info.py
+++ b/plugins/modules/vcenter_host_info.py
@@ -152,8 +152,6 @@ PAYLOAD_FORMAT = {
     }
 }  # pylint: disable=line-too-long
 
-import json
-import socket
 from ansible.module_utils.basic import env_fallback
 
 try:
@@ -171,11 +169,7 @@ from ansible_collections.vmware.vmware_rest.plugins.module_utils.vmware_rest imp
     build_full_device_list,
     exists,
     gen_args,
-    get_device_info,
-    get_subdevice_type,
-    list_devices,
     open_session,
-    prepare_payload,
     update_changed_flag,
     session_timeout,
 )

--- a/plugins/modules/vcenter_network_info.py
+++ b/plugins/modules/vcenter_network_info.py
@@ -150,8 +150,6 @@ PAYLOAD_FORMAT = {
     }
 }  # pylint: disable=line-too-long
 
-import json
-import socket
 from ansible.module_utils.basic import env_fallback
 
 try:
@@ -166,14 +164,8 @@ try:
 except ImportError:
     from ansible.module_utils.basic import AnsibleModule
 from ansible_collections.vmware.vmware_rest.plugins.module_utils.vmware_rest import (
-    build_full_device_list,
-    exists,
     gen_args,
-    get_device_info,
-    get_subdevice_type,
-    list_devices,
     open_session,
-    prepare_payload,
     update_changed_flag,
     session_timeout,
 )

--- a/plugins/modules/vcenter_ovf_libraryitem.py
+++ b/plugins/modules/vcenter_ovf_libraryitem.py
@@ -298,8 +298,6 @@ PAYLOAD_FORMAT = {
     },
 }  # pylint: disable=line-too-long
 
-import json
-import socket
 from ansible.module_utils.basic import env_fallback
 
 try:
@@ -314,12 +312,10 @@ try:
 except ImportError:
     from ansible.module_utils.basic import AnsibleModule
 from ansible_collections.vmware.vmware_rest.plugins.module_utils.vmware_rest import (
-    build_full_device_list,
     exists,
     gen_args,
     get_device_info,
     get_subdevice_type,
-    list_devices,
     open_session,
     prepare_payload,
     update_changed_flag,

--- a/plugins/modules/vcenter_resourcepool.py
+++ b/plugins/modules/vcenter_resourcepool.py
@@ -260,8 +260,6 @@ PAYLOAD_FORMAT = {
     },
 }  # pylint: disable=line-too-long
 
-import json
-import socket
 from ansible.module_utils.basic import env_fallback
 
 try:
@@ -276,12 +274,10 @@ try:
 except ImportError:
     from ansible.module_utils.basic import AnsibleModule
 from ansible_collections.vmware.vmware_rest.plugins.module_utils.vmware_rest import (
-    build_full_device_list,
     exists,
     gen_args,
     get_device_info,
     get_subdevice_type,
-    list_devices,
     open_session,
     prepare_payload,
     update_changed_flag,

--- a/plugins/modules/vcenter_resourcepool_info.py
+++ b/plugins/modules/vcenter_resourcepool_info.py
@@ -183,8 +183,6 @@ PAYLOAD_FORMAT = {
     },
 }  # pylint: disable=line-too-long
 
-import json
-import socket
 from ansible.module_utils.basic import env_fallback
 
 try:
@@ -202,11 +200,7 @@ from ansible_collections.vmware.vmware_rest.plugins.module_utils.vmware_rest imp
     build_full_device_list,
     exists,
     gen_args,
-    get_device_info,
-    get_subdevice_type,
-    list_devices,
     open_session,
-    prepare_payload,
     update_changed_flag,
     session_timeout,
 )

--- a/plugins/modules/vcenter_storage_policies_info.py
+++ b/plugins/modules/vcenter_storage_policies_info.py
@@ -135,8 +135,6 @@ PAYLOAD_FORMAT = {
     "list": {"query": {"policies": "policies"}, "body": {}, "path": {}}
 }  # pylint: disable=line-too-long
 
-import json
-import socket
 from ansible.module_utils.basic import env_fallback
 
 try:
@@ -151,14 +149,8 @@ try:
 except ImportError:
     from ansible.module_utils.basic import AnsibleModule
 from ansible_collections.vmware.vmware_rest.plugins.module_utils.vmware_rest import (
-    build_full_device_list,
-    exists,
     gen_args,
-    get_device_info,
-    get_subdevice_type,
-    list_devices,
     open_session,
-    prepare_payload,
     update_changed_flag,
     session_timeout,
 )

--- a/plugins/modules/vcenter_vm.py
+++ b/plugins/modules/vcenter_vm.py
@@ -1086,8 +1086,6 @@ PAYLOAD_FORMAT = {
     "unregister": {"query": {}, "body": {}, "path": {"vm": "vm"}},
 }  # pylint: disable=line-too-long
 
-import json
-import socket
 from ansible.module_utils.basic import env_fallback
 
 try:
@@ -1102,12 +1100,10 @@ try:
 except ImportError:
     from ansible.module_utils.basic import AnsibleModule
 from ansible_collections.vmware.vmware_rest.plugins.module_utils.vmware_rest import (
-    build_full_device_list,
     exists,
     gen_args,
     get_device_info,
     get_subdevice_type,
-    list_devices,
     open_session,
     prepare_payload,
     update_changed_flag,

--- a/plugins/modules/vcenter_vm_guest_customization.py
+++ b/plugins/modules/vcenter_vm_guest_customization.py
@@ -220,8 +220,6 @@ PAYLOAD_FORMAT = {
     }
 }  # pylint: disable=line-too-long
 
-import json
-import socket
 from ansible.module_utils.basic import env_fallback
 
 try:
@@ -236,12 +234,9 @@ try:
 except ImportError:
     from ansible.module_utils.basic import AnsibleModule
 from ansible_collections.vmware.vmware_rest.plugins.module_utils.vmware_rest import (
-    build_full_device_list,
     exists,
     gen_args,
-    get_device_info,
     get_subdevice_type,
-    list_devices,
     open_session,
     prepare_payload,
     update_changed_flag,

--- a/plugins/modules/vcenter_vm_guest_filesystem_directories.py
+++ b/plugins/modules/vcenter_vm_guest_filesystem_directories.py
@@ -232,8 +232,6 @@ PAYLOAD_FORMAT = {
     },
 }  # pylint: disable=line-too-long
 
-import json
-import socket
 from ansible.module_utils.basic import env_fallback
 
 try:
@@ -248,12 +246,10 @@ try:
 except ImportError:
     from ansible.module_utils.basic import AnsibleModule
 from ansible_collections.vmware.vmware_rest.plugins.module_utils.vmware_rest import (
-    build_full_device_list,
     exists,
     gen_args,
     get_device_info,
     get_subdevice_type,
-    list_devices,
     open_session,
     prepare_payload,
     update_changed_flag,

--- a/plugins/modules/vcenter_vm_guest_identity_info.py
+++ b/plugins/modules/vcenter_vm_guest_identity_info.py
@@ -114,8 +114,6 @@ PAYLOAD_FORMAT = {
     "get": {"query": {}, "body": {}, "path": {"vm": "vm"}}
 }  # pylint: disable=line-too-long
 
-import json
-import socket
 from ansible.module_utils.basic import env_fallback
 
 try:
@@ -130,14 +128,8 @@ try:
 except ImportError:
     from ansible.module_utils.basic import AnsibleModule
 from ansible_collections.vmware.vmware_rest.plugins.module_utils.vmware_rest import (
-    build_full_device_list,
-    exists,
     gen_args,
-    get_device_info,
-    get_subdevice_type,
-    list_devices,
     open_session,
-    prepare_payload,
     update_changed_flag,
     session_timeout,
 )

--- a/plugins/modules/vcenter_vm_guest_localfilesystem_info.py
+++ b/plugins/modules/vcenter_vm_guest_localfilesystem_info.py
@@ -116,8 +116,6 @@ PAYLOAD_FORMAT = {
     "get": {"query": {}, "body": {}, "path": {"vm": "vm"}}
 }  # pylint: disable=line-too-long
 
-import json
-import socket
 from ansible.module_utils.basic import env_fallback
 
 try:
@@ -132,14 +130,8 @@ try:
 except ImportError:
     from ansible.module_utils.basic import AnsibleModule
 from ansible_collections.vmware.vmware_rest.plugins.module_utils.vmware_rest import (
-    build_full_device_list,
-    exists,
     gen_args,
-    get_device_info,
-    get_subdevice_type,
-    list_devices,
     open_session,
-    prepare_payload,
     update_changed_flag,
     session_timeout,
 )

--- a/plugins/modules/vcenter_vm_guest_networking_info.py
+++ b/plugins/modules/vcenter_vm_guest_networking_info.py
@@ -117,8 +117,6 @@ PAYLOAD_FORMAT = {
     "get": {"query": {}, "body": {}, "path": {"vm": "vm"}}
 }  # pylint: disable=line-too-long
 
-import json
-import socket
 from ansible.module_utils.basic import env_fallback
 
 try:
@@ -133,14 +131,8 @@ try:
 except ImportError:
     from ansible.module_utils.basic import AnsibleModule
 from ansible_collections.vmware.vmware_rest.plugins.module_utils.vmware_rest import (
-    build_full_device_list,
-    exists,
     gen_args,
-    get_device_info,
-    get_subdevice_type,
-    list_devices,
     open_session,
-    prepare_payload,
     update_changed_flag,
     session_timeout,
 )

--- a/plugins/modules/vcenter_vm_guest_networking_interfaces_info.py
+++ b/plugins/modules/vcenter_vm_guest_networking_interfaces_info.py
@@ -113,8 +113,6 @@ PAYLOAD_FORMAT = {
     "list": {"query": {}, "body": {}, "path": {"vm": "vm"}}
 }  # pylint: disable=line-too-long
 
-import json
-import socket
 from ansible.module_utils.basic import env_fallback
 
 try:
@@ -129,14 +127,8 @@ try:
 except ImportError:
     from ansible.module_utils.basic import AnsibleModule
 from ansible_collections.vmware.vmware_rest.plugins.module_utils.vmware_rest import (
-    build_full_device_list,
-    exists,
     gen_args,
-    get_device_info,
-    get_subdevice_type,
-    list_devices,
     open_session,
-    prepare_payload,
     update_changed_flag,
     session_timeout,
 )

--- a/plugins/modules/vcenter_vm_guest_networking_routes_info.py
+++ b/plugins/modules/vcenter_vm_guest_networking_routes_info.py
@@ -108,8 +108,6 @@ PAYLOAD_FORMAT = {
     "list": {"query": {}, "body": {}, "path": {"vm": "vm"}}
 }  # pylint: disable=line-too-long
 
-import json
-import socket
 from ansible.module_utils.basic import env_fallback
 
 try:
@@ -124,14 +122,8 @@ try:
 except ImportError:
     from ansible.module_utils.basic import AnsibleModule
 from ansible_collections.vmware.vmware_rest.plugins.module_utils.vmware_rest import (
-    build_full_device_list,
-    exists,
     gen_args,
-    get_device_info,
-    get_subdevice_type,
-    list_devices,
     open_session,
-    prepare_payload,
     update_changed_flag,
     session_timeout,
 )

--- a/plugins/modules/vcenter_vm_guest_operations_info.py
+++ b/plugins/modules/vcenter_vm_guest_operations_info.py
@@ -86,8 +86,6 @@ PAYLOAD_FORMAT = {
     "get": {"query": {}, "body": {}, "path": {"vm": "vm"}}
 }  # pylint: disable=line-too-long
 
-import json
-import socket
 from ansible.module_utils.basic import env_fallback
 
 try:
@@ -102,14 +100,8 @@ try:
 except ImportError:
     from ansible.module_utils.basic import AnsibleModule
 from ansible_collections.vmware.vmware_rest.plugins.module_utils.vmware_rest import (
-    build_full_device_list,
-    exists,
     gen_args,
-    get_device_info,
-    get_subdevice_type,
-    list_devices,
     open_session,
-    prepare_payload,
     update_changed_flag,
     session_timeout,
 )

--- a/plugins/modules/vcenter_vm_guest_power.py
+++ b/plugins/modules/vcenter_vm_guest_power.py
@@ -146,8 +146,6 @@ PAYLOAD_FORMAT = {
     "standby": {"query": {}, "body": {}, "path": {"vm": "vm"}},
 }  # pylint: disable=line-too-long
 
-import json
-import socket
 from ansible.module_utils.basic import env_fallback
 
 try:
@@ -162,12 +160,9 @@ try:
 except ImportError:
     from ansible.module_utils.basic import AnsibleModule
 from ansible_collections.vmware.vmware_rest.plugins.module_utils.vmware_rest import (
-    build_full_device_list,
     exists,
     gen_args,
-    get_device_info,
     get_subdevice_type,
-    list_devices,
     open_session,
     prepare_payload,
     update_changed_flag,

--- a/plugins/modules/vcenter_vm_guest_power_info.py
+++ b/plugins/modules/vcenter_vm_guest_power_info.py
@@ -130,8 +130,6 @@ PAYLOAD_FORMAT = {
     "get": {"query": {}, "body": {}, "path": {"vm": "vm"}}
 }  # pylint: disable=line-too-long
 
-import json
-import socket
 from ansible.module_utils.basic import env_fallback
 
 try:
@@ -146,14 +144,8 @@ try:
 except ImportError:
     from ansible.module_utils.basic import AnsibleModule
 from ansible_collections.vmware.vmware_rest.plugins.module_utils.vmware_rest import (
-    build_full_device_list,
-    exists,
     gen_args,
-    get_device_info,
-    get_subdevice_type,
-    list_devices,
     open_session,
-    prepare_payload,
     update_changed_flag,
     session_timeout,
 )

--- a/plugins/modules/vcenter_vm_hardware.py
+++ b/plugins/modules/vcenter_vm_hardware.py
@@ -174,8 +174,6 @@ PAYLOAD_FORMAT = {
     "upgrade": {"query": {}, "body": {"version": "version"}, "path": {"vm": "vm"}},
 }  # pylint: disable=line-too-long
 
-import json
-import socket
 from ansible.module_utils.basic import env_fallback
 
 try:
@@ -190,12 +188,9 @@ try:
 except ImportError:
     from ansible.module_utils.basic import AnsibleModule
 from ansible_collections.vmware.vmware_rest.plugins.module_utils.vmware_rest import (
-    build_full_device_list,
     exists,
     gen_args,
-    get_device_info,
     get_subdevice_type,
-    list_devices,
     open_session,
     prepare_payload,
     update_changed_flag,

--- a/plugins/modules/vcenter_vm_hardware_adapter_sata.py
+++ b/plugins/modules/vcenter_vm_hardware_adapter_sata.py
@@ -23,6 +23,7 @@ options:
         description:
         - SATA bus number.
         type: int
+        default: 0
     label:
         description:
         - The name of the item
@@ -158,8 +159,6 @@ PAYLOAD_FORMAT = {
     "delete": {"query": {}, "body": {}, "path": {"adapter": "adapter", "vm": "vm"}},
 }  # pylint: disable=line-too-long
 
-import json
-import socket
 from ansible.module_utils.basic import env_fallback
 
 try:
@@ -174,12 +173,10 @@ try:
 except ImportError:
     from ansible.module_utils.basic import AnsibleModule
 from ansible_collections.vmware.vmware_rest.plugins.module_utils.vmware_rest import (
-    build_full_device_list,
     exists,
     gen_args,
     get_device_info,
     get_subdevice_type,
-    list_devices,
     open_session,
     prepare_payload,
     update_changed_flag,

--- a/plugins/modules/vcenter_vm_hardware_adapter_sata_info.py
+++ b/plugins/modules/vcenter_vm_hardware_adapter_sata_info.py
@@ -130,8 +130,6 @@ PAYLOAD_FORMAT = {
     "list": {"query": {}, "body": {}, "path": {"vm": "vm"}},
 }  # pylint: disable=line-too-long
 
-import json
-import socket
 from ansible.module_utils.basic import env_fallback
 
 try:
@@ -149,11 +147,7 @@ from ansible_collections.vmware.vmware_rest.plugins.module_utils.vmware_rest imp
     build_full_device_list,
     exists,
     gen_args,
-    get_device_info,
-    get_subdevice_type,
-    list_devices,
     open_session,
-    prepare_payload,
     update_changed_flag,
     session_timeout,
 )

--- a/plugins/modules/vcenter_vm_hardware_adapter_scsi.py
+++ b/plugins/modules/vcenter_vm_hardware_adapter_scsi.py
@@ -23,6 +23,7 @@ options:
         description:
         - SCSI bus number.
         type: int
+        default: 0
     label:
         description:
         - The name of the item
@@ -185,8 +186,6 @@ PAYLOAD_FORMAT = {
     },
 }  # pylint: disable=line-too-long
 
-import json
-import socket
 from ansible.module_utils.basic import env_fallback
 
 try:
@@ -201,12 +200,10 @@ try:
 except ImportError:
     from ansible.module_utils.basic import AnsibleModule
 from ansible_collections.vmware.vmware_rest.plugins.module_utils.vmware_rest import (
-    build_full_device_list,
     exists,
     gen_args,
     get_device_info,
     get_subdevice_type,
-    list_devices,
     open_session,
     prepare_payload,
     update_changed_flag,

--- a/plugins/modules/vcenter_vm_hardware_adapter_scsi_info.py
+++ b/plugins/modules/vcenter_vm_hardware_adapter_scsi_info.py
@@ -118,8 +118,6 @@ PAYLOAD_FORMAT = {
     "list": {"query": {}, "body": {}, "path": {"vm": "vm"}},
 }  # pylint: disable=line-too-long
 
-import json
-import socket
 from ansible.module_utils.basic import env_fallback
 
 try:
@@ -137,11 +135,7 @@ from ansible_collections.vmware.vmware_rest.plugins.module_utils.vmware_rest imp
     build_full_device_list,
     exists,
     gen_args,
-    get_device_info,
-    get_subdevice_type,
-    list_devices,
     open_session,
-    prepare_payload,
     update_changed_flag,
     session_timeout,
 )

--- a/plugins/modules/vcenter_vm_hardware_boot.py
+++ b/plugins/modules/vcenter_vm_hardware_boot.py
@@ -177,8 +177,6 @@ PAYLOAD_FORMAT = {
     }
 }  # pylint: disable=line-too-long
 
-import json
-import socket
 from ansible.module_utils.basic import env_fallback
 
 try:
@@ -193,12 +191,6 @@ try:
 except ImportError:
     from ansible.module_utils.basic import AnsibleModule
 from ansible_collections.vmware.vmware_rest.plugins.module_utils.vmware_rest import (
-    build_full_device_list,
-    exists,
-    gen_args,
-    get_device_info,
-    get_subdevice_type,
-    list_devices,
     open_session,
     prepare_payload,
     update_changed_flag,

--- a/plugins/modules/vcenter_vm_hardware_boot_device.py
+++ b/plugins/modules/vcenter_vm_hardware_boot_device.py
@@ -141,8 +141,6 @@ PAYLOAD_FORMAT = {
     "set": {"query": {}, "body": {"devices": "devices"}, "path": {"vm": "vm"}}
 }  # pylint: disable=line-too-long
 
-import json
-import socket
 from ansible.module_utils.basic import env_fallback
 
 try:
@@ -157,12 +155,9 @@ try:
 except ImportError:
     from ansible.module_utils.basic import AnsibleModule
 from ansible_collections.vmware.vmware_rest.plugins.module_utils.vmware_rest import (
-    build_full_device_list,
     exists,
     gen_args,
-    get_device_info,
     get_subdevice_type,
-    list_devices,
     open_session,
     prepare_payload,
     update_changed_flag,

--- a/plugins/modules/vcenter_vm_hardware_boot_device_info.py
+++ b/plugins/modules/vcenter_vm_hardware_boot_device_info.py
@@ -114,8 +114,6 @@ PAYLOAD_FORMAT = {
     "get": {"query": {}, "body": {}, "path": {"vm": "vm"}}
 }  # pylint: disable=line-too-long
 
-import json
-import socket
 from ansible.module_utils.basic import env_fallback
 
 try:
@@ -130,14 +128,8 @@ try:
 except ImportError:
     from ansible.module_utils.basic import AnsibleModule
 from ansible_collections.vmware.vmware_rest.plugins.module_utils.vmware_rest import (
-    build_full_device_list,
-    exists,
     gen_args,
-    get_device_info,
-    get_subdevice_type,
-    list_devices,
     open_session,
-    prepare_payload,
     update_changed_flag,
     session_timeout,
 )

--- a/plugins/modules/vcenter_vm_hardware_boot_info.py
+++ b/plugins/modules/vcenter_vm_hardware_boot_info.py
@@ -111,8 +111,6 @@ PAYLOAD_FORMAT = {
     "get": {"query": {}, "body": {}, "path": {"vm": "vm"}}
 }  # pylint: disable=line-too-long
 
-import json
-import socket
 from ansible.module_utils.basic import env_fallback
 
 try:
@@ -127,14 +125,8 @@ try:
 except ImportError:
     from ansible.module_utils.basic import AnsibleModule
 from ansible_collections.vmware.vmware_rest.plugins.module_utils.vmware_rest import (
-    build_full_device_list,
-    exists,
     gen_args,
-    get_device_info,
-    get_subdevice_type,
-    list_devices,
     open_session,
-    prepare_payload,
     update_changed_flag,
     session_timeout,
 )

--- a/plugins/modules/vcenter_vm_hardware_cdrom.py
+++ b/plugins/modules/vcenter_vm_hardware_cdrom.py
@@ -232,8 +232,6 @@ PAYLOAD_FORMAT = {
     "connect": {"query": {}, "body": {}, "path": {"cdrom": "cdrom", "vm": "vm"}},
 }  # pylint: disable=line-too-long
 
-import json
-import socket
 from ansible.module_utils.basic import env_fallback
 
 try:
@@ -248,12 +246,10 @@ try:
 except ImportError:
     from ansible.module_utils.basic import AnsibleModule
 from ansible_collections.vmware.vmware_rest.plugins.module_utils.vmware_rest import (
-    build_full_device_list,
     exists,
     gen_args,
     get_device_info,
     get_subdevice_type,
-    list_devices,
     open_session,
     prepare_payload,
     update_changed_flag,

--- a/plugins/modules/vcenter_vm_hardware_cdrom_info.py
+++ b/plugins/modules/vcenter_vm_hardware_cdrom_info.py
@@ -117,8 +117,6 @@ PAYLOAD_FORMAT = {
     "list": {"query": {}, "body": {}, "path": {"vm": "vm"}},
 }  # pylint: disable=line-too-long
 
-import json
-import socket
 from ansible.module_utils.basic import env_fallback
 
 try:
@@ -136,11 +134,7 @@ from ansible_collections.vmware.vmware_rest.plugins.module_utils.vmware_rest imp
     build_full_device_list,
     exists,
     gen_args,
-    get_device_info,
-    get_subdevice_type,
-    list_devices,
     open_session,
-    prepare_payload,
     update_changed_flag,
     session_timeout,
 )

--- a/plugins/modules/vcenter_vm_hardware_cpu.py
+++ b/plugins/modules/vcenter_vm_hardware_cpu.py
@@ -160,8 +160,6 @@ PAYLOAD_FORMAT = {
     }
 }  # pylint: disable=line-too-long
 
-import json
-import socket
 from ansible.module_utils.basic import env_fallback
 
 try:
@@ -176,12 +174,6 @@ try:
 except ImportError:
     from ansible.module_utils.basic import AnsibleModule
 from ansible_collections.vmware.vmware_rest.plugins.module_utils.vmware_rest import (
-    build_full_device_list,
-    exists,
-    gen_args,
-    get_device_info,
-    get_subdevice_type,
-    list_devices,
     open_session,
     prepare_payload,
     update_changed_flag,

--- a/plugins/modules/vcenter_vm_hardware_cpu_info.py
+++ b/plugins/modules/vcenter_vm_hardware_cpu_info.py
@@ -111,8 +111,6 @@ PAYLOAD_FORMAT = {
     "get": {"query": {}, "body": {}, "path": {"vm": "vm"}}
 }  # pylint: disable=line-too-long
 
-import json
-import socket
 from ansible.module_utils.basic import env_fallback
 
 try:
@@ -127,14 +125,8 @@ try:
 except ImportError:
     from ansible.module_utils.basic import AnsibleModule
 from ansible_collections.vmware.vmware_rest.plugins.module_utils.vmware_rest import (
-    build_full_device_list,
-    exists,
     gen_args,
-    get_device_info,
-    get_subdevice_type,
-    list_devices,
     open_session,
-    prepare_payload,
     update_changed_flag,
     session_timeout,
 )

--- a/plugins/modules/vcenter_vm_hardware_disk.py
+++ b/plugins/modules/vcenter_vm_hardware_disk.py
@@ -232,8 +232,6 @@ PAYLOAD_FORMAT = {
     },
 }  # pylint: disable=line-too-long
 
-import json
-import socket
 from ansible.module_utils.basic import env_fallback
 
 try:
@@ -248,12 +246,10 @@ try:
 except ImportError:
     from ansible.module_utils.basic import AnsibleModule
 from ansible_collections.vmware.vmware_rest.plugins.module_utils.vmware_rest import (
-    build_full_device_list,
     exists,
     gen_args,
     get_device_info,
     get_subdevice_type,
-    list_devices,
     open_session,
     prepare_payload,
     update_changed_flag,

--- a/plugins/modules/vcenter_vm_hardware_disk_info.py
+++ b/plugins/modules/vcenter_vm_hardware_disk_info.py
@@ -137,8 +137,6 @@ PAYLOAD_FORMAT = {
     "list": {"query": {}, "body": {}, "path": {"vm": "vm"}},
 }  # pylint: disable=line-too-long
 
-import json
-import socket
 from ansible.module_utils.basic import env_fallback
 
 try:
@@ -156,11 +154,7 @@ from ansible_collections.vmware.vmware_rest.plugins.module_utils.vmware_rest imp
     build_full_device_list,
     exists,
     gen_args,
-    get_device_info,
-    get_subdevice_type,
-    list_devices,
     open_session,
-    prepare_payload,
     update_changed_flag,
     session_timeout,
 )

--- a/plugins/modules/vcenter_vm_hardware_ethernet.py
+++ b/plugins/modules/vcenter_vm_hardware_ethernet.py
@@ -314,8 +314,6 @@ PAYLOAD_FORMAT = {
     "connect": {"query": {}, "body": {}, "path": {"nic": "nic", "vm": "vm"}},
 }  # pylint: disable=line-too-long
 
-import json
-import socket
 from ansible.module_utils.basic import env_fallback
 
 try:
@@ -330,12 +328,10 @@ try:
 except ImportError:
     from ansible.module_utils.basic import AnsibleModule
 from ansible_collections.vmware.vmware_rest.plugins.module_utils.vmware_rest import (
-    build_full_device_list,
     exists,
     gen_args,
     get_device_info,
     get_subdevice_type,
-    list_devices,
     open_session,
     prepare_payload,
     update_changed_flag,

--- a/plugins/modules/vcenter_vm_hardware_ethernet_info.py
+++ b/plugins/modules/vcenter_vm_hardware_ethernet_info.py
@@ -122,8 +122,6 @@ PAYLOAD_FORMAT = {
     "list": {"query": {}, "body": {}, "path": {"vm": "vm"}},
 }  # pylint: disable=line-too-long
 
-import json
-import socket
 from ansible.module_utils.basic import env_fallback
 
 try:
@@ -141,11 +139,7 @@ from ansible_collections.vmware.vmware_rest.plugins.module_utils.vmware_rest imp
     build_full_device_list,
     exists,
     gen_args,
-    get_device_info,
-    get_subdevice_type,
-    list_devices,
     open_session,
-    prepare_payload,
     update_changed_flag,
     session_timeout,
 )

--- a/plugins/modules/vcenter_vm_hardware_floppy.py
+++ b/plugins/modules/vcenter_vm_hardware_floppy.py
@@ -192,8 +192,6 @@ PAYLOAD_FORMAT = {
     "connect": {"query": {}, "body": {}, "path": {"floppy": "floppy", "vm": "vm"}},
 }  # pylint: disable=line-too-long
 
-import json
-import socket
 from ansible.module_utils.basic import env_fallback
 
 try:
@@ -208,12 +206,10 @@ try:
 except ImportError:
     from ansible.module_utils.basic import AnsibleModule
 from ansible_collections.vmware.vmware_rest.plugins.module_utils.vmware_rest import (
-    build_full_device_list,
     exists,
     gen_args,
     get_device_info,
     get_subdevice_type,
-    list_devices,
     open_session,
     prepare_payload,
     update_changed_flag,

--- a/plugins/modules/vcenter_vm_hardware_floppy_info.py
+++ b/plugins/modules/vcenter_vm_hardware_floppy_info.py
@@ -117,8 +117,6 @@ PAYLOAD_FORMAT = {
     "list": {"query": {}, "body": {}, "path": {"vm": "vm"}},
 }  # pylint: disable=line-too-long
 
-import json
-import socket
 from ansible.module_utils.basic import env_fallback
 
 try:
@@ -136,11 +134,7 @@ from ansible_collections.vmware.vmware_rest.plugins.module_utils.vmware_rest imp
     build_full_device_list,
     exists,
     gen_args,
-    get_device_info,
-    get_subdevice_type,
-    list_devices,
     open_session,
-    prepare_payload,
     update_changed_flag,
     session_timeout,
 )

--- a/plugins/modules/vcenter_vm_hardware_info.py
+++ b/plugins/modules/vcenter_vm_hardware_info.py
@@ -105,8 +105,6 @@ PAYLOAD_FORMAT = {
     "get": {"query": {}, "body": {}, "path": {"vm": "vm"}}
 }  # pylint: disable=line-too-long
 
-import json
-import socket
 from ansible.module_utils.basic import env_fallback
 
 try:
@@ -121,14 +119,8 @@ try:
 except ImportError:
     from ansible.module_utils.basic import AnsibleModule
 from ansible_collections.vmware.vmware_rest.plugins.module_utils.vmware_rest import (
-    build_full_device_list,
-    exists,
     gen_args,
-    get_device_info,
-    get_subdevice_type,
-    list_devices,
     open_session,
-    prepare_payload,
     update_changed_flag,
     session_timeout,
 )

--- a/plugins/modules/vcenter_vm_hardware_memory.py
+++ b/plugins/modules/vcenter_vm_hardware_memory.py
@@ -141,8 +141,6 @@ PAYLOAD_FORMAT = {
     }
 }  # pylint: disable=line-too-long
 
-import json
-import socket
 from ansible.module_utils.basic import env_fallback
 
 try:
@@ -157,12 +155,6 @@ try:
 except ImportError:
     from ansible.module_utils.basic import AnsibleModule
 from ansible_collections.vmware.vmware_rest.plugins.module_utils.vmware_rest import (
-    build_full_device_list,
-    exists,
-    gen_args,
-    get_device_info,
-    get_subdevice_type,
-    list_devices,
     open_session,
     prepare_payload,
     update_changed_flag,

--- a/plugins/modules/vcenter_vm_hardware_memory_info.py
+++ b/plugins/modules/vcenter_vm_hardware_memory_info.py
@@ -109,8 +109,6 @@ PAYLOAD_FORMAT = {
     "get": {"query": {}, "body": {}, "path": {"vm": "vm"}}
 }  # pylint: disable=line-too-long
 
-import json
-import socket
 from ansible.module_utils.basic import env_fallback
 
 try:
@@ -125,14 +123,8 @@ try:
 except ImportError:
     from ansible.module_utils.basic import AnsibleModule
 from ansible_collections.vmware.vmware_rest.plugins.module_utils.vmware_rest import (
-    build_full_device_list,
-    exists,
     gen_args,
-    get_device_info,
-    get_subdevice_type,
-    list_devices,
     open_session,
-    prepare_payload,
     update_changed_flag,
     session_timeout,
 )

--- a/plugins/modules/vcenter_vm_hardware_parallel.py
+++ b/plugins/modules/vcenter_vm_hardware_parallel.py
@@ -184,8 +184,6 @@ PAYLOAD_FORMAT = {
     "connect": {"query": {}, "body": {}, "path": {"port": "port", "vm": "vm"}},
 }  # pylint: disable=line-too-long
 
-import json
-import socket
 from ansible.module_utils.basic import env_fallback
 
 try:
@@ -200,12 +198,10 @@ try:
 except ImportError:
     from ansible.module_utils.basic import AnsibleModule
 from ansible_collections.vmware.vmware_rest.plugins.module_utils.vmware_rest import (
-    build_full_device_list,
     exists,
     gen_args,
     get_device_info,
     get_subdevice_type,
-    list_devices,
     open_session,
     prepare_payload,
     update_changed_flag,

--- a/plugins/modules/vcenter_vm_hardware_parallel_info.py
+++ b/plugins/modules/vcenter_vm_hardware_parallel_info.py
@@ -117,8 +117,6 @@ PAYLOAD_FORMAT = {
     "list": {"query": {}, "body": {}, "path": {"vm": "vm"}},
 }  # pylint: disable=line-too-long
 
-import json
-import socket
 from ansible.module_utils.basic import env_fallback
 
 try:
@@ -136,11 +134,7 @@ from ansible_collections.vmware.vmware_rest.plugins.module_utils.vmware_rest imp
     build_full_device_list,
     exists,
     gen_args,
-    get_device_info,
-    get_subdevice_type,
-    list_devices,
     open_session,
-    prepare_payload,
     update_changed_flag,
     session_timeout,
 )

--- a/plugins/modules/vcenter_vm_hardware_serial.py
+++ b/plugins/modules/vcenter_vm_hardware_serial.py
@@ -250,8 +250,6 @@ PAYLOAD_FORMAT = {
     "connect": {"query": {}, "body": {}, "path": {"port": "port", "vm": "vm"}},
 }  # pylint: disable=line-too-long
 
-import json
-import socket
 from ansible.module_utils.basic import env_fallback
 
 try:
@@ -266,12 +264,10 @@ try:
 except ImportError:
     from ansible.module_utils.basic import AnsibleModule
 from ansible_collections.vmware.vmware_rest.plugins.module_utils.vmware_rest import (
-    build_full_device_list,
     exists,
     gen_args,
     get_device_info,
     get_subdevice_type,
-    list_devices,
     open_session,
     prepare_payload,
     update_changed_flag,

--- a/plugins/modules/vcenter_vm_hardware_serial_info.py
+++ b/plugins/modules/vcenter_vm_hardware_serial_info.py
@@ -137,8 +137,6 @@ PAYLOAD_FORMAT = {
     "list": {"query": {}, "body": {}, "path": {"vm": "vm"}},
 }  # pylint: disable=line-too-long
 
-import json
-import socket
 from ansible.module_utils.basic import env_fallback
 
 try:
@@ -156,11 +154,7 @@ from ansible_collections.vmware.vmware_rest.plugins.module_utils.vmware_rest imp
     build_full_device_list,
     exists,
     gen_args,
-    get_device_info,
-    get_subdevice_type,
-    list_devices,
     open_session,
-    prepare_payload,
     update_changed_flag,
     session_timeout,
 )

--- a/plugins/modules/vcenter_vm_info.py
+++ b/plugins/modules/vcenter_vm_info.py
@@ -310,8 +310,6 @@ PAYLOAD_FORMAT = {
     },
 }  # pylint: disable=line-too-long
 
-import json
-import socket
 from ansible.module_utils.basic import env_fallback
 
 try:
@@ -329,11 +327,7 @@ from ansible_collections.vmware.vmware_rest.plugins.module_utils.vmware_rest imp
     build_full_device_list,
     exists,
     gen_args,
-    get_device_info,
-    get_subdevice_type,
-    list_devices,
     open_session,
-    prepare_payload,
     update_changed_flag,
     session_timeout,
 )

--- a/plugins/modules/vcenter_vm_libraryitem_info.py
+++ b/plugins/modules/vcenter_vm_libraryitem_info.py
@@ -109,8 +109,6 @@ PAYLOAD_FORMAT = {
     "get": {"query": {}, "body": {}, "path": {"vm": "vm"}}
 }  # pylint: disable=line-too-long
 
-import json
-import socket
 from ansible.module_utils.basic import env_fallback
 
 try:
@@ -125,14 +123,8 @@ try:
 except ImportError:
     from ansible.module_utils.basic import AnsibleModule
 from ansible_collections.vmware.vmware_rest.plugins.module_utils.vmware_rest import (
-    build_full_device_list,
-    exists,
     gen_args,
-    get_device_info,
-    get_subdevice_type,
-    list_devices,
     open_session,
-    prepare_payload,
     update_changed_flag,
     session_timeout,
 )

--- a/plugins/modules/vcenter_vm_power.py
+++ b/plugins/modules/vcenter_vm_power.py
@@ -238,8 +238,6 @@ PAYLOAD_FORMAT = {
     "start": {"query": {}, "body": {}, "path": {"vm": "vm"}},
 }  # pylint: disable=line-too-long
 
-import json
-import socket
 from ansible.module_utils.basic import env_fallback
 
 try:
@@ -254,12 +252,9 @@ try:
 except ImportError:
     from ansible.module_utils.basic import AnsibleModule
 from ansible_collections.vmware.vmware_rest.plugins.module_utils.vmware_rest import (
-    build_full_device_list,
     exists,
     gen_args,
-    get_device_info,
     get_subdevice_type,
-    list_devices,
     open_session,
     prepare_payload,
     update_changed_flag,

--- a/plugins/modules/vcenter_vm_power_info.py
+++ b/plugins/modules/vcenter_vm_power_info.py
@@ -108,8 +108,6 @@ PAYLOAD_FORMAT = {
     "get": {"query": {}, "body": {}, "path": {"vm": "vm"}}
 }  # pylint: disable=line-too-long
 
-import json
-import socket
 from ansible.module_utils.basic import env_fallback
 
 try:
@@ -124,14 +122,8 @@ try:
 except ImportError:
     from ansible.module_utils.basic import AnsibleModule
 from ansible_collections.vmware.vmware_rest.plugins.module_utils.vmware_rest import (
-    build_full_device_list,
-    exists,
     gen_args,
-    get_device_info,
-    get_subdevice_type,
-    list_devices,
     open_session,
-    prepare_payload,
     update_changed_flag,
     session_timeout,
 )

--- a/plugins/modules/vcenter_vm_storage_policy.py
+++ b/plugins/modules/vcenter_vm_storage_policy.py
@@ -152,8 +152,6 @@ PAYLOAD_FORMAT = {
     }
 }  # pylint: disable=line-too-long
 
-import json
-import socket
 from ansible.module_utils.basic import env_fallback
 
 try:
@@ -168,12 +166,6 @@ try:
 except ImportError:
     from ansible.module_utils.basic import AnsibleModule
 from ansible_collections.vmware.vmware_rest.plugins.module_utils.vmware_rest import (
-    build_full_device_list,
-    exists,
-    gen_args,
-    get_device_info,
-    get_subdevice_type,
-    list_devices,
     open_session,
     prepare_payload,
     update_changed_flag,

--- a/plugins/modules/vcenter_vm_storage_policy_compliance.py
+++ b/plugins/modules/vcenter_vm_storage_policy_compliance.py
@@ -111,8 +111,6 @@ PAYLOAD_FORMAT = {
     }
 }  # pylint: disable=line-too-long
 
-import json
-import socket
 from ansible.module_utils.basic import env_fallback
 
 try:
@@ -127,12 +125,9 @@ try:
 except ImportError:
     from ansible.module_utils.basic import AnsibleModule
 from ansible_collections.vmware.vmware_rest.plugins.module_utils.vmware_rest import (
-    build_full_device_list,
     exists,
     gen_args,
-    get_device_info,
     get_subdevice_type,
-    list_devices,
     open_session,
     prepare_payload,
     update_changed_flag,

--- a/plugins/modules/vcenter_vm_storage_policy_compliance_info.py
+++ b/plugins/modules/vcenter_vm_storage_policy_compliance_info.py
@@ -116,8 +116,6 @@ PAYLOAD_FORMAT = {
     "get": {"query": {}, "body": {}, "path": {"vm": "vm"}}
 }  # pylint: disable=line-too-long
 
-import json
-import socket
 from ansible.module_utils.basic import env_fallback
 
 try:
@@ -132,14 +130,8 @@ try:
 except ImportError:
     from ansible.module_utils.basic import AnsibleModule
 from ansible_collections.vmware.vmware_rest.plugins.module_utils.vmware_rest import (
-    build_full_device_list,
-    exists,
     gen_args,
-    get_device_info,
-    get_subdevice_type,
-    list_devices,
     open_session,
-    prepare_payload,
     update_changed_flag,
     session_timeout,
 )

--- a/plugins/modules/vcenter_vm_storage_policy_info.py
+++ b/plugins/modules/vcenter_vm_storage_policy_info.py
@@ -110,8 +110,6 @@ PAYLOAD_FORMAT = {
     "get": {"query": {}, "body": {}, "path": {"vm": "vm"}}
 }  # pylint: disable=line-too-long
 
-import json
-import socket
 from ansible.module_utils.basic import env_fallback
 
 try:
@@ -126,14 +124,8 @@ try:
 except ImportError:
     from ansible.module_utils.basic import AnsibleModule
 from ansible_collections.vmware.vmware_rest.plugins.module_utils.vmware_rest import (
-    build_full_device_list,
-    exists,
     gen_args,
-    get_device_info,
-    get_subdevice_type,
-    list_devices,
     open_session,
-    prepare_payload,
     update_changed_flag,
     session_timeout,
 )

--- a/plugins/modules/vcenter_vm_tools.py
+++ b/plugins/modules/vcenter_vm_tools.py
@@ -162,8 +162,6 @@ PAYLOAD_FORMAT = {
     },
 }  # pylint: disable=line-too-long
 
-import json
-import socket
 from ansible.module_utils.basic import env_fallback
 
 try:
@@ -178,12 +176,9 @@ try:
 except ImportError:
     from ansible.module_utils.basic import AnsibleModule
 from ansible_collections.vmware.vmware_rest.plugins.module_utils.vmware_rest import (
-    build_full_device_list,
     exists,
     gen_args,
-    get_device_info,
     get_subdevice_type,
-    list_devices,
     open_session,
     prepare_payload,
     update_changed_flag,

--- a/plugins/modules/vcenter_vm_tools_info.py
+++ b/plugins/modules/vcenter_vm_tools_info.py
@@ -173,8 +173,6 @@ PAYLOAD_FORMAT = {
     "get": {"query": {}, "body": {}, "path": {"vm": "vm"}}
 }  # pylint: disable=line-too-long
 
-import json
-import socket
 from ansible.module_utils.basic import env_fallback
 
 try:
@@ -189,14 +187,8 @@ try:
 except ImportError:
     from ansible.module_utils.basic import AnsibleModule
 from ansible_collections.vmware.vmware_rest.plugins.module_utils.vmware_rest import (
-    build_full_device_list,
-    exists,
     gen_args,
-    get_device_info,
-    get_subdevice_type,
-    list_devices,
     open_session,
-    prepare_payload,
     update_changed_flag,
     session_timeout,
 )

--- a/plugins/modules/vcenter_vm_tools_installer.py
+++ b/plugins/modules/vcenter_vm_tools_installer.py
@@ -146,8 +146,6 @@ PAYLOAD_FORMAT = {
     "connect": {"query": {}, "body": {}, "path": {"vm": "vm"}},
 }  # pylint: disable=line-too-long
 
-import json
-import socket
 from ansible.module_utils.basic import env_fallback
 
 try:
@@ -162,12 +160,9 @@ try:
 except ImportError:
     from ansible.module_utils.basic import AnsibleModule
 from ansible_collections.vmware.vmware_rest.plugins.module_utils.vmware_rest import (
-    build_full_device_list,
     exists,
     gen_args,
-    get_device_info,
     get_subdevice_type,
-    list_devices,
     open_session,
     prepare_payload,
     update_changed_flag,

--- a/plugins/modules/vcenter_vm_tools_installer_info.py
+++ b/plugins/modules/vcenter_vm_tools_installer_info.py
@@ -129,8 +129,6 @@ PAYLOAD_FORMAT = {
     "get": {"query": {}, "body": {}, "path": {"vm": "vm"}}
 }  # pylint: disable=line-too-long
 
-import json
-import socket
 from ansible.module_utils.basic import env_fallback
 
 try:
@@ -145,14 +143,8 @@ try:
 except ImportError:
     from ansible.module_utils.basic import AnsibleModule
 from ansible_collections.vmware.vmware_rest.plugins.module_utils.vmware_rest import (
-    build_full_device_list,
-    exists,
     gen_args,
-    get_device_info,
-    get_subdevice_type,
-    list_devices,
     open_session,
-    prepare_payload,
     update_changed_flag,
     session_timeout,
 )

--- a/plugins/modules/vcenter_vmtemplate_libraryitems.py
+++ b/plugins/modules/vcenter_vmtemplate_libraryitems.py
@@ -343,8 +343,6 @@ PAYLOAD_FORMAT = {
     },
 }  # pylint: disable=line-too-long
 
-import json
-import socket
 from ansible.module_utils.basic import env_fallback
 
 try:
@@ -359,12 +357,10 @@ try:
 except ImportError:
     from ansible.module_utils.basic import AnsibleModule
 from ansible_collections.vmware.vmware_rest.plugins.module_utils.vmware_rest import (
-    build_full_device_list,
     exists,
     gen_args,
     get_device_info,
     get_subdevice_type,
-    list_devices,
     open_session,
     prepare_payload,
     update_changed_flag,

--- a/plugins/modules/vcenter_vmtemplate_libraryitems_info.py
+++ b/plugins/modules/vcenter_vmtemplate_libraryitems_info.py
@@ -93,8 +93,6 @@ PAYLOAD_FORMAT = {
     }
 }  # pylint: disable=line-too-long
 
-import json
-import socket
 from ansible.module_utils.basic import env_fallback
 
 try:
@@ -109,14 +107,8 @@ try:
 except ImportError:
     from ansible.module_utils.basic import AnsibleModule
 from ansible_collections.vmware.vmware_rest.plugins.module_utils.vmware_rest import (
-    build_full_device_list,
-    exists,
     gen_args,
-    get_device_info,
-    get_subdevice_type,
-    list_devices,
     open_session,
-    prepare_payload,
     update_changed_flag,
     session_timeout,
 )

--- a/tests/sanity/ignore-2.16.txt
+++ b/tests/sanity/ignore-2.16.txt
@@ -1,0 +1,2 @@
+plugins/modules/vcenter_vm_guest_customization.py pep8!skip
+plugins/modules/appliance_infraprofile_configs.py pep8!skip


### PR DESCRIPTION
Fix GHA sanity tests.

Follow-up to #431

_edit_:

I know those files are generated and shouldn't be touched manually, but I'd like to see the CI succeeding. Most of the stuff were unused imports. In the long run, I think we need a fix for this: ansible-community/ansible.content_builder#67

However, there were also two issues that we should have a closer look at:

```
ERROR: Found 2 validate-modules issue(s) which need to be resolved:
ERROR: plugins/modules/vcenter_vm_hardware_adapter_sata.py:0:0: doc-default-does-not-match-spec: Argument 'bus' in argument_spec defines default as (0) but documentation defines default as (None)
ERROR: plugins/modules/vcenter_vm_hardware_adapter_scsi.py:0:0: doc-default-does-not-match-spec: Argument 'bus' in argument_spec defines default as (0) but documentation defines default as (None)
```

Might be a bug in the code generator.

_edit2_:

I'll remove the 2.16 sanity tests again because:

```
Running sanity test "import" on Python 3.12
Run command with data: importer.py
Run command with data: importer.py
ERROR: Found 132 import issue(s) on python 3.12 which need to be resolved:
ERROR: plugins/modules/appliance_access_consolecli.py:256:0: traceback: DeprecationWarning: There is no current event loop
.
.
.
```