### PR TITLE
Run sanity tests with ansible-core 2.18

### DIFF
--- a/.github/workflows/sanity-tests.yaml
+++ b/.github/workflows/sanity-tests.yaml
@@ -78,6 +78,7 @@ jobs:
           - stable-2.15
           - stable-2.16
           - stable-2.17
+          - stable-2.18
           # - devel
           # - milestone
     # Ansible-test on various stable branches does not yet work well with cgroups v2.

--- a/tests/sanity/ignore-2.18.txt
+++ b/tests/sanity/ignore-2.18.txt
@@ -1,0 +1,2 @@
+plugins/modules/vcenter_vm_guest_customization.py pep8!skip
+plugins/modules/appliance_infraprofile_configs.py pep8!skip


### PR DESCRIPTION
Now that ansible-core 2.18 is out, we should (actually: have to) run the sanity tests with this release.