### PR TITLE
Fix options parsing to use vcenter_validate_certs false value

### DIFF
--- a/changelogs/fragments/20240105-bugfix-lookup-options-parsing.yml
+++ b/changelogs/fragments/20240105-bugfix-lookup-options-parsing.yml
@@ -1,0 +1,4 @@
+---
+bugfixes:
+  - lookup plugins - Refactor to use native options configuration via doc_fragment, which ensures that vcenter_validate_certs=false is honored
+    (https://github.com/ansible-collections/vmware.vmware_rest/issues/425).

--- a/plugins/doc_fragments/moid.py
+++ b/plugins/doc_fragments/moid.py
@@ -12,42 +12,43 @@ class ModuleDocFragment(object):
     options:
         _terms:
             description: Path to query.
-            required: true
+            required: True
+            type: string
         vcenter_hostname:
             description:
                 - The hostname or IP address of the vSphere vCenter.
-                - If the value is not specified in the task, the value of environment variable
-                  C(VMWARE_HOST) will be used instead.
-            required: true
-            type: str
+            env:
+                - name: VMWARE_HOST
+            required: True
+            type: string
         vcenter_password:
             description:
                 - The vSphere vCenter password.
-                - If the value is not specified in the task, the value of environment variable
-                  C(VMWARE_PASSWORD) will be used instead.
-            required: true
-            type: str
+            env:
+                - name: VMWARE_PASSWORD
+            required: True
+            type: string
         vcenter_rest_log_file:
             description:
                 - You can use this optional parameter to set the location of a log file.
-                - This file will be used to record the HTTP REST interaction.
-                - The file will be stored on the host that run the module.
-                - If the value is not specified in the task, the value of environment variable
-                  C(VMWARE_REST_LOG_FILE) will be used instead.
-            type: str
+                - This file will be used to record the HTTP REST interactions.
+                - The file will be stored on the host that runs the module.
+            env:
+                - name: VMWARE_REST_LOG_FILE
+            type: string
         vcenter_username:
             description:
                 - The vSphere vCenter username.
-                - If the value is not specified in the task, the value of environment variable
-                  C(VMWARE_USER) will be used instead.
-            required: true
-            type: str
+            env:
+                - name: VMWARE_USER
+            required: True
+            type: string
         vcenter_validate_certs:
-            default: true
             description:
-                - Allows connection when SSL certificates are not valid. Set to C(false) when
+                - Allows connection when SSL certificates are not valid. Set to V(false) when
                   certificates are not trusted.
-                - If the value is not specified in the task, the value of environment variable
-                  C(VMWARE_VALIDATE_CERTS) will be used instead.
-            type: bool
+            default: true
+            env:
+                - name: VMWARE_VALIDATE_CERTS
+            type: boolean
 """

--- a/plugins/lookup/cluster_moid.py
+++ b/plugins/lookup/cluster_moid.py
@@ -52,15 +52,12 @@ _raw:
 from ansible_collections.cloud.common.plugins.plugin_utils.turbo.lookup import (
     TurboLookupBase as LookupBase,
 )
-from ansible_collections.vmware.vmware_rest.plugins.plugin_utils.lookup import (
-    Lookup,
-    get_credentials,
-)
+from ansible_collections.vmware.vmware_rest.plugins.plugin_utils.lookup import Lookup
 
 
 class LookupModule(LookupBase):
     async def _run(self, terms, variables, **kwargs):
-        self.set_options(var_options=variables, direct=get_credentials(**kwargs))
+        self.set_options(var_options=variables, direct=kwargs)
         self.set_option("object_type", "cluster")
         result = await Lookup.entry_point(terms, self._options)
         return [result]

--- a/plugins/lookup/datacenter_moid.py
+++ b/plugins/lookup/datacenter_moid.py
@@ -52,15 +52,12 @@ _raw:
 from ansible_collections.cloud.common.plugins.plugin_utils.turbo.lookup import (
     TurboLookupBase as LookupBase,
 )
-from ansible_collections.vmware.vmware_rest.plugins.plugin_utils.lookup import (
-    Lookup,
-    get_credentials,
-)
+from ansible_collections.vmware.vmware_rest.plugins.plugin_utils.lookup import Lookup
 
 
 class LookupModule(LookupBase):
     async def _run(self, terms, variables, **kwargs):
-        self.set_options(var_options=variables, direct=get_credentials(**kwargs))
+        self.set_options(var_options=variables, direct=kwargs)
         self.set_option("object_type", "datacenter")
         result = await Lookup.entry_point(terms, self._options)
         return [result]

--- a/plugins/lookup/datastore_moid.py
+++ b/plugins/lookup/datastore_moid.py
@@ -52,15 +52,12 @@ _raw:
 from ansible_collections.cloud.common.plugins.plugin_utils.turbo.lookup import (
     TurboLookupBase as LookupBase,
 )
-from ansible_collections.vmware.vmware_rest.plugins.plugin_utils.lookup import (
-    Lookup,
-    get_credentials,
-)
+from ansible_collections.vmware.vmware_rest.plugins.plugin_utils.lookup import Lookup
 
 
 class LookupModule(LookupBase):
     async def _run(self, terms, variables, **kwargs):
-        self.set_options(var_options=variables, direct=get_credentials(**kwargs))
+        self.set_options(var_options=variables, direct=kwargs)
         self.set_option("object_type", "datastore")
         result = await Lookup.entry_point(terms, self._options)
         return [result]

--- a/plugins/lookup/folder_moid.py
+++ b/plugins/lookup/folder_moid.py
@@ -52,15 +52,12 @@ _raw:
 from ansible_collections.cloud.common.plugins.plugin_utils.turbo.lookup import (
     TurboLookupBase as LookupBase,
 )
-from ansible_collections.vmware.vmware_rest.plugins.plugin_utils.lookup import (
-    Lookup,
-    get_credentials,
-)
+from ansible_collections.vmware.vmware_rest.plugins.plugin_utils.lookup import Lookup
 
 
 class LookupModule(LookupBase):
     async def _run(self, terms, variables, **kwargs):
-        self.set_options(var_options=variables, direct=get_credentials(**kwargs))
+        self.set_options(var_options=variables, direct=kwargs)
         self.set_option("object_type", "folder")
         result = await Lookup.entry_point(terms, self._options)
         return [result]

--- a/plugins/lookup/host_moid.py
+++ b/plugins/lookup/host_moid.py
@@ -52,15 +52,12 @@ _raw:
 from ansible_collections.cloud.common.plugins.plugin_utils.turbo.lookup import (
     TurboLookupBase as LookupBase,
 )
-from ansible_collections.vmware.vmware_rest.plugins.plugin_utils.lookup import (
-    Lookup,
-    get_credentials,
-)
+from ansible_collections.vmware.vmware_rest.plugins.plugin_utils.lookup import Lookup
 
 
 class LookupModule(LookupBase):
     async def _run(self, terms, variables, **kwargs):
-        self.set_options(var_options=variables, direct=get_credentials(**kwargs))
+        self.set_options(var_options=variables, direct=kwargs)
         self.set_option("object_type", "host")
         result = await Lookup.entry_point(terms, self._options)
         return [result]

--- a/plugins/lookup/network_moid.py
+++ b/plugins/lookup/network_moid.py
@@ -52,15 +52,12 @@ _raw:
 from ansible_collections.cloud.common.plugins.plugin_utils.turbo.lookup import (
     TurboLookupBase as LookupBase,
 )
-from ansible_collections.vmware.vmware_rest.plugins.plugin_utils.lookup import (
-    Lookup,
-    get_credentials,
-)
+from ansible_collections.vmware.vmware_rest.plugins.plugin_utils.lookup import Lookup
 
 
 class LookupModule(LookupBase):
     async def _run(self, terms, variables, **kwargs):
-        self.set_options(var_options=variables, direct=get_credentials(**kwargs))
+        self.set_options(var_options=variables, direct=kwargs)
         self.set_option("object_type", "network")
         result = await Lookup.entry_point(terms, self._options)
         return [result]

--- a/plugins/lookup/resource_pool_moid.py
+++ b/plugins/lookup/resource_pool_moid.py
@@ -52,15 +52,12 @@ _raw:
 from ansible_collections.cloud.common.plugins.plugin_utils.turbo.lookup import (
     TurboLookupBase as LookupBase,
 )
-from ansible_collections.vmware.vmware_rest.plugins.plugin_utils.lookup import (
-    Lookup,
-    get_credentials,
-)
+from ansible_collections.vmware.vmware_rest.plugins.plugin_utils.lookup import Lookup
 
 
 class LookupModule(LookupBase):
     async def _run(self, terms, variables, **kwargs):
-        self.set_options(var_options=variables, direct=get_credentials(**kwargs))
+        self.set_options(var_options=variables, direct=kwargs)
         self.set_option("object_type", "resource_pool")
         result = await Lookup.entry_point(terms, self._options)
         return [result]

--- a/plugins/lookup/vm_moid.py
+++ b/plugins/lookup/vm_moid.py
@@ -52,15 +52,12 @@ _raw:
 from ansible_collections.cloud.common.plugins.plugin_utils.turbo.lookup import (
     TurboLookupBase as LookupBase,
 )
-from ansible_collections.vmware.vmware_rest.plugins.plugin_utils.lookup import (
-    Lookup,
-    get_credentials,
-)
+from ansible_collections.vmware.vmware_rest.plugins.plugin_utils.lookup import Lookup
 
 
 class LookupModule(LookupBase):
     async def _run(self, terms, variables, **kwargs):
-        self.set_options(var_options=variables, direct=get_credentials(**kwargs))
+        self.set_options(var_options=variables, direct=kwargs)
         self.set_option("object_type", "vm")
         result = await Lookup.entry_point(terms, self._options)
         return [result]

--- a/plugins/plugin_utils/lookup.py
+++ b/plugins/plugin_utils/lookup.py
@@ -126,7 +126,9 @@ def get_credentials(**options):
     )
     credentials["vcenter_validate_certs"] = options.get(
         "vcenter_validate_certs"
-    ) or os.getenv("VMWARE_VALIDATE_CERTS")
+    )
+    if credentials["vcenter_validate_certs"] is None:
+        credentials["vcenter_validate_certs"] = os.getenv("VMWARE_VALIDATE_CERTS")
     credentials["vcenter_rest_log_file"] = options.get(
         "vcenter_rest_log_file"
     ) or os.getenv("VMWARE_REST_LOG_FILE")

--- a/plugins/plugin_utils/lookup.py
+++ b/plugins/plugin_utils/lookup.py
@@ -113,47 +113,22 @@ INVENTORY = {
 }
 
 
-def get_credentials(**options):
-    credentials = {}
-    credentials["vcenter_hostname"] = options.get("vcenter_hostname") or os.getenv(
-        "VMWARE_HOST"
-    )
-    credentials["vcenter_username"] = options.get("vcenter_username") or os.getenv(
-        "VMWARE_USER"
-    )
-    credentials["vcenter_password"] = options.get("vcenter_password") or os.getenv(
-        "VMWARE_PASSWORD"
-    )
-    credentials["vcenter_validate_certs"] = options.get("vcenter_validate_certs")
-    if credentials["vcenter_validate_certs"] is None:
-        credentials["vcenter_validate_certs"] = os.getenv("VMWARE_VALIDATE_CERTS")
-    credentials["vcenter_rest_log_file"] = options.get(
-        "vcenter_rest_log_file"
-    ) or os.getenv("VMWARE_REST_LOG_FILE")
-    return credentials
-
-
 class Lookup:
     def __init__(self, options):
         self._options = options
 
     @classmethod
     async def entry_point(cls, terms, options):
+        if not terms or not terms[0]:
+            raise AnsibleLookupError("Option _terms is required but no object has been specified")
         session = None
-
-        if not options.get("vcenter_hostname"):
-            raise AnsibleLookupError("vcenter_hostname cannot be empty")
-        if not options.get("vcenter_username"):
-            raise AnsibleLookupError("vcenter_username cannot be empty")
-        if not options.get("vcenter_password"):
-            raise AnsibleLookupError("vcenter_password cannot be empty")
 
         try:
             session = await open_session(
-                vcenter_hostname=options.get("vcenter_hostname"),
-                vcenter_username=options.get("vcenter_username"),
-                vcenter_password=options.get("vcenter_password"),
-                validate_certs=bool(options.get("vcenter_validate_certs")),
+                vcenter_hostname=options["vcenter_hostname"],
+                vcenter_username=options["vcenter_username"],
+                vcenter_password=options["vcenter_password"],
+                validate_certs=options.get("vcenter_validate_certs"),
                 log_file=options.get("vcenter_rest_log_file"),
             )
         except EmbeddedModuleFailure as e:
@@ -163,9 +138,6 @@ class Lookup:
 
         lookup = cls(options)
         lookup._options["session"] = session
-
-        if not terms:
-            raise AnsibleLookupError("No object has been specified.")
 
         task = asyncio.ensure_future(lookup.moid(terms[0]))
 

--- a/plugins/plugin_utils/lookup.py
+++ b/plugins/plugin_utils/lookup.py
@@ -8,7 +8,6 @@ __metaclass__ = type
 
 
 import asyncio
-import os
 import urllib
 
 from ansible.errors import AnsibleLookupError
@@ -120,7 +119,9 @@ class Lookup:
     @classmethod
     async def entry_point(cls, terms, options):
         if not terms or not terms[0]:
-            raise AnsibleLookupError("Option _terms is required but no object has been specified")
+            raise AnsibleLookupError(
+                "Option _terms is required but no object has been specified"
+            )
         session = None
 
         try:

--- a/plugins/plugin_utils/lookup.py
+++ b/plugins/plugin_utils/lookup.py
@@ -124,9 +124,7 @@ def get_credentials(**options):
     credentials["vcenter_password"] = options.get("vcenter_password") or os.getenv(
         "VMWARE_PASSWORD"
     )
-    credentials["vcenter_validate_certs"] = options.get(
-        "vcenter_validate_certs"
-    )
+    credentials["vcenter_validate_certs"] = options.get("vcenter_validate_certs")
     if credentials["vcenter_validate_certs"] is None:
         credentials["vcenter_validate_certs"] = os.getenv("VMWARE_VALIDATE_CERTS")
     credentials["vcenter_rest_log_file"] = options.get(


### PR DESCRIPTION
##### SUMMARY
Fixes the credentials options parsing to use `vcenter_validate_certs=false` if provided. It was previously defaulting to the env variable for any falsy value of `vcenter_validate_certs`, which meant both `None` (option not provided) and `False` (passed by the user) values were ignored.

Fixes #425 

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
plugin_utils.lookup
