### PR TITLE
Fix lookups return empty string when looking up resources inside folders

### DIFF
--- a/plugins/plugin_utils/lookup.py
+++ b/plugins/plugin_utils/lookup.py
@@ -134,6 +134,7 @@ def get_credentials(**options):
     ) or os.getenv("VMWARE_REST_LOG_FILE")
     return credentials
 
+
 class VcenterResource:
     def __init__(self, raw, api):
         self.raw = raw
@@ -142,11 +143,11 @@ class VcenterResource:
     @property
     def moid(self):
         return self.raw[self.object_type]
-#        return self.raw[self.get_type(self.raw)]
 
     @property
     def name(self):
         return self.raw["name"]
+
 
 class VcenterCluster(VcenterResource):
     object_type = "cluster"
@@ -178,7 +179,9 @@ class VcenterCluster(VcenterResource):
                 },
             )
         else:
-            child_resources = [i for i in self.child_resources if i != VcenterResourcePool]
+            child_resources = [
+                i for i in self.child_resources if i != VcenterResourcePool
+            ]
             for child_resource in child_resources:
                 child = await self._api.list_resource_one(
                     resource=child_resource,
@@ -192,6 +195,7 @@ class VcenterCluster(VcenterResource):
                     return child
 
                 return None
+
 
 class VcenterDatacenter(VcenterResource):
     object_type = "datacenter"
@@ -213,12 +217,14 @@ class VcenterDatacenter(VcenterResource):
             },
         )
 
+
 class VcenterDatastore(VcenterResource):
     object_type = "datastore"
     api_type = "datastore"
 
     async def get_child(self, resource, name):
         return None
+
 
 class VcenterFolder(VcenterResource):
     object_type = "folder"
@@ -279,6 +285,7 @@ class VcenterFolder(VcenterResource):
 
         return None
 
+
 class VcenterHost(VcenterResource):
     object_type = "host"
     api_type = "host"
@@ -323,12 +330,14 @@ class VcenterHost(VcenterResource):
 
         return result
 
+
 class VcenterNetwork(VcenterResource):
     object_type = "network"
     api_type = "network"
 
     async def get_child(self, resource, name):
         return None
+
 
 class VcenterResourcePool(VcenterResource):
     object_type = "resource_pool"
@@ -358,12 +367,14 @@ class VcenterResourcePool(VcenterResource):
 
             return None
 
+
 class VcenterVm(VcenterResource):
     object_type = "vm"
     api_type = "vm"
 
     async def get_child(self, resource, name):
         return None
+
 
 def get_vcenter_object_type(raw):
     for cls in VcenterResource.__subclasses__():
@@ -375,10 +386,12 @@ def get_vcenter_object_type(raw):
 
     return None
 
+
 def make_vcenter_resource(raw, api):
     object_type = get_vcenter_object_type(raw)
     resource = get_vcenter_resource(object_type)
     return resource(raw, api)
+
 
 def get_vcenter_resource(object_type):
     for cls in VcenterResource.__subclasses__():
@@ -387,6 +400,7 @@ def get_vcenter_resource(object_type):
 
     return None
 
+
 class VcenterApi:
     def __init__(self, hostname, session):
         self.hostname = hostname
@@ -394,15 +408,17 @@ class VcenterApi:
 
     def build_url(self, resource, params):
         try:
-            _in_query_parameters = INVENTORY[resource.object_type]["list"]["query"].keys()
+            _in_query_parameters = INVENTORY[resource.object_type]["list"][
+                "query"
+            ].keys()
         except KeyError:
             raise AnsibleLookupError(
                 "object_type must be one of [%s]." % ", ".join(list(INVENTORY.keys()))
             )
 
-        return (
-            f"https://{self.hostname}/api/vcenter/{resource.api_type}"
-        ) + gen_args(params, _in_query_parameters)
+        return (f"https://{self.hostname}/api/vcenter/{resource.api_type}") + gen_args(
+            params, _in_query_parameters
+        )
 
     async def fetch(self, url):
         async with self._session.get(url) as response:
@@ -426,6 +442,7 @@ class VcenterApi:
         if result:
             return result[0]
         return None
+
 
 class Lookup:
     def __init__(self, options, api):

--- a/plugins/plugin_utils/lookup.py
+++ b/plugins/plugin_utils/lookup.py
@@ -11,17 +11,15 @@ import asyncio
 import os
 import urllib
 
-from ansible.module_utils._text import to_native
 from ansible.errors import AnsibleLookupError
-
+from ansible.module_utils._text import to_native
 from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
     EmbeddedModuleFailure,
 )
 from ansible_collections.vmware.vmware_rest.plugins.module_utils.vmware_rest import (
-    open_session,
     gen_args,
+    open_session,
 )
-
 
 INVENTORY = {
     "resource_pool": {

--- a/plugins/plugin_utils/lookup.py
+++ b/plugins/plugin_utils/lookup.py
@@ -11,15 +11,17 @@ import asyncio
 import os
 import urllib
 
-from ansible.errors import AnsibleLookupError
 from ansible.module_utils._text import to_native
+from ansible.errors import AnsibleLookupError
+
 from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
     EmbeddedModuleFailure,
 )
 from ansible_collections.vmware.vmware_rest.plugins.module_utils.vmware_rest import (
-    gen_args,
     open_session,
+    gen_args,
 )
+
 
 INVENTORY = {
     "resource_pool": {
@@ -132,15 +134,306 @@ def get_credentials(**options):
     ) or os.getenv("VMWARE_REST_LOG_FILE")
     return credentials
 
+class VcenterResource:
+    def __init__(self, raw, api):
+        self.raw = raw
+        self._api = api
+
+    @property
+    def moid(self):
+        return self.raw[self.object_type]
+#        return self.raw[self.get_type(self.raw)]
+
+    @property
+    def name(self):
+        return self.raw["name"]
+
+class VcenterCluster(VcenterResource):
+    object_type = "cluster"
+    api_type = "cluster"
+
+    @property
+    def child_resources(self):
+        return [
+            VcenterHost,
+            VcenterResourcePool,
+        ]
+
+    async def get_child(self, resource, name):
+        if resource not in self.child_resources:
+            return None
+
+        if resource == VcenterResourcePool:
+            # We can't filter for resource_pools which are direct children of a cluster.
+            # Instead, fetch cluster directly which contains the root resource_pool.
+            # See: https://developer.vmware.com/apis/vsphere-automation/latest/vcenter/api/vcenter/cluster/cluster/get/
+            cluster = await self._api.get_resource(VcenterCluster, self.moid)
+            resource_pool_moid = cluster.raw["resource_pool"]
+
+            # Now we can fetch the resource_pool
+            return await self._api.list_resource_one(
+                resource=VcenterResourcePool,
+                filters={
+                    "resource_pools": resource_pool_moid,
+                },
+            )
+        else:
+            child_resources = [i for i in self.child_resources if i != VcenterResourcePool]
+            for child_resource in child_resources:
+                child = await self._api.list_resource_one(
+                    resource=child_resource,
+                    filters={
+                        "clusters": self.moid,
+                        "names": name,
+                    },
+                )
+
+                if child:
+                    return child
+
+                return None
+
+class VcenterDatacenter(VcenterResource):
+    object_type = "datacenter"
+    api_type = "datacenter"
+
+    async def get_child(self, resource, name):
+        # We can't filter for folders which are direct children of a datacenter.
+        # Instead, fetch datacenter directly which contains the root folder moids for each object_type.
+        # See: https://developer.vmware.com/apis/vsphere-automation/latest/vcenter/api/vcenter/datacenter/datacenter/get/
+        datacenter = await self._api.get_resource(VcenterDatacenter, self.moid)
+        key = f"{name}_folder"
+        folder_moid = datacenter.raw[key]
+
+        # Now we can fetch the folder
+        return await self._api.list_resource_one(
+            resource=VcenterFolder,
+            filters={
+                "folders": folder_moid,
+            },
+        )
+
+class VcenterDatastore(VcenterResource):
+    object_type = "datastore"
+    api_type = "datastore"
+
+    async def get_child(self, resource, name):
+        return None
+
+class VcenterFolder(VcenterResource):
+    object_type = "folder"
+    api_type = "folder"
+
+    @property
+    def folder_type(self):
+        return self.raw["type"]
+
+    @property
+    def child_resources(self):
+        lookup = {
+            "DATACENTER": [
+                VcenterFolder,
+                VcenterDatacenter,
+            ],
+            "DATASTORE": [
+                VcenterFolder,
+                VcenterDatastore,
+            ],
+            "HOST": [
+                VcenterFolder,
+                VcenterHost,
+                VcenterCluster,
+            ],
+            "NETWORK": [
+                VcenterFolder,
+                VcenterNetwork,
+            ],
+            "VIRTUAL_MACHINE": [
+                VcenterFolder,
+                VcenterVm,
+            ],
+        }
+
+        return lookup[self.folder_type]
+
+    async def get_child(self, resource, name):
+        # We don't check if the requested resource is a valid child_resource, because all possible children implement this behaviour.
+        # Checking here would make the code more complex than it needs to be. Of course, we sacrifice performance for simplicity here.
+
+        for child_resource in self.child_resources:
+            if child_resource == VcenterFolder:
+                filters = {
+                    "parent_folders": self.moid,
+                    "names": name,
+                }
+            else:
+                filters = {
+                    "folders": self.moid,
+                    "names": name,
+                }
+
+            child = await self._api.list_resource_one(child_resource, filters)
+
+            if child:
+                return child
+
+        return None
+
+class VcenterHost(VcenterResource):
+    object_type = "host"
+    api_type = "host"
+
+    @property
+    def child_resources(self):
+        return [
+            VcenterResourcePool,
+        ]
+
+    async def get_child(self, resource, name):
+        if resource not in self.child_resources:
+            return None
+
+        # Unlike in clusters, there is no way to get the root resource_pool of a host.
+        # So we fetch all resource_pools on this host.
+        potential_roots = await self._api.list_resource(
+            resource=VcenterResourcePool,
+            filters={
+                "hosts": self.moid,
+            },
+        )
+
+        result = potential_roots.copy()
+        for root in potential_roots:
+            children = await self._api.list_resource(
+                resource=VcenterResourcePool,
+                filters={
+                    "hosts": self.moid,
+                    "parent_resource_pools": root.moid,
+                },
+            )
+            moids = [i.moid for i in children]
+            # We identify our root by deleting all resource_pools which appear as a child of another resource_pool.
+            # Our root will be the last one left because it is no child of another resource_pool.
+            result = [i for i in result if i.moid not in moids]
+
+        result = result[0]
+
+        if result.name != name:
+            return None
+
+        return result
+
+class VcenterNetwork(VcenterResource):
+    object_type = "network"
+    api_type = "network"
+
+    async def get_child(self, resource, name):
+        return None
+
+class VcenterResourcePool(VcenterResource):
+    object_type = "resource_pool"
+    api_type = "resource-pool"
+
+    @property
+    def child_resources(self):
+        return [
+            VcenterResourcePool,
+        ]
+
+    async def get_child(self, resource, name):
+        if resource not in self.child_resources:
+            return None
+
+        for child_resource in self.child_resources:
+            child = await self._api.list_resource_one(
+                resource=child_resource,
+                filters={
+                    "parent_resource_pools": self.moid,
+                    "names": name,
+                },
+            )
+
+            if child:
+                return child
+
+            return None
+
+class VcenterVm(VcenterResource):
+    object_type = "vm"
+    api_type = "vm"
+
+    async def get_child(self, resource, name):
+        return None
+
+def get_vcenter_object_type(raw):
+    for cls in VcenterResource.__subclasses__():
+        if cls.object_type in raw:
+            return cls.object_type
+
+    if "vm_folder" in raw:
+        return VcenterDatacenter.object_type
+
+    return None
+
+def make_vcenter_resource(raw, api):
+    object_type = get_vcenter_object_type(raw)
+    resource = get_vcenter_resource(object_type)
+    return resource(raw, api)
+
+def get_vcenter_resource(object_type):
+    for cls in VcenterResource.__subclasses__():
+        if cls.object_type == object_type:
+            return cls
+
+    return None
+
+class VcenterApi:
+    def __init__(self, hostname, session):
+        self.hostname = hostname
+        self._session = session
+
+    def build_url(self, resource, params):
+        try:
+            _in_query_parameters = INVENTORY[resource.object_type]["list"]["query"].keys()
+        except KeyError:
+            raise AnsibleLookupError(
+                "object_type must be one of [%s]." % ", ".join(list(INVENTORY.keys()))
+            )
+
+        return (
+            f"https://{self.hostname}/api/vcenter/{resource.api_type}"
+        ) + gen_args(params, _in_query_parameters)
+
+    async def fetch(self, url):
+        async with self._session.get(url) as response:
+            result = await response.json()
+            return result
+
+    async def get_resource(self, resource, moid):
+        url = f"https://{self.hostname}/api/vcenter/{resource.api_type}/{moid}"
+        result = await self.fetch(url)
+        if result:
+            return make_vcenter_resource(result, self)
+        return None
+
+    async def list_resource(self, resource, filters):
+        url = self.build_url(resource, filters)
+        result = await self.fetch(url)
+        return [make_vcenter_resource(i, self) for i in result]
+
+    async def list_resource_one(self, resource, filters):
+        result = await self.list_resource(resource, filters)
+        if result:
+            return result[0]
+        return None
 
 class Lookup:
-    def __init__(self, options):
+    def __init__(self, options, api):
         self._options = options
+        self._api = api
 
     @classmethod
     async def entry_point(cls, terms, options):
-        session = None
-
         if not options.get("vcenter_hostname"):
             raise AnsibleLookupError("vcenter_hostname cannot be empty")
         if not options.get("vcenter_username"):
@@ -161,8 +454,8 @@ class Lookup:
                 f'Unable to connect to vCenter or ESXi API at {options.get("vcenter_hostname")}: {to_native(e)}'
             )
 
-        lookup = cls(options)
-        lookup._options["session"] = session
+        api = VcenterApi(options.get("vcenter_hostname"), session)
+        lookup = cls(options, api)
 
         if not terms:
             raise AnsibleLookupError("No object has been specified.")
@@ -171,434 +464,38 @@ class Lookup:
 
         return await task
 
-    async def fetch(self, url):
-        async with self._options["session"].get(url) as response:
-            result = await response.json()
-            return result
-
-    def build_url(self, object_type, params):
-        try:
-            _in_query_parameters = INVENTORY[object_type]["list"]["query"].keys()
-            if object_type == "resource_pool":
-                object_type = object_type.replace("_", "-")
-        except KeyError:
-            raise AnsibleLookupError(
-                "object_type must be one of [%s]." % ", ".join(list(INVENTORY.keys()))
-            )
-
-        return (
-            f"https://{self._options['vcenter_hostname']}/api/vcenter/{object_type}"
-        ) + gen_args(params, _in_query_parameters)
-
-    async def _helper_fetch(self, object_type, filters):
-        _url = self.build_url(object_type, filters)
-        return await self.fetch(_url)
-
-    @staticmethod
-    def ensure_result(result, object_type, object_name=None):
-        object_name_decoded = None
-
-        if object_name:
-            object_name_decoded = urllib.parse.unquote(object_name)
-
-        if (
-            not result
-            or object_name_decoded
-            and object_name_decoded not in result[0].values()
-        ):
-            return ""
-
-        def _filter_result(result):
-            return [obj for obj in result if "%2f" not in obj["name"]]
-
-        result = _filter_result(result)
-        if result and len(result) > 1:
-            raise AnsibleLookupError(
-                "More than one object available: [%s]."
-                % ", ".join(
-                    list(f"{item['name']} => {item[object_type]}" for item in result)
-                )
-            )
-        try:
-            object_moid = result[0][object_type]
-        except (TypeError, KeyError, IndexError) as e:
-            raise AnsibleLookupError(to_native(e))
-        return object_moid
-
-    def _init_filter(self):
-        filters = {}
-        filters["datacenters"] = self._options["dc_moid"]
-        return filters
-
-    async def _get_datacenter_moid(self, path):
-        filters = {}
-        dc_name = ""
-        dc_moid = ""
-        _result = ""
-        folder_moid = ""
-        _path = path
-
-        # Retrieve folders MoID if any
-        folder_moid, _path = await self._get_folder_moid(path, filters)
-
-        if _path:
-            dc_name = _path[0]
-
-        filters["names"] = dc_name
-        filters["folders"] = folder_moid
-        _result = await self._helper_fetch("datacenter", filters)
-        dc_moid = self.ensure_result(_result, "datacenter", dc_name)
-
-        return dc_moid, _path
-
-    async def _fetch_result(self, object_path, object_type, filters):
-        _result = ""
-        obj_moid = ""
-        visited = []
-        _object_path_list = list(object_path)
-
-        _result = await self.recursive_folder_or_rp_moid_search(
-            object_path, object_type, filters
-        )
-        if _result:
-            if object_path:
-                for obj in _result:
-                    if _object_path_list:
-                        if obj["name"] == _object_path_list[0]:
-                            del _object_path_list[0]
-                        else:
-                            visited.append(obj)
-                if not visited:
-                    obj_moid = [_result[-1]]
-            else:
-                obj_moid = _result
-        return obj_moid, _object_path_list
-
-    async def _get_folder_moid(self, object_path, filters):
-        object_name = ""
-        result = ""
-        _result = ""
-        _object_path = []
-
-        if object_path:
-            _result, _object_path = await self._fetch_result(
-                object_path, "folder", filters
-            )
-            result = self.ensure_result(_result, "folder")
-
-        if _result and self._options["object_type"] == "folder":
-            if isinstance(_result, list) and _object_path:
-                obj_path_set = set(_object_path)
-                path_set = set([elem["name"] for elem in _result])
-                if path_set - obj_path_set and self._options["_terms"][-1] != "/":
-                    return "", _object_path
-
-            if self._options["_terms"][-1] != "/":
-                object_name = object_path[-1]
-
-            result = self.ensure_result([_result[-1]], "folder", object_name)
-
-        if (
-            self._options["_terms"][-1] == "/"
-            and self._options["object_type"] == "folder"
-        ):
-            result = await self.look_inside(result, filters)
-
-        return result, _object_path
-
-    async def _get_host_moid(self, object_path, filters):
-        host_moid = ""
-        result = ""
-        _object_path = []
-
-        # Host might be inside a cluster
-        if self._options["object_type"] in ("host", "vm", "network", "datastore"):
-            filters["names"] = object_path[0]
-            cluster_moid, _object_path = await self._get_cluster_moid(
-                object_path, filters
-            )
-            if not cluster_moid:
-                return "", object_path[1:]
-
-            filters = self._init_filter()
-            filters["clusters"] = cluster_moid
-            if _object_path:
-                filters["names"] = _object_path[0]
-            else:
-                filters["names"] = ""
-
-        result = await self._helper_fetch("host", filters)
-        host_moid = self.ensure_result(result, "host", filters["names"])
-
-        return host_moid, _object_path[1:]
-
-    async def _helper_get_resource_pool_moid(self, object_path, filters):
-        result = ""
-        rp_moid = ""
-        _object_path = []
-
-        # Resource pool might be inside a cluster
-        filters["names"] = object_path[0]
-        cluster_moid, _object_path = await self._get_cluster_moid(object_path, filters)
-        if not cluster_moid:
-            return "", _object_path
-
-        filters = self._init_filter()
-        filters["clusters"] = cluster_moid
-
-        if _object_path:
-            result, _object_path = await self._fetch_result(
-                _object_path, "resource_pool", filters
-            )
-            rp_moid = self.ensure_result(result, "resource_pool")
-
-        if not result and _object_path:
-            filters = self._init_filter()
-            filters["names"] = _object_path[0]
-            filters["clusters"] = cluster_moid
-            # Resource pool might be inside a host
-            host_moid, _object_path = await self._get_host_moid(_object_path, filters)
-            if not host_moid:
-                return "", _object_path
-
-            filters["hosts"] = host_moid
-            if _object_path:
-                filters["names"] = _object_path[0]
-                result, _object_path = await self._fetch_result(
-                    _object_path, "resource_pool", filters
-                )
-
-        if result and self._options["object_type"] == "resource_pool":
-            if isinstance(result, list) and _object_path:
-                obj_path_set = set(_object_path)
-                path_set = set([elem["name"] for elem in result])
-                if path_set - obj_path_set and self._options["_terms"][-1] != "/":
-                    return "", _object_path
-
-        if (
-            self._options["_terms"][-1] == "/"
-            and self._options["object_type"] == "resource_pool"
-        ):
-            result = await self.look_inside(rp_moid, filters)
-            return result, _object_path
-
-        result = self.ensure_result(result, "resource_pool")
-
-        return result, _object_path
-
-    async def look_inside(self, pre_object, filters):
-        result = ""
-        _result = ""
-        filters["names"] = ""
-        object_type = self._options["object_type"]
-
-        if pre_object:
-            if (object_type == "resource_pool" and "resgroup" in pre_object) or (
-                object_type == "folder" and "group" in pre_object
-            ):
-                parent_key = f"parent_{object_type}s"
-                filters[parent_key] = pre_object
-
-        object_key = f"{object_type}s"
-        filters[object_key] = ""
-        _result = await self._helper_fetch(object_type, filters)
-        result = self.ensure_result(_result, object_type)
-
-        return result
-
-    async def _get_subset_moid(self, object_path, filters):
-        object_name = ""
-        result = ""
-        _result = ""
-        _object_path = []
-
-        if not object_path:
-            if self._options["_terms"][-1] != "/":
-                return "", object_path
-        else:
-            if self._options["_terms"][-1] != "/":
-                object_name = object_path[-1]
-
-        filters["names"] = object_name
-        _result = await self._helper_fetch(self._options["object_type"], filters)
-        result = self.ensure_result(_result, self._options["object_type"])
-        if not result:
-            filters["names"] = ""
-
-            if self._options["object_type"] == "vm":
-                # VM might be in a resource pool
-                result, _object_path = await self._helper_get_resource_pool_moid(
-                    object_path, filters
-                )
-                if result:
-                    return result
-
-            # Object might be inside a host
-            host_moid, _object_path = await self._get_host_moid(object_path, filters)
-            if not host_moid:
-                return ""
-
-            filters["hosts"] = host_moid
-            filters["folders"] = ""
-            filters["names"] = object_name
-            _result = await self._helper_fetch(self._options["object_type"], filters)
-            result = self.ensure_result(_result, self._options["object_type"])
-
-        return result
-
-    async def _get_cluster_moid(self, object_path, filters):
-        cluster_moid = ""
-        result = await self._helper_fetch("cluster", filters)
-        cluster_moid = self.ensure_result(result, "cluster", filters["names"])
-
-        return cluster_moid, object_path[1:]
-
-    async def get_all_objects_path_moid(self, object_path, object_type, filters):
-        # GET MoID of all the objects specified in the path
-        filters["names"] = list(set(object_path))
-
-        if self._options["object_type"] == "vm":
-            filters["type"] = "VIRTUAL_MACHINE"
-        elif self._options["object_type"] not in ("resource_pool", "cluster", "folder"):
-            filters["type"] = self._options[
-                "object_type"
-            ].upper()  # HOST, DATASTORE, DATACENTER, NETWORK
-
-        return await self._helper_fetch(object_type, filters)
-
-    async def recursive_folder_or_rp_moid_search(
+    async def moid(
         self,
         object_path,
-        object_type,
-        filters,
-        parent_object=None,
-        objects_moid=None,
-        result=None,
     ):
-        if result is None:
-            # GET MoID of all the objects specified in the path
-            result = []
-            objects_moid = await self.get_all_objects_path_moid(
-                object_path, object_type, filters
-            )
-            if not objects_moid:
-                return ""
-            elif len(objects_moid) == 1:
-                return objects_moid
-
-            return await self.recursive_folder_or_rp_moid_search(
-                object_path,
-                object_type,
-                filters,
-                objects_moid=objects_moid,
-                result=result,
-            )
-        parent_key = f"parent_{object_type}s"
-        filters[parent_key] = ""
-
-        if objects_moid and object_path and objects_moid[0]["name"] == object_path[0]:
-            # There exists a folder MoID with this name
-            filters["names"] = object_path[0]
-
-            if parent_object is not None:
-                filters[parent_key] = parent_object
-                tasks = [
-                    asyncio.ensure_future(self._helper_fetch(object_type, filters))
-                    for parent_object_info in objects_moid
-                    if parent_object_info["name"] == object_path[0]
-                ]
-                _result = [await i for i in tasks]
-                [
-                    result.append(elem[0])
-                    for elem in _result
-                    if elem
-                    if _result and elem[0] not in result
-                ]
-            else:
-                _result = await self._helper_fetch(object_type, filters)
-                if not _result:
-                    return ""
-                [result.append(elem) for elem in _result if elem not in result]
-                # Update parent_object
-                parent_object = result[0][object_type]
-                return await self.recursive_folder_or_rp_moid_search(
-                    object_path[1:],
-                    object_type,
-                    filters,
-                    parent_object,
-                    objects_moid[1:],
-                    result,
-                )
-        if not object_path or (objects_moid and len(objects_moid) == 0):
-            # Return result and what left in the path
-            if not result:
-                result = objects_moid
-            return result
-
-        if result:
-            # Update parent_object
-            parent_object = result[-1][object_type]
-        return await self.recursive_folder_or_rp_moid_search(
-            object_path[1:],
-            object_type,
-            filters,
-            parent_object,
-            objects_moid[1:],
-            result,
-        )
-
-    async def moid(self, object_path):
-        folder_moid = ""
-        result = ""
-        filters = {}
-        _path = []
-
         if not object_path:
             return ""
 
-        # Split object_path for transversal
+        # Split object_path for traversal
         self._options["_terms"] = object_path
-        object_type = self._options["object_type"]
-        path = tuple(filter(None, object_path.split("/")))
+        object_path = tuple(filter(None, object_path.split("/")))
+        resource = get_vcenter_resource(self._options["object_type"])
 
-        # Retrieve datacenter MoID
-        dc_moid, _path = await self._get_datacenter_moid(path)
-        if object_type == "datacenter" or not dc_moid:
-            return dc_moid
-        self._options["dc_moid"] = dc_moid
-        filters["datacenters"] = self._options["dc_moid"]
+        # We start our search with the root folder in vCenter
+        obj = make_vcenter_resource(
+            raw={
+                "folder": "group-d1",
+                "type": "DATACENTER",
+            },
+            api=self._api,
+        )
 
-        if _path:
-            _path = _path[1:]
+        while True:
+            name = object_path[0]
+            obj = await obj.get_child(resource, name)
 
-        # Retrieve folders MoID
-        folder_moid, _path = await self._get_folder_moid(_path, filters)
-        if object_type == "folder" or not folder_moid:
-            return folder_moid
-        filters["folders"] = folder_moid
+            if not obj:
+                return ""
 
-        if object_type == "cluster":
-            if object_path[-1] != "/":
-                # Save object name
-                filters["names"] = _path[-1]
-            else:
-                filters["names"] = ""
-            result, _obj_path = await self._get_cluster_moid(_path, filters)
+            if len(object_path) == 1:
+                if resource.object_type == obj.object_type:
+                    return obj.moid
+                else:
+                    return ""
 
-        if object_type in ("datastore", "network"):
-            filters = self._init_filter()
-            filters["folders"] = folder_moid
-            result = await self._get_subset_moid(_path, filters)
-
-        if object_type == "resource_pool":
-            result, _obj_path = await self._helper_get_resource_pool_moid(
-                _path, filters
-            )
-
-        if object_type == "vm":
-            result = await self._get_subset_moid(_path, filters)
-
-        if object_type == "host":
-            result, _obj_path = await self._get_host_moid(_path, filters)
-
-        return result
+            object_path = object_path[1:]


### PR DESCRIPTION
##### SUMMARY
When lookups search for resources inside folders, they return an empty string even if the resource is available in this path. For example, a vm_moid lookup with the term `/mydc/vm/myfolder1/myvm2` returns an empty string while a lookup for `/mydc/vm/myvm1` returns the expected moid.

One could've fixed this issue with no major overhaul of the file. But by looking at the code, I expect that more issues would arise such as finding the wrong folder if multiple folders have the same name, e. g. `/mydc/vm/myfolder1/foo` and `/mydc/vm/myfolder2/foo`.

So I rewrote large parts of the file to strictly follow the path top-down. On some occasions the lookups now make multiple requests against the api to ensure we find the correct resource (e. g. finding the root resource pool on a standalone host). This will certainly decrease performance at the expense of correct results.

Also I think the code is no easier to read and reason about as there is no complex recursive function anymore.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
cluster_moid 
datacenter_moid 
datastore_moid 
folder_moid 
host_moid 
network_moid 
resource_pool_moid 
vm_moid 

##### ADDITIONAL INFORMATION
I used an ansible playbook to reproduce the issue. Please note that parts of this playbook (path, moid) must be adjusted to the environment in which the tests are executed. The credentials were set via environment variables.

```yaml
- name: Test
  hosts: localhost
  gather_facts: false
  tasks:
    - name: Test
      ansible.builtin.debug:
        msg: "{{ lookup('vmware.vmware_rest.' + item['type'] + '_moid', item['path']) == item['moid'] }}"
      loop:
        - type: datacenter
          path: /mydc
          moid: datacenter-xxxxxx
        - type: network
          path: /mydc/network/mynet1
          moid: network-xxxxxx
        - type: datastore
          path: /mydc/datastore/myds1
          moid: datastore-xxxxxx
        - type: folder
          path: /mydc/vm
          moid: group-xxxxxx
        - type: folder
          path: /mydc/vm/myfolder1
          moid: group-xxxxxx
        - type: vm
          path: /mydc/vm/myvm1
          moid: vm-xxxxxx
        - type: vm
          path: /mydc/vm/myfolder1/myvm2
          moid: vm-xxxxxx
        - type: cluster
          path: /mydc/host/mycluster1
          moid: domain-xxxxxx
        - type: host
          path: /mydc/host/mycluster1/myhost1
          moid: host-xxxxxx
        - type: resource_pool
          path: /mydc/host/myhost1/Resources
          moid: resgroup-xxxxxx
        - type: resource_pool
          path: /mydc/host/myhost1/Resources/myrp1
          moid: resgroup-xxxxxx
```

The output before the changes was:

```
ok: [localhost] => (item={'type': 'datacenter', 'path': '/mydc', 'moid': 'datacenter-xxxxxx'}) => {
    "msg": true
}
ok: [localhost] => (item={'type': 'network', 'path': '/mydc/network/mynet1', 'moid': 'network-xxxxxx'}) => {
    "msg": true
}
ok: [localhost] => (item={'type': 'datastore', 'path': '/mydc/datastore/myds1', 'moid': 'datastore-xxxxxx'}) => {
    "msg": true
}
ok: [localhost] => (item={'type': 'folder', 'path': '/mydc/vm', 'moid': 'group-xxxxxx'}) => {
    "msg": true
}
ok: [localhost] => (item={'type': 'folder', 'path': '/mydc/vm/myfolder1', 'moid': 'group-xxxxxx'}) => {
    "msg": false
}
ok: [localhost] => (item={'type': 'vm', 'path': '/mydc/vm/myvm1', 'moid': 'vm-xxxxxx'}) => {
    "msg": true
}
ok: [localhost] => (item={'type': 'vm', 'path': '/mydc/vm/myfolder1/myvm2', 'moid': 'vm-xxxxxx'}) => {
    "msg": false
}
ok: [localhost] => (item={'type': 'cluster', 'path': '/mydc/host/mycluster1', 'moid': 'domain-xxxxxx'}) => {
    "msg": true
}
ok: [localhost] => (item={'type': 'host', 'path': '/mydc/host/mycluster1/myhost1', 'moid': 'host-xxxxxx'}) => {
    "msg": true
}
ok: [localhost] => (item={'type': 'resource_pool', 'path': '/mydc/host/myhost1/Resources', 'moid': 'resgroup-xxxxxx'}) => {
    "msg": false
}
ok: [localhost] => (item={'type': 'resource_pool', 'path': '/mydc/host/myhost1/Resources/myrp1', 'moid': 'resgroup-xxxxxx'}) => {
    "msg": false
}
```

The output after the changes was:

```
ok: [localhost] => (item={'type': 'datacenter', 'path': '/mydc', 'moid': 'datacenter-xxxxxx'}) => {
    "msg": true
}
ok: [localhost] => (item={'type': 'network', 'path': '/mydc/network/mynet1', 'moid': 'network-xxxxxx'}) => {
    "msg": true
}
ok: [localhost] => (item={'type': 'datastore', 'path': '/mydc/datastore/myds1', 'moid': 'datastore-xxxxxx'}) => {
    "msg": true
}
ok: [localhost] => (item={'type': 'folder', 'path': '/mydc/vm', 'moid': 'group-xxxxxx'}) => {
    "msg": true
}
ok: [localhost] => (item={'type': 'folder', 'path': '/mydc/vm/myfolder1', 'moid': 'group-xxxxxx'}) => {
    "msg": true
}
ok: [localhost] => (item={'type': 'vm', 'path': '/mydc/vm/myvm1', 'moid': 'vm-xxxxxx'}) => {
    "msg": true
}
ok: [localhost] => (item={'type': 'vm', 'path': '/mydc/vm/myfolder1/myvm2', 'moid': 'vm-xxxxxx'}) => {
    "msg": true
}
ok: [localhost] => (item={'type': 'cluster', 'path': '/mydc/host/mycluster1', 'moid': 'domain-xxxxxx'}) => {
    "msg": true
}
ok: [localhost] => (item={'type': 'host', 'path': '/mydc/host/mycluster1/myhost1', 'moid': 'host-xxxxxx'}) => {
    "msg": true
}
ok: [localhost] => (item={'type': 'resource_pool', 'path': '/mydc/host/myhost1/Resources', 'moid': 'resgroup-xxxxxx'}) => {
    "msg": true
}
ok: [localhost] => (item={'type': 'resource_pool', 'path': '/mydc/host/myhost1/Resources/myrp1', 'moid': 'resgroup-xxxxxx'}) => {
    "msg": true
}
```