### PR TITLE
Add vmware.vmware for docs CI

### DIFF
--- a/.github/workflows/docs-pr.yml
+++ b/.github/workflows/docs-pr.yml
@@ -17,6 +17,7 @@ jobs:
     name: Validate Ansible Docs
     uses: ansible-community/github-docs-build/.github/workflows/_shared-docs-build-pr.yml@main
     with:
+      extra-collections: vmware.vmware
       init-lenient: false
       init-fail-on-error: true
       artifact-name: ${{ github.event.repository.name }}_docs_${{ github.event.pull_request.head.sha }}_validate

--- a/changelogs/fragments/513-add-vmware.vmware-for-docs-ci.yaml
+++ b/changelogs/fragments/513-add-vmware.vmware-for-docs-ci.yaml
@@ -1,0 +1,3 @@
+---
+trivial:
+  - Add vmware.vmware for docs CI (https://github.com/ansible-collections/vmware.vmware_rest/pull/513).


### PR DESCRIPTION
##### SUMMARY
Now that some modules reference [vmware.vmware](https://github.com/ansible-collections/vmware.vmware) we see some problems in the CI checking the documentation. I'm not sure if this will fix it, it's just a try.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
.github/workflows/docs-pr.yml

##### ADDITIONAL INFORMATION
#511