### PR TITLE
Update docs for network_moid lookup

### DIFF
--- a/changelogs/fragments/20240305-network-moid-docs-update.yml
+++ b/changelogs/fragments/20240305-network-moid-docs-update.yml
@@ -1,0 +1,3 @@
+---
+trivial:
+  - network_moid lookup - Update docs to reflect unique network name requirement (https://github.com/ansible-collections/vmware.vmware_rest/issues/467).

--- a/plugins/lookup/network_moid.py
+++ b/plugins/lookup/network_moid.py
@@ -12,6 +12,8 @@ name: network_moid
 short_description: Look up MoID for vSphere network objects using vCenter REST API
 description:
     - Returns Managed Object Reference (MoID) of the vSphere network object contained in the specified path.
+    - This lookup cannot distinguish between multiple networks with the same name defined in multiple switches
+      as that is not supported by the vSphere REST API; network names must be unique within a given datacenter/folder path.
 author:
     - Alina Buzachis (@alinabuzachis)
 version_added: 2.1.0


### PR DESCRIPTION
##### SUMMARY
Update documentation block for network_moid lookup to reflect constraint that the network name must be unique across switches in a given datacenter/folder for the lookup to work. See https://github.com/ansible-collections/vmware.vmware_rest/issues/467

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
plugins.lookup.network_moid
