### PR TITLE
Change URL for library item list in 7.0.3 spec

### DIFF
--- a/changelogs/fragments/463_fix_library_url.yaml
+++ b/changelogs/fragments/463_fix_library_url.yaml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - "content_library_item_info - fixed error with unsupported property"

--- a/config/api_specifications/7.0.3/content.json
+++ b/config/api_specifications/7.0.3/content.json
@@ -1800,7 +1800,7 @@
                 ]
             }
         },
-        "/api/content/library/item?library_id": {
+        "/api/content/library/item": {
             "get": {
                 "tags": [
                     "library/item"

--- a/plugins/modules/content_library_item_info.py
+++ b/plugins/modules/content_library_item_info.py
@@ -288,9 +288,7 @@ def build_url(params):
         )
     _in_query_parameters = PAYLOAD_FORMAT["list"]["query"].keys()
     return yarl.URL(
-        ("https://{vcenter_hostname}" "/api/content/library/item?library_id").format(
-            **params
-        )
+        ("https://{vcenter_hostname}" "/api/content/library/item").format(**params)
         + gen_args(params, _in_query_parameters),
         encoded=True,
     )


### PR DESCRIPTION
##### SUMMARY
When retrieving a list of items inside a content library, the URL was malformed due to a double key in the query. Spec 7.0.3 is changed to look like it did in 7.0.2.

Fixes #463 

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
content_library_item_info
