### PR TITLE
adding better documentation for the customization module

### DIFF
--- a/changelogs/fragments/534-docs-for-vm_customization-module.yml
+++ b/changelogs/fragments/534-docs-for-vm_customization-module.yml
@@ -1,0 +1,4 @@
+---
+minor_changes:
+  - vcenter_vm_guest_customization - Added better examples that cover more use-cases
+    (https://github.com/ansible-collections/vmware.vmware_rest/pull/534).

--- a/development.md
+++ b/development.md
@@ -37,8 +37,7 @@ See [Ansible Using collections](https://docs.ansible.com/ansible/latest/user_gui
 
 The `generate.yml` playbook will copy the old blocks to the new modules. You can refresh the blocks if you introduce a new API version.
 
-
-**Note** The steps below will run a playbook that stops all of the VMs in a vcenter
+**Note** The steps below will run a playbook that stops all of the VMs in a vcenter. It will also potentially wipe out the examples and return values in each module, so please review changes carefully.
 
 Create `/tmp/inventory-vmware_rest` like:
 ```


### PR DESCRIPTION
##### SUMMARY
Updates the examples in the vm customization module to be more detailed and cover both the linux and cloud-init configuration schemes.

Fixes
https://github.com/ansible-collections/vmware.vmware_rest/issues/472
https://github.com/ansible-collections/vmware.vmware_rest/issues/527


##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
vcenter_vm_guest_customization
