### PR TITLE
Fix Build Ansible Docs workflow

### DIFF
--- a/.github/workflows/docs-push.yml
+++ b/.github/workflows/docs-push.yml
@@ -24,6 +24,8 @@ jobs:
       init-fail-on-error: true
       intersphinx-links: |
         ansible_devel:https://docs.ansible.com/ansible-core/devel/
+      provide-link-targets: |
+        ansible_collections.vmware.vmware.vcsa_settings_module
 
   publish-docs-gh-pages:
     # use to prevent running on forks


### PR DESCRIPTION
##### SUMMARY
Trying to fix the `Build Ansible Docs` CI workflow which fails ATM.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
.github/workflows/docs-push.yml

##### ADDITIONAL INFORMATION
[This](https://github.com/ansible-collections/vmware.vmware_rest/pull/511#issuecomment-2291830581) and the following comment.
