### PR TITLE
Mention vmware.vmware.vcsa_settings

### DIFF
--- a/changelogs/fragments/506-mention_vmware.vmware.vcsa_settings.yml
+++ b/changelogs/fragments/506-mention_vmware.vmware.vcsa_settings.yml
@@ -1,0 +1,11 @@
+---
+trivial:
+  - appliance_access_consolecli - Mention new module `vmware.vmware.vcsa_settings` (https://github.com/ansible-collections/vmware.vmware_rest/pull/506).
+  - appliance_access_dcui - Mention new module `vmware.vmware.vcsa_settings` (https://github.com/ansible-collections/vmware.vmware_rest/pull/506).
+  - appliance_access_shell - Mention new module `vmware.vmware.vcsa_settings` (https://github.com/ansible-collections/vmware.vmware_rest/pull/506).
+  - appliance_access_ssh - Mention new module `vmware.vmware.vcsa_settings` (https://github.com/ansible-collections/vmware.vmware_rest/pull/506).
+  - appliance_networking_dns_domains - Mention new module `vmware.vmware.vcsa_settings` (https://github.com/ansible-collections/vmware.vmware_rest/pull/506).
+  - appliance_networking_dns_servers - Mention new module `vmware.vmware.vcsa_settings` (https://github.com/ansible-collections/vmware.vmware_rest/pull/506).
+  - appliance_ntp - Mention new module `vmware.vmware.vcsa_settings` (https://github.com/ansible-collections/vmware.vmware_rest/pull/506).
+  - appliance_system_time_timezone - Mention new module `vmware.vmware.vcsa_settings` (https://github.com/ansible-collections/vmware.vmware_rest/pull/506).
+  - appliance_timesync - Mention new module `vmware.vmware.vcsa_settings` (https://github.com/ansible-collections/vmware.vmware_rest/pull/506).

--- a/config/modules.yaml
+++ b/config/modules.yaml
@@ -1,12 +1,24 @@
 ---
 - appliance_access_consolecli_info:
 - appliance_access_consolecli:
+    documentation:
+      seealso:
+        - M(vmware.vmware.vcsa_settings)
 - appliance_access_dcui_info:
 - appliance_access_dcui:
+    documentation:
+      seealso:
+        - M(vmware.vmware.vcsa_settings)
 - appliance_access_shell_info:
 - appliance_access_shell:
+    documentation:
+      seealso:
+        - M(vmware.vmware.vcsa_settings)
 - appliance_access_ssh_info:
 - appliance_access_ssh:
+    documentation:
+      seealso:
+        - M(vmware.vmware.vcsa_settings)
 - appliance_health_applmgmt_info:
 - appliance_health_database_info:
 - appliance_health_databasestorage_info:
@@ -32,10 +44,16 @@
 - appliance_monitoring_query:
 - appliance_networking_dns_domains_info:
 - appliance_networking_dns_domains:
+    documentation:
+      seealso:
+        - M(vmware.vmware.vcsa_settings)
 - appliance_networking_dns_hostname_info:
 - appliance_networking_dns_hostname:
 - appliance_networking_dns_servers_info:
 - appliance_networking_dns_servers:
+    documentation:
+      seealso:
+        - M(vmware.vmware.vcsa_settings)
 - appliance_networking_firewall_inbound_info:
 - appliance_networking_firewall_inbound:
 - appliance_networking_info:
@@ -51,6 +69,9 @@
 - appliance_networking:
 - appliance_ntp_info:
 - appliance_ntp:
+    documentation:
+      seealso:
+        - M(vmware.vmware.vcsa_settings)
 - appliance_services_info:
 - appliance_services:
 - appliance_shutdown_info:
@@ -62,9 +83,15 @@
 - appliance_system_time_info:
 - appliance_system_time_timezone_info:
 - appliance_system_time_timezone:
+    documentation:
+      seealso:
+        - M(vmware.vmware.vcsa_settings)
 - appliance_system_version_info:
 - appliance_timesync_info:
 - appliance_timesync:
+    documentation:
+      seealso:
+        - M(vmware.vmware.vcsa_settings)
 - appliance_update_info:
 - appliance_vmon_service_info:
 - appliance_vmon_service:


### PR DESCRIPTION
##### SUMMARY
Mention `vmware.vmware.vcsa_settings` in modules (instead of deprecating them in favor of it).

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
appliance_access_consolecli
appliance_access_dcui
appliance_access_shell
appliance_access_ssh
appliance_networking_dns_domains
appliance_networking_dns_servers
appliance_ntp
appliance_system_time_timezone
appliance_timesync

##### ADDITIONAL INFORMATION
#502