### PR TITLE
Remove version 3.0.0 from galaxy.yml

### DIFF
--- a/changelogs/fragments/remove_3.0.0_from_galaxy.yml
+++ b/changelogs/fragments/remove_3.0.0_from_galaxy.yml
@@ -1,0 +1,3 @@
+---
+trivial:
+  - Remove version 3.0.0 from galaxy.yml

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -2,7 +2,7 @@
 namespace: vmware
 name: vmware_rest
 readme: README.md
-version: 3.0.0
+version: null
 authors:
   - Ansible (https://github.com/ansible)
 description: VMware collection for Ansible


### PR DESCRIPTION
I don't know how you feel about this, but I like to remove the version from `galaxy.yml` once the release has been tagged and done.

What I mean is: If there are any changes and people install directly from the repo, they will _not_ install 3.0.0 but something different.

