### PR TITLE
README: Add Communication section with Forum information

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,6 +231,16 @@ We currently are not planning any deprecations or new major releases like 2.0.0 
 
 ## Communication
 
+* Join the Ansible forum:
+  * [Get Help](https://forum.ansible.com/c/help/6): get help or help others.
+  * [Posts tagged with 'vmware'](https://forum.ansible.com/tag/vmware): subscribe to participate in collection-related conversations.
+  * [Social Spaces](https://forum.ansible.com/c/chat/4): gather and interact with fellow enthusiasts.
+  * [News & Announcements](https://forum.ansible.com/c/news/5): track project-wide announcements including social events.
+
+* The Ansible [Bullhorn newsletter](https://docs.ansible.com/ansible/devel/community/communication.html#the-bullhorn): used to announce releases and important changes.
+
+For more information about the forum, see the [Ansible communication guide](https://docs.ansible.com/ansible/devel/community/communication.html).
+
 We have a dedicated Working Group for VMware.
 You can find other people interested in this in `#ansible-vmware` on [libera.chat](https://libera.chat/) IRC.
 For more information about communities, meetings and agendas see https://github.com/ansible/community/wiki/VMware.


### PR DESCRIPTION
##### SUMMARY
Dear maintainers,
As a part of the [Consolidating Ansible discussion platforms initiative](https://forum.ansible.com/t/proposal-consolidating-ansible-discussion-platforms/6812), this PR adds the communication section template defined by the community to the README. Similar PRs are being raised across all included collections under the ansible-collection org for now.

If you have other tags/forum groups related to the collection I didn't spot, please update corresponding lines by suggesting changes to the PR.

IMPORTANT: please, consider moving your WG mentioned in README to the forum group, request it using https://docs.ansible.com/ansible/devel/community/communication.html#requesting-a-forum-group and update the README (or let me know)

##### ISSUE TYPE

- Docs Pull Request

##### COMPONENT NAME
README.md