### PR TITLE
fixing typos in module documentation

### DIFF
--- a/changelogs/fragments/540-typo-fixes-in-module-docs.yml
+++ b/changelogs/fragments/540-typo-fixes-in-module-docs.yml
@@ -1,0 +1,4 @@
+---
+bugfixes:
+  - vcenter_vm_guest_customization - Fixed typos and spacing in the module examples
+  - Fixed grammatical error in vcenter_rest_log_file parameter description

--- a/plugins/modules/appliance_access_consolecli.py
+++ b/plugins/modules/appliance_access_consolecli.py
@@ -49,7 +49,7 @@ options:
         description:
         - 'You can use this optional parameter to set the location of a log file. '
         - 'This file will be used to record the HTTP REST interaction. '
-        - 'The file will be stored on the host that run the module. '
+        - 'The file will be stored on the host that runs the module. '
         - 'If the value is not specified in the task, the value of '
         - environment variable C(VMWARE_REST_LOG_FILE) will be used instead.
         type: str

--- a/plugins/modules/appliance_access_consolecli_info.py
+++ b/plugins/modules/appliance_access_consolecli_info.py
@@ -38,7 +38,7 @@ options:
         description:
         - 'You can use this optional parameter to set the location of a log file. '
         - 'This file will be used to record the HTTP REST interaction. '
-        - 'The file will be stored on the host that run the module. '
+        - 'The file will be stored on the host that runs the module. '
         - 'If the value is not specified in the task, the value of '
         - environment variable C(VMWARE_REST_LOG_FILE) will be used instead.
         type: str

--- a/plugins/modules/appliance_access_dcui.py
+++ b/plugins/modules/appliance_access_dcui.py
@@ -49,7 +49,7 @@ options:
         description:
         - 'You can use this optional parameter to set the location of a log file. '
         - 'This file will be used to record the HTTP REST interaction. '
-        - 'The file will be stored on the host that run the module. '
+        - 'The file will be stored on the host that runs the module. '
         - 'If the value is not specified in the task, the value of '
         - environment variable C(VMWARE_REST_LOG_FILE) will be used instead.
         type: str

--- a/plugins/modules/appliance_access_dcui_info.py
+++ b/plugins/modules/appliance_access_dcui_info.py
@@ -38,7 +38,7 @@ options:
         description:
         - 'You can use this optional parameter to set the location of a log file. '
         - 'This file will be used to record the HTTP REST interaction. '
-        - 'The file will be stored on the host that run the module. '
+        - 'The file will be stored on the host that runs the module. '
         - 'If the value is not specified in the task, the value of '
         - environment variable C(VMWARE_REST_LOG_FILE) will be used instead.
         type: str

--- a/plugins/modules/appliance_access_shell.py
+++ b/plugins/modules/appliance_access_shell.py
@@ -57,7 +57,7 @@ options:
         description:
         - 'You can use this optional parameter to set the location of a log file. '
         - 'This file will be used to record the HTTP REST interaction. '
-        - 'The file will be stored on the host that run the module. '
+        - 'The file will be stored on the host that runs the module. '
         - 'If the value is not specified in the task, the value of '
         - environment variable C(VMWARE_REST_LOG_FILE) will be used instead.
         type: str

--- a/plugins/modules/appliance_access_shell_info.py
+++ b/plugins/modules/appliance_access_shell_info.py
@@ -40,7 +40,7 @@ options:
         description:
         - 'You can use this optional parameter to set the location of a log file. '
         - 'This file will be used to record the HTTP REST interaction. '
-        - 'The file will be stored on the host that run the module. '
+        - 'The file will be stored on the host that runs the module. '
         - 'If the value is not specified in the task, the value of '
         - environment variable C(VMWARE_REST_LOG_FILE) will be used instead.
         type: str

--- a/plugins/modules/appliance_access_ssh.py
+++ b/plugins/modules/appliance_access_ssh.py
@@ -49,7 +49,7 @@ options:
         description:
         - 'You can use this optional parameter to set the location of a log file. '
         - 'This file will be used to record the HTTP REST interaction. '
-        - 'The file will be stored on the host that run the module. '
+        - 'The file will be stored on the host that runs the module. '
         - 'If the value is not specified in the task, the value of '
         - environment variable C(VMWARE_REST_LOG_FILE) will be used instead.
         type: str

--- a/plugins/modules/appliance_access_ssh_info.py
+++ b/plugins/modules/appliance_access_ssh_info.py
@@ -38,7 +38,7 @@ options:
         description:
         - 'You can use this optional parameter to set the location of a log file. '
         - 'This file will be used to record the HTTP REST interaction. '
-        - 'The file will be stored on the host that run the module. '
+        - 'The file will be stored on the host that runs the module. '
         - 'If the value is not specified in the task, the value of '
         - environment variable C(VMWARE_REST_LOG_FILE) will be used instead.
         type: str

--- a/plugins/modules/appliance_health_applmgmt_info.py
+++ b/plugins/modules/appliance_health_applmgmt_info.py
@@ -38,7 +38,7 @@ options:
         description:
         - 'You can use this optional parameter to set the location of a log file. '
         - 'This file will be used to record the HTTP REST interaction. '
-        - 'The file will be stored on the host that run the module. '
+        - 'The file will be stored on the host that runs the module. '
         - 'If the value is not specified in the task, the value of '
         - environment variable C(VMWARE_REST_LOG_FILE) will be used instead.
         type: str

--- a/plugins/modules/appliance_health_database_info.py
+++ b/plugins/modules/appliance_health_database_info.py
@@ -38,7 +38,7 @@ options:
         description:
         - 'You can use this optional parameter to set the location of a log file. '
         - 'This file will be used to record the HTTP REST interaction. '
-        - 'The file will be stored on the host that run the module. '
+        - 'The file will be stored on the host that runs the module. '
         - 'If the value is not specified in the task, the value of '
         - environment variable C(VMWARE_REST_LOG_FILE) will be used instead.
         type: str

--- a/plugins/modules/appliance_health_databasestorage_info.py
+++ b/plugins/modules/appliance_health_databasestorage_info.py
@@ -38,7 +38,7 @@ options:
         description:
         - 'You can use this optional parameter to set the location of a log file. '
         - 'This file will be used to record the HTTP REST interaction. '
-        - 'The file will be stored on the host that run the module. '
+        - 'The file will be stored on the host that runs the module. '
         - 'If the value is not specified in the task, the value of '
         - environment variable C(VMWARE_REST_LOG_FILE) will be used instead.
         type: str

--- a/plugins/modules/appliance_health_load_info.py
+++ b/plugins/modules/appliance_health_load_info.py
@@ -38,7 +38,7 @@ options:
         description:
         - 'You can use this optional parameter to set the location of a log file. '
         - 'This file will be used to record the HTTP REST interaction. '
-        - 'The file will be stored on the host that run the module. '
+        - 'The file will be stored on the host that runs the module. '
         - 'If the value is not specified in the task, the value of '
         - environment variable C(VMWARE_REST_LOG_FILE) will be used instead.
         type: str

--- a/plugins/modules/appliance_health_mem_info.py
+++ b/plugins/modules/appliance_health_mem_info.py
@@ -38,7 +38,7 @@ options:
         description:
         - 'You can use this optional parameter to set the location of a log file. '
         - 'This file will be used to record the HTTP REST interaction. '
-        - 'The file will be stored on the host that run the module. '
+        - 'The file will be stored on the host that runs the module. '
         - 'If the value is not specified in the task, the value of '
         - environment variable C(VMWARE_REST_LOG_FILE) will be used instead.
         type: str

--- a/plugins/modules/appliance_health_softwarepackages_info.py
+++ b/plugins/modules/appliance_health_softwarepackages_info.py
@@ -43,7 +43,7 @@ options:
         description:
         - 'You can use this optional parameter to set the location of a log file. '
         - 'This file will be used to record the HTTP REST interaction. '
-        - 'The file will be stored on the host that run the module. '
+        - 'The file will be stored on the host that runs the module. '
         - 'If the value is not specified in the task, the value of '
         - environment variable C(VMWARE_REST_LOG_FILE) will be used instead.
         type: str

--- a/plugins/modules/appliance_health_storage_info.py
+++ b/plugins/modules/appliance_health_storage_info.py
@@ -38,7 +38,7 @@ options:
         description:
         - 'You can use this optional parameter to set the location of a log file. '
         - 'This file will be used to record the HTTP REST interaction. '
-        - 'The file will be stored on the host that run the module. '
+        - 'The file will be stored on the host that runs the module. '
         - 'If the value is not specified in the task, the value of '
         - environment variable C(VMWARE_REST_LOG_FILE) will be used instead.
         type: str

--- a/plugins/modules/appliance_health_swap_info.py
+++ b/plugins/modules/appliance_health_swap_info.py
@@ -38,7 +38,7 @@ options:
         description:
         - 'You can use this optional parameter to set the location of a log file. '
         - 'This file will be used to record the HTTP REST interaction. '
-        - 'The file will be stored on the host that run the module. '
+        - 'The file will be stored on the host that runs the module. '
         - 'If the value is not specified in the task, the value of '
         - environment variable C(VMWARE_REST_LOG_FILE) will be used instead.
         type: str

--- a/plugins/modules/appliance_health_system_info.py
+++ b/plugins/modules/appliance_health_system_info.py
@@ -38,7 +38,7 @@ options:
         description:
         - 'You can use this optional parameter to set the location of a log file. '
         - 'This file will be used to record the HTTP REST interaction. '
-        - 'The file will be stored on the host that run the module. '
+        - 'The file will be stored on the host that runs the module. '
         - 'If the value is not specified in the task, the value of '
         - environment variable C(VMWARE_REST_LOG_FILE) will be used instead.
         type: str

--- a/plugins/modules/appliance_infraprofile_configs.py
+++ b/plugins/modules/appliance_infraprofile_configs.py
@@ -62,7 +62,7 @@ options:
         description:
         - 'You can use this optional parameter to set the location of a log file. '
         - 'This file will be used to record the HTTP REST interaction. '
-        - 'The file will be stored on the host that run the module. '
+        - 'The file will be stored on the host that runs the module. '
         - 'If the value is not specified in the task, the value of '
         - environment variable C(VMWARE_REST_LOG_FILE) will be used instead.
         type: str

--- a/plugins/modules/appliance_infraprofile_configs_info.py
+++ b/plugins/modules/appliance_infraprofile_configs_info.py
@@ -38,7 +38,7 @@ options:
         description:
         - 'You can use this optional parameter to set the location of a log file. '
         - 'This file will be used to record the HTTP REST interaction. '
-        - 'The file will be stored on the host that run the module. '
+        - 'The file will be stored on the host that runs the module. '
         - 'If the value is not specified in the task, the value of '
         - environment variable C(VMWARE_REST_LOG_FILE) will be used instead.
         type: str

--- a/plugins/modules/appliance_localaccounts_globalpolicy.py
+++ b/plugins/modules/appliance_localaccounts_globalpolicy.py
@@ -56,7 +56,7 @@ options:
         description:
         - 'You can use this optional parameter to set the location of a log file. '
         - 'This file will be used to record the HTTP REST interaction. '
-        - 'The file will be stored on the host that run the module. '
+        - 'The file will be stored on the host that runs the module. '
         - 'If the value is not specified in the task, the value of '
         - environment variable C(VMWARE_REST_LOG_FILE) will be used instead.
         type: str

--- a/plugins/modules/appliance_localaccounts_globalpolicy_info.py
+++ b/plugins/modules/appliance_localaccounts_globalpolicy_info.py
@@ -38,7 +38,7 @@ options:
         description:
         - 'You can use this optional parameter to set the location of a log file. '
         - 'This file will be used to record the HTTP REST interaction. '
-        - 'The file will be stored on the host that run the module. '
+        - 'The file will be stored on the host that runs the module. '
         - 'If the value is not specified in the task, the value of '
         - environment variable C(VMWARE_REST_LOG_FILE) will be used instead.
         type: str

--- a/plugins/modules/appliance_localaccounts_info.py
+++ b/plugins/modules/appliance_localaccounts_info.py
@@ -42,7 +42,7 @@ options:
         description:
         - 'You can use this optional parameter to set the location of a log file. '
         - 'This file will be used to record the HTTP REST interaction. '
-        - 'The file will be stored on the host that run the module. '
+        - 'The file will be stored on the host that runs the module. '
         - 'If the value is not specified in the task, the value of '
         - environment variable C(VMWARE_REST_LOG_FILE) will be used instead.
         type: str

--- a/plugins/modules/appliance_monitoring_info.py
+++ b/plugins/modules/appliance_monitoring_info.py
@@ -44,7 +44,7 @@ options:
         description:
         - 'You can use this optional parameter to set the location of a log file. '
         - 'This file will be used to record the HTTP REST interaction. '
-        - 'The file will be stored on the host that run the module. '
+        - 'The file will be stored on the host that runs the module. '
         - 'If the value is not specified in the task, the value of '
         - environment variable C(VMWARE_REST_LOG_FILE) will be used instead.
         type: str

--- a/plugins/modules/appliance_monitoring_query.py
+++ b/plugins/modules/appliance_monitoring_query.py
@@ -79,7 +79,7 @@ options:
         description:
         - 'You can use this optional parameter to set the location of a log file. '
         - 'This file will be used to record the HTTP REST interaction. '
-        - 'The file will be stored on the host that run the module. '
+        - 'The file will be stored on the host that runs the module. '
         - 'If the value is not specified in the task, the value of '
         - environment variable C(VMWARE_REST_LOG_FILE) will be used instead.
         type: str

--- a/plugins/modules/appliance_networking.py
+++ b/plugins/modules/appliance_networking.py
@@ -52,7 +52,7 @@ options:
         description:
         - 'You can use this optional parameter to set the location of a log file. '
         - 'This file will be used to record the HTTP REST interaction. '
-        - 'The file will be stored on the host that run the module. '
+        - 'The file will be stored on the host that runs the module. '
         - 'If the value is not specified in the task, the value of '
         - environment variable C(VMWARE_REST_LOG_FILE) will be used instead.
         type: str

--- a/plugins/modules/appliance_networking_dns_domains.py
+++ b/plugins/modules/appliance_networking_dns_domains.py
@@ -54,7 +54,7 @@ options:
         description:
         - 'You can use this optional parameter to set the location of a log file. '
         - 'This file will be used to record the HTTP REST interaction. '
-        - 'The file will be stored on the host that run the module. '
+        - 'The file will be stored on the host that runs the module. '
         - 'If the value is not specified in the task, the value of '
         - environment variable C(VMWARE_REST_LOG_FILE) will be used instead.
         type: str

--- a/plugins/modules/appliance_networking_dns_domains_info.py
+++ b/plugins/modules/appliance_networking_dns_domains_info.py
@@ -38,7 +38,7 @@ options:
         description:
         - 'You can use this optional parameter to set the location of a log file. '
         - 'This file will be used to record the HTTP REST interaction. '
-        - 'The file will be stored on the host that run the module. '
+        - 'The file will be stored on the host that runs the module. '
         - 'If the value is not specified in the task, the value of '
         - environment variable C(VMWARE_REST_LOG_FILE) will be used instead.
         type: str

--- a/plugins/modules/appliance_networking_dns_hostname.py
+++ b/plugins/modules/appliance_networking_dns_hostname.py
@@ -50,7 +50,7 @@ options:
         description:
         - 'You can use this optional parameter to set the location of a log file. '
         - 'This file will be used to record the HTTP REST interaction. '
-        - 'The file will be stored on the host that run the module. '
+        - 'The file will be stored on the host that runs the module. '
         - 'If the value is not specified in the task, the value of '
         - environment variable C(VMWARE_REST_LOG_FILE) will be used instead.
         type: str

--- a/plugins/modules/appliance_networking_dns_hostname_info.py
+++ b/plugins/modules/appliance_networking_dns_hostname_info.py
@@ -38,7 +38,7 @@ options:
         description:
         - 'You can use this optional parameter to set the location of a log file. '
         - 'This file will be used to record the HTTP REST interaction. '
-        - 'The file will be stored on the host that run the module. '
+        - 'The file will be stored on the host that runs the module. '
         - 'If the value is not specified in the task, the value of '
         - environment variable C(VMWARE_REST_LOG_FILE) will be used instead.
         type: str

--- a/plugins/modules/appliance_networking_dns_servers.py
+++ b/plugins/modules/appliance_networking_dns_servers.py
@@ -64,7 +64,7 @@ options:
         description:
         - 'You can use this optional parameter to set the location of a log file. '
         - 'This file will be used to record the HTTP REST interaction. '
-        - 'The file will be stored on the host that run the module. '
+        - 'The file will be stored on the host that runs the module. '
         - 'If the value is not specified in the task, the value of '
         - environment variable C(VMWARE_REST_LOG_FILE) will be used instead.
         type: str

--- a/plugins/modules/appliance_networking_dns_servers_info.py
+++ b/plugins/modules/appliance_networking_dns_servers_info.py
@@ -38,7 +38,7 @@ options:
         description:
         - 'You can use this optional parameter to set the location of a log file. '
         - 'This file will be used to record the HTTP REST interaction. '
-        - 'The file will be stored on the host that run the module. '
+        - 'The file will be stored on the host that runs the module. '
         - 'If the value is not specified in the task, the value of '
         - environment variable C(VMWARE_REST_LOG_FILE) will be used instead.
         type: str

--- a/plugins/modules/appliance_networking_firewall_inbound.py
+++ b/plugins/modules/appliance_networking_firewall_inbound.py
@@ -73,7 +73,7 @@ options:
         description:
         - 'You can use this optional parameter to set the location of a log file. '
         - 'This file will be used to record the HTTP REST interaction. '
-        - 'The file will be stored on the host that run the module. '
+        - 'The file will be stored on the host that runs the module. '
         - 'If the value is not specified in the task, the value of '
         - environment variable C(VMWARE_REST_LOG_FILE) will be used instead.
         type: str

--- a/plugins/modules/appliance_networking_firewall_inbound_info.py
+++ b/plugins/modules/appliance_networking_firewall_inbound_info.py
@@ -41,7 +41,7 @@ options:
         description:
         - 'You can use this optional parameter to set the location of a log file. '
         - 'This file will be used to record the HTTP REST interaction. '
-        - 'The file will be stored on the host that run the module. '
+        - 'The file will be stored on the host that runs the module. '
         - 'If the value is not specified in the task, the value of '
         - environment variable C(VMWARE_REST_LOG_FILE) will be used instead.
         type: str

--- a/plugins/modules/appliance_networking_info.py
+++ b/plugins/modules/appliance_networking_info.py
@@ -38,7 +38,7 @@ options:
         description:
         - 'You can use this optional parameter to set the location of a log file. '
         - 'This file will be used to record the HTTP REST interaction. '
-        - 'The file will be stored on the host that run the module. '
+        - 'The file will be stored on the host that runs the module. '
         - 'If the value is not specified in the task, the value of '
         - environment variable C(VMWARE_REST_LOG_FILE) will be used instead.
         type: str

--- a/plugins/modules/appliance_networking_interfaces_info.py
+++ b/plugins/modules/appliance_networking_interfaces_info.py
@@ -44,7 +44,7 @@ options:
         description:
         - 'You can use this optional parameter to set the location of a log file. '
         - 'This file will be used to record the HTTP REST interaction. '
-        - 'The file will be stored on the host that run the module. '
+        - 'The file will be stored on the host that runs the module. '
         - 'If the value is not specified in the task, the value of '
         - environment variable C(VMWARE_REST_LOG_FILE) will be used instead.
         type: str

--- a/plugins/modules/appliance_networking_interfaces_ipv4.py
+++ b/plugins/modules/appliance_networking_interfaces_ipv4.py
@@ -84,7 +84,7 @@ options:
         description:
         - 'You can use this optional parameter to set the location of a log file. '
         - 'This file will be used to record the HTTP REST interaction. '
-        - 'The file will be stored on the host that run the module. '
+        - 'The file will be stored on the host that runs the module. '
         - 'If the value is not specified in the task, the value of '
         - environment variable C(VMWARE_REST_LOG_FILE) will be used instead.
         type: str

--- a/plugins/modules/appliance_networking_interfaces_ipv4_info.py
+++ b/plugins/modules/appliance_networking_interfaces_ipv4_info.py
@@ -44,7 +44,7 @@ options:
         description:
         - 'You can use this optional parameter to set the location of a log file. '
         - 'This file will be used to record the HTTP REST interaction. '
-        - 'The file will be stored on the host that run the module. '
+        - 'The file will be stored on the host that runs the module. '
         - 'If the value is not specified in the task, the value of '
         - environment variable C(VMWARE_REST_LOG_FILE) will be used instead.
         type: str

--- a/plugins/modules/appliance_networking_interfaces_ipv6.py
+++ b/plugins/modules/appliance_networking_interfaces_ipv6.py
@@ -85,7 +85,7 @@ options:
         description:
         - 'You can use this optional parameter to set the location of a log file. '
         - 'This file will be used to record the HTTP REST interaction. '
-        - 'The file will be stored on the host that run the module. '
+        - 'The file will be stored on the host that runs the module. '
         - 'If the value is not specified in the task, the value of '
         - environment variable C(VMWARE_REST_LOG_FILE) will be used instead.
         type: str

--- a/plugins/modules/appliance_networking_interfaces_ipv6_info.py
+++ b/plugins/modules/appliance_networking_interfaces_ipv6_info.py
@@ -44,7 +44,7 @@ options:
         description:
         - 'You can use this optional parameter to set the location of a log file. '
         - 'This file will be used to record the HTTP REST interaction. '
-        - 'The file will be stored on the host that run the module. '
+        - 'The file will be stored on the host that runs the module. '
         - 'If the value is not specified in the task, the value of '
         - environment variable C(VMWARE_REST_LOG_FILE) will be used instead.
         type: str

--- a/plugins/modules/appliance_networking_noproxy.py
+++ b/plugins/modules/appliance_networking_noproxy.py
@@ -56,7 +56,7 @@ options:
         description:
         - 'You can use this optional parameter to set the location of a log file. '
         - 'This file will be used to record the HTTP REST interaction. '
-        - 'The file will be stored on the host that run the module. '
+        - 'The file will be stored on the host that runs the module. '
         - 'If the value is not specified in the task, the value of '
         - environment variable C(VMWARE_REST_LOG_FILE) will be used instead.
         type: str

--- a/plugins/modules/appliance_networking_noproxy_info.py
+++ b/plugins/modules/appliance_networking_noproxy_info.py
@@ -38,7 +38,7 @@ options:
         description:
         - 'You can use this optional parameter to set the location of a log file. '
         - 'This file will be used to record the HTTP REST interaction. '
-        - 'The file will be stored on the host that run the module. '
+        - 'The file will be stored on the host that runs the module. '
         - 'If the value is not specified in the task, the value of '
         - environment variable C(VMWARE_REST_LOG_FILE) will be used instead.
         type: str

--- a/plugins/modules/appliance_networking_proxy.py
+++ b/plugins/modules/appliance_networking_proxy.py
@@ -106,7 +106,7 @@ options:
         description:
         - 'You can use this optional parameter to set the location of a log file. '
         - 'This file will be used to record the HTTP REST interaction. '
-        - 'The file will be stored on the host that run the module. '
+        - 'The file will be stored on the host that runs the module. '
         - 'If the value is not specified in the task, the value of '
         - environment variable C(VMWARE_REST_LOG_FILE) will be used instead.
         type: str

--- a/plugins/modules/appliance_networking_proxy_info.py
+++ b/plugins/modules/appliance_networking_proxy_info.py
@@ -42,7 +42,7 @@ options:
         description:
         - 'You can use this optional parameter to set the location of a log file. '
         - 'This file will be used to record the HTTP REST interaction. '
-        - 'The file will be stored on the host that run the module. '
+        - 'The file will be stored on the host that runs the module. '
         - 'If the value is not specified in the task, the value of '
         - environment variable C(VMWARE_REST_LOG_FILE) will be used instead.
         type: str

--- a/plugins/modules/appliance_ntp.py
+++ b/plugins/modules/appliance_ntp.py
@@ -55,7 +55,7 @@ options:
         description:
         - 'You can use this optional parameter to set the location of a log file. '
         - 'This file will be used to record the HTTP REST interaction. '
-        - 'The file will be stored on the host that run the module. '
+        - 'The file will be stored on the host that runs the module. '
         - 'If the value is not specified in the task, the value of '
         - environment variable C(VMWARE_REST_LOG_FILE) will be used instead.
         type: str

--- a/plugins/modules/appliance_ntp_info.py
+++ b/plugins/modules/appliance_ntp_info.py
@@ -42,7 +42,7 @@ options:
         description:
         - 'You can use this optional parameter to set the location of a log file. '
         - 'This file will be used to record the HTTP REST interaction. '
-        - 'The file will be stored on the host that run the module. '
+        - 'The file will be stored on the host that runs the module. '
         - 'If the value is not specified in the task, the value of '
         - environment variable C(VMWARE_REST_LOG_FILE) will be used instead.
         type: str

--- a/plugins/modules/appliance_services.py
+++ b/plugins/modules/appliance_services.py
@@ -53,7 +53,7 @@ options:
         description:
         - 'You can use this optional parameter to set the location of a log file. '
         - 'This file will be used to record the HTTP REST interaction. '
-        - 'The file will be stored on the host that run the module. '
+        - 'The file will be stored on the host that runs the module. '
         - 'If the value is not specified in the task, the value of '
         - environment variable C(VMWARE_REST_LOG_FILE) will be used instead.
         type: str

--- a/plugins/modules/appliance_services_info.py
+++ b/plugins/modules/appliance_services_info.py
@@ -44,7 +44,7 @@ options:
         description:
         - 'You can use this optional parameter to set the location of a log file. '
         - 'This file will be used to record the HTTP REST interaction. '
-        - 'The file will be stored on the host that run the module. '
+        - 'The file will be stored on the host that runs the module. '
         - 'If the value is not specified in the task, the value of '
         - environment variable C(VMWARE_REST_LOG_FILE) will be used instead.
         type: str

--- a/plugins/modules/appliance_shutdown.py
+++ b/plugins/modules/appliance_shutdown.py
@@ -55,7 +55,7 @@ options:
         description:
         - 'You can use this optional parameter to set the location of a log file. '
         - 'This file will be used to record the HTTP REST interaction. '
-        - 'The file will be stored on the host that run the module. '
+        - 'The file will be stored on the host that runs the module. '
         - 'If the value is not specified in the task, the value of '
         - environment variable C(VMWARE_REST_LOG_FILE) will be used instead.
         type: str

--- a/plugins/modules/appliance_shutdown_info.py
+++ b/plugins/modules/appliance_shutdown_info.py
@@ -38,7 +38,7 @@ options:
         description:
         - 'You can use this optional parameter to set the location of a log file. '
         - 'This file will be used to record the HTTP REST interaction. '
-        - 'The file will be stored on the host that run the module. '
+        - 'The file will be stored on the host that runs the module. '
         - 'If the value is not specified in the task, the value of '
         - environment variable C(VMWARE_REST_LOG_FILE) will be used instead.
         type: str

--- a/plugins/modules/appliance_system_globalfips.py
+++ b/plugins/modules/appliance_system_globalfips.py
@@ -49,7 +49,7 @@ options:
         description:
         - 'You can use this optional parameter to set the location of a log file. '
         - 'This file will be used to record the HTTP REST interaction. '
-        - 'The file will be stored on the host that run the module. '
+        - 'The file will be stored on the host that runs the module. '
         - 'If the value is not specified in the task, the value of '
         - environment variable C(VMWARE_REST_LOG_FILE) will be used instead.
         type: str

--- a/plugins/modules/appliance_system_globalfips_info.py
+++ b/plugins/modules/appliance_system_globalfips_info.py
@@ -38,7 +38,7 @@ options:
         description:
         - 'You can use this optional parameter to set the location of a log file. '
         - 'This file will be used to record the HTTP REST interaction. '
-        - 'The file will be stored on the host that run the module. '
+        - 'The file will be stored on the host that runs the module. '
         - 'If the value is not specified in the task, the value of '
         - environment variable C(VMWARE_REST_LOG_FILE) will be used instead.
         type: str

--- a/plugins/modules/appliance_system_storage.py
+++ b/plugins/modules/appliance_system_storage.py
@@ -45,7 +45,7 @@ options:
         description:
         - 'You can use this optional parameter to set the location of a log file. '
         - 'This file will be used to record the HTTP REST interaction. '
-        - 'The file will be stored on the host that run the module. '
+        - 'The file will be stored on the host that runs the module. '
         - 'If the value is not specified in the task, the value of '
         - environment variable C(VMWARE_REST_LOG_FILE) will be used instead.
         type: str

--- a/plugins/modules/appliance_system_storage_info.py
+++ b/plugins/modules/appliance_system_storage_info.py
@@ -38,7 +38,7 @@ options:
         description:
         - 'You can use this optional parameter to set the location of a log file. '
         - 'This file will be used to record the HTTP REST interaction. '
-        - 'The file will be stored on the host that run the module. '
+        - 'The file will be stored on the host that runs the module. '
         - 'If the value is not specified in the task, the value of '
         - environment variable C(VMWARE_REST_LOG_FILE) will be used instead.
         type: str

--- a/plugins/modules/appliance_system_time_info.py
+++ b/plugins/modules/appliance_system_time_info.py
@@ -38,7 +38,7 @@ options:
         description:
         - 'You can use this optional parameter to set the location of a log file. '
         - 'This file will be used to record the HTTP REST interaction. '
-        - 'The file will be stored on the host that run the module. '
+        - 'The file will be stored on the host that runs the module. '
         - 'If the value is not specified in the task, the value of '
         - environment variable C(VMWARE_REST_LOG_FILE) will be used instead.
         type: str

--- a/plugins/modules/appliance_system_time_timezone.py
+++ b/plugins/modules/appliance_system_time_timezone.py
@@ -49,7 +49,7 @@ options:
         description:
         - 'You can use this optional parameter to set the location of a log file. '
         - 'This file will be used to record the HTTP REST interaction. '
-        - 'The file will be stored on the host that run the module. '
+        - 'The file will be stored on the host that runs the module. '
         - 'If the value is not specified in the task, the value of '
         - environment variable C(VMWARE_REST_LOG_FILE) will be used instead.
         type: str

--- a/plugins/modules/appliance_system_time_timezone_info.py
+++ b/plugins/modules/appliance_system_time_timezone_info.py
@@ -38,7 +38,7 @@ options:
         description:
         - 'You can use this optional parameter to set the location of a log file. '
         - 'This file will be used to record the HTTP REST interaction. '
-        - 'The file will be stored on the host that run the module. '
+        - 'The file will be stored on the host that runs the module. '
         - 'If the value is not specified in the task, the value of '
         - environment variable C(VMWARE_REST_LOG_FILE) will be used instead.
         type: str

--- a/plugins/modules/appliance_system_version_info.py
+++ b/plugins/modules/appliance_system_version_info.py
@@ -38,7 +38,7 @@ options:
         description:
         - 'You can use this optional parameter to set the location of a log file. '
         - 'This file will be used to record the HTTP REST interaction. '
-        - 'The file will be stored on the host that run the module. '
+        - 'The file will be stored on the host that runs the module. '
         - 'If the value is not specified in the task, the value of '
         - environment variable C(VMWARE_REST_LOG_FILE) will be used instead.
         type: str

--- a/plugins/modules/appliance_timesync.py
+++ b/plugins/modules/appliance_timesync.py
@@ -54,7 +54,7 @@ options:
         description:
         - 'You can use this optional parameter to set the location of a log file. '
         - 'This file will be used to record the HTTP REST interaction. '
-        - 'The file will be stored on the host that run the module. '
+        - 'The file will be stored on the host that runs the module. '
         - 'If the value is not specified in the task, the value of '
         - environment variable C(VMWARE_REST_LOG_FILE) will be used instead.
         type: str

--- a/plugins/modules/appliance_timesync_info.py
+++ b/plugins/modules/appliance_timesync_info.py
@@ -38,7 +38,7 @@ options:
         description:
         - 'You can use this optional parameter to set the location of a log file. '
         - 'This file will be used to record the HTTP REST interaction. '
-        - 'The file will be stored on the host that run the module. '
+        - 'The file will be stored on the host that runs the module. '
         - 'If the value is not specified in the task, the value of '
         - environment variable C(VMWARE_REST_LOG_FILE) will be used instead.
         type: str

--- a/plugins/modules/appliance_update_info.py
+++ b/plugins/modules/appliance_update_info.py
@@ -38,7 +38,7 @@ options:
         description:
         - 'You can use this optional parameter to set the location of a log file. '
         - 'This file will be used to record the HTTP REST interaction. '
-        - 'The file will be stored on the host that run the module. '
+        - 'The file will be stored on the host that runs the module. '
         - 'If the value is not specified in the task, the value of '
         - environment variable C(VMWARE_REST_LOG_FILE) will be used instead.
         type: str

--- a/plugins/modules/appliance_vmon_service.py
+++ b/plugins/modules/appliance_vmon_service.py
@@ -63,7 +63,7 @@ options:
         description:
         - 'You can use this optional parameter to set the location of a log file. '
         - 'This file will be used to record the HTTP REST interaction. '
-        - 'The file will be stored on the host that run the module. '
+        - 'The file will be stored on the host that runs the module. '
         - 'If the value is not specified in the task, the value of '
         - environment variable C(VMWARE_REST_LOG_FILE) will be used instead.
         type: str

--- a/plugins/modules/appliance_vmon_service_info.py
+++ b/plugins/modules/appliance_vmon_service_info.py
@@ -44,7 +44,7 @@ options:
         description:
         - 'You can use this optional parameter to set the location of a log file. '
         - 'This file will be used to record the HTTP REST interaction. '
-        - 'The file will be stored on the host that run the module. '
+        - 'The file will be stored on the host that runs the module. '
         - 'If the value is not specified in the task, the value of '
         - environment variable C(VMWARE_REST_LOG_FILE) will be used instead.
         type: str

--- a/plugins/modules/content_configuration.py
+++ b/plugins/modules/content_configuration.py
@@ -91,7 +91,7 @@ options:
         description:
         - 'You can use this optional parameter to set the location of a log file. '
         - 'This file will be used to record the HTTP REST interaction. '
-        - 'The file will be stored on the host that run the module. '
+        - 'The file will be stored on the host that runs the module. '
         - 'If the value is not specified in the task, the value of '
         - environment variable C(VMWARE_REST_LOG_FILE) will be used instead.
         type: str

--- a/plugins/modules/content_configuration_info.py
+++ b/plugins/modules/content_configuration_info.py
@@ -38,7 +38,7 @@ options:
         description:
         - 'You can use this optional parameter to set the location of a log file. '
         - 'This file will be used to record the HTTP REST interaction. '
-        - 'The file will be stored on the host that run the module. '
+        - 'The file will be stored on the host that runs the module. '
         - 'If the value is not specified in the task, the value of '
         - environment variable C(VMWARE_REST_LOG_FILE) will be used instead.
         type: str

--- a/plugins/modules/content_library_info.py
+++ b/plugins/modules/content_library_info.py
@@ -44,7 +44,7 @@ options:
         description:
         - 'You can use this optional parameter to set the location of a log file. '
         - 'This file will be used to record the HTTP REST interaction. '
-        - 'The file will be stored on the host that run the module. '
+        - 'The file will be stored on the host that runs the module. '
         - 'If the value is not specified in the task, the value of '
         - environment variable C(VMWARE_REST_LOG_FILE) will be used instead.
         type: str

--- a/plugins/modules/content_library_item_info.py
+++ b/plugins/modules/content_library_item_info.py
@@ -50,7 +50,7 @@ options:
         description:
         - 'You can use this optional parameter to set the location of a log file. '
         - 'This file will be used to record the HTTP REST interaction. '
-        - 'The file will be stored on the host that run the module. '
+        - 'The file will be stored on the host that runs the module. '
         - 'If the value is not specified in the task, the value of '
         - environment variable C(VMWARE_REST_LOG_FILE) will be used instead.
         type: str

--- a/plugins/modules/content_library_subscriptions_info.py
+++ b/plugins/modules/content_library_subscriptions_info.py
@@ -53,7 +53,7 @@ options:
         description:
         - 'You can use this optional parameter to set the location of a log file. '
         - 'This file will be used to record the HTTP REST interaction. '
-        - 'The file will be stored on the host that run the module. '
+        - 'The file will be stored on the host that runs the module. '
         - 'If the value is not specified in the task, the value of '
         - environment variable C(VMWARE_REST_LOG_FILE) will be used instead.
         type: str

--- a/plugins/modules/content_locallibrary.py
+++ b/plugins/modules/content_locallibrary.py
@@ -461,7 +461,7 @@ options:
         description:
         - 'You can use this optional parameter to set the location of a log file. '
         - 'This file will be used to record the HTTP REST interaction. '
-        - 'The file will be stored on the host that run the module. '
+        - 'The file will be stored on the host that runs the module. '
         - 'If the value is not specified in the task, the value of '
         - environment variable C(VMWARE_REST_LOG_FILE) will be used instead.
         type: str

--- a/plugins/modules/content_locallibrary_info.py
+++ b/plugins/modules/content_locallibrary_info.py
@@ -44,7 +44,7 @@ options:
         description:
         - 'You can use this optional parameter to set the location of a log file. '
         - 'This file will be used to record the HTTP REST interaction. '
-        - 'The file will be stored on the host that run the module. '
+        - 'The file will be stored on the host that runs the module. '
         - 'If the value is not specified in the task, the value of '
         - environment variable C(VMWARE_REST_LOG_FILE) will be used instead.
         type: str

--- a/plugins/modules/content_subscribedlibrary.py
+++ b/plugins/modules/content_subscribedlibrary.py
@@ -452,7 +452,7 @@ options:
         description:
         - 'You can use this optional parameter to set the location of a log file. '
         - 'This file will be used to record the HTTP REST interaction. '
-        - 'The file will be stored on the host that run the module. '
+        - 'The file will be stored on the host that runs the module. '
         - 'If the value is not specified in the task, the value of '
         - environment variable C(VMWARE_REST_LOG_FILE) will be used instead.
         type: str

--- a/plugins/modules/content_subscribedlibrary_info.py
+++ b/plugins/modules/content_subscribedlibrary_info.py
@@ -44,7 +44,7 @@ options:
         description:
         - 'You can use this optional parameter to set the location of a log file. '
         - 'This file will be used to record the HTTP REST interaction. '
-        - 'The file will be stored on the host that run the module. '
+        - 'The file will be stored on the host that runs the module. '
         - 'If the value is not specified in the task, the value of '
         - environment variable C(VMWARE_REST_LOG_FILE) will be used instead.
         type: str

--- a/plugins/modules/vcenter_cluster_info.py
+++ b/plugins/modules/vcenter_cluster_info.py
@@ -80,7 +80,7 @@ options:
         description:
         - 'You can use this optional parameter to set the location of a log file. '
         - 'This file will be used to record the HTTP REST interaction. '
-        - 'The file will be stored on the host that run the module. '
+        - 'The file will be stored on the host that runs the module. '
         - 'If the value is not specified in the task, the value of '
         - environment variable C(VMWARE_REST_LOG_FILE) will be used instead.
         type: str

--- a/plugins/modules/vcenter_datacenter.py
+++ b/plugins/modules/vcenter_datacenter.py
@@ -70,7 +70,7 @@ options:
         description:
         - 'You can use this optional parameter to set the location of a log file. '
         - 'This file will be used to record the HTTP REST interaction. '
-        - 'The file will be stored on the host that run the module. '
+        - 'The file will be stored on the host that runs the module. '
         - 'If the value is not specified in the task, the value of '
         - environment variable C(VMWARE_REST_LOG_FILE) will be used instead.
         type: str

--- a/plugins/modules/vcenter_datacenter_info.py
+++ b/plugins/modules/vcenter_datacenter_info.py
@@ -73,7 +73,7 @@ options:
         description:
         - 'You can use this optional parameter to set the location of a log file. '
         - 'This file will be used to record the HTTP REST interaction. '
-        - 'The file will be stored on the host that run the module. '
+        - 'The file will be stored on the host that runs the module. '
         - 'If the value is not specified in the task, the value of '
         - environment variable C(VMWARE_REST_LOG_FILE) will be used instead.
         type: str

--- a/plugins/modules/vcenter_datastore_info.py
+++ b/plugins/modules/vcenter_datastore_info.py
@@ -89,7 +89,7 @@ options:
         description:
         - 'You can use this optional parameter to set the location of a log file. '
         - 'This file will be used to record the HTTP REST interaction. '
-        - 'The file will be stored on the host that run the module. '
+        - 'The file will be stored on the host that runs the module. '
         - 'If the value is not specified in the task, the value of '
         - environment variable C(VMWARE_REST_LOG_FILE) will be used instead.
         type: str

--- a/plugins/modules/vcenter_folder_info.py
+++ b/plugins/modules/vcenter_folder_info.py
@@ -90,7 +90,7 @@ options:
         description:
         - 'You can use this optional parameter to set the location of a log file. '
         - 'This file will be used to record the HTTP REST interaction. '
-        - 'The file will be stored on the host that run the module. '
+        - 'The file will be stored on the host that runs the module. '
         - 'If the value is not specified in the task, the value of '
         - environment variable C(VMWARE_REST_LOG_FILE) will be used instead.
         type: str

--- a/plugins/modules/vcenter_host.py
+++ b/plugins/modules/vcenter_host.py
@@ -108,7 +108,7 @@ options:
         description:
         - 'You can use this optional parameter to set the location of a log file. '
         - 'This file will be used to record the HTTP REST interaction. '
-        - 'The file will be stored on the host that run the module. '
+        - 'The file will be stored on the host that runs the module. '
         - 'If the value is not specified in the task, the value of '
         - environment variable C(VMWARE_REST_LOG_FILE) will be used instead.
         type: str

--- a/plugins/modules/vcenter_host_info.py
+++ b/plugins/modules/vcenter_host_info.py
@@ -101,7 +101,7 @@ options:
         description:
         - 'You can use this optional parameter to set the location of a log file. '
         - 'This file will be used to record the HTTP REST interaction. '
-        - 'The file will be stored on the host that run the module. '
+        - 'The file will be stored on the host that runs the module. '
         - 'If the value is not specified in the task, the value of '
         - environment variable C(VMWARE_REST_LOG_FILE) will be used instead.
         type: str

--- a/plugins/modules/vcenter_network_info.py
+++ b/plugins/modules/vcenter_network_info.py
@@ -84,7 +84,7 @@ options:
         description:
         - 'You can use this optional parameter to set the location of a log file. '
         - 'This file will be used to record the HTTP REST interaction. '
-        - 'The file will be stored on the host that run the module. '
+        - 'The file will be stored on the host that runs the module. '
         - 'If the value is not specified in the task, the value of '
         - environment variable C(VMWARE_REST_LOG_FILE) will be used instead.
         type: str

--- a/plugins/modules/vcenter_ovf_libraryitem.py
+++ b/plugins/modules/vcenter_ovf_libraryitem.py
@@ -230,7 +230,7 @@ options:
         description:
         - 'You can use this optional parameter to set the location of a log file. '
         - 'This file will be used to record the HTTP REST interaction. '
-        - 'The file will be stored on the host that run the module. '
+        - 'The file will be stored on the host that runs the module. '
         - 'If the value is not specified in the task, the value of '
         - environment variable C(VMWARE_REST_LOG_FILE) will be used instead.
         type: str

--- a/plugins/modules/vcenter_resourcepool.py
+++ b/plugins/modules/vcenter_resourcepool.py
@@ -144,7 +144,7 @@ options:
         description:
         - 'You can use this optional parameter to set the location of a log file. '
         - 'This file will be used to record the HTTP REST interaction. '
-        - 'The file will be stored on the host that run the module. '
+        - 'The file will be stored on the host that runs the module. '
         - 'If the value is not specified in the task, the value of '
         - environment variable C(VMWARE_REST_LOG_FILE) will be used instead.
         type: str

--- a/plugins/modules/vcenter_resourcepool_info.py
+++ b/plugins/modules/vcenter_resourcepool_info.py
@@ -98,7 +98,7 @@ options:
         description:
         - 'You can use this optional parameter to set the location of a log file. '
         - 'This file will be used to record the HTTP REST interaction. '
-        - 'The file will be stored on the host that run the module. '
+        - 'The file will be stored on the host that runs the module. '
         - 'If the value is not specified in the task, the value of '
         - environment variable C(VMWARE_REST_LOG_FILE) will be used instead.
         type: str

--- a/plugins/modules/vcenter_storage_policies_info.py
+++ b/plugins/modules/vcenter_storage_policies_info.py
@@ -49,7 +49,7 @@ options:
         description:
         - 'You can use this optional parameter to set the location of a log file. '
         - 'This file will be used to record the HTTP REST interaction. '
-        - 'The file will be stored on the host that run the module. '
+        - 'The file will be stored on the host that runs the module. '
         - 'If the value is not specified in the task, the value of '
         - environment variable C(VMWARE_REST_LOG_FILE) will be used instead.
         type: str

--- a/plugins/modules/vcenter_vm.py
+++ b/plugins/modules/vcenter_vm.py
@@ -978,7 +978,7 @@ options:
         description:
         - 'You can use this optional parameter to set the location of a log file. '
         - 'This file will be used to record the HTTP REST interaction. '
-        - 'The file will be stored on the host that run the module. '
+        - 'The file will be stored on the host that runs the module. '
         - 'If the value is not specified in the task, the value of '
         - environment variable C(VMWARE_REST_LOG_FILE) will be used instead.
         type: str

--- a/plugins/modules/vcenter_vm_guest_customization.py
+++ b/plugins/modules/vcenter_vm_guest_customization.py
@@ -190,7 +190,7 @@ options:
         description:
         - 'You can use this optional parameter to set the location of a log file. '
         - 'This file will be used to record the HTTP REST interaction. '
-        - 'The file will be stored on the host that run the module. '
+        - 'The file will be stored on the host that runs the module. '
         - 'If the value is not specified in the task, the value of '
         - environment variable C(VMWARE_REST_LOG_FILE) will be used instead.
         type: str
@@ -241,7 +241,7 @@ EXAMPLES = r"""
 #
 ##########
 
-# Heres the basic workflow for creating a new VM and then customizing it
+# Here is the basic workflow for creating a new VM and then customizing it
 - name: Deploy a new VM based on a template
   vmware.vmware_rest.vcenter_vmtemplate_libraryitems:
     name: vm-from-template
@@ -274,59 +274,59 @@ EXAMPLES = r"""
 
 - name: Customize the VM
   vmware.vmware_rest.vcenter_vm_guest_customization:
-  vm: "{{ my_new_vm.id }}"
-  global_DNS_settings:
-    dns_suffix_list:
-      - lan
-      - foo.internal
-    dns_servers:
-      - "8.8.8.8"
-  interfaces:
-    - adapter:
-        ipv4:
-          type: DHCP
-  configuration_spec:
-    linux_config:
-      domain: test
-      hostname:
-        fixed_name: myhost
-        type: FIXED
+    vm: "{{ my_new_vm.id }}"
+    global_DNS_settings:
+      dns_suffix_list:
+        - lan
+        - foo.internal
+      dns_servers:
+        - "8.8.8.8"
+    interfaces:
+      - adapter:
+          ipv4:
+            type: DHCP
+    configuration_spec:
+      linux_config:
+        domain: test
+        hostname:
+          fixed_name: myhost
+          type: FIXED
 
-# Heres an example using the Linux script text. The script shebang can be anything (bash, perl, python), so long as the script will actually run
-# Theres also size and length limitation on the script text, as described in the module documentation.
+# Here is an example using the Linux script text. The script shebang can be anything (bash, perl, python), so long as the script will actually run
+# There is also size and length limitation on the script text, as described in the module documentation.
 # Finally, note the script is run twice. Once before all of the other customization and once after.
 - name: Customize the VM
   vmware.vmware_rest.vcenter_vm_guest_customization:
-  vm: "{{ my_new_vm.id }}"
-  global_DNS_settings:
-    dns_suffix_list:
-      - lan
-      - foo.internal
-    dns_servers:
-      - "8.8.8.8"
-  interfaces:
-    - adapter:
-        ipv4:
-          type: DHCP
-  configuration_spec:
-    linux_config:
-      domain: test
-      hostname:
-        fixed_name: myhost
-        type: FIXED
-      script_text: |
-        #!/bin/sh
-        if [ x$1 == x"precustomization" ]; then
-          echo "PRE" >> /tmp/vmware_rest_init_script.log
-          # add any other pre-customization tasks here
-        fi
+    vm: "{{ my_new_vm.id }}"
+    global_DNS_settings:
+      dns_suffix_list:
+        - lan
+        - foo.internal
+      dns_servers:
+        - "8.8.8.8"
+    interfaces:
+      - adapter:
+          ipv4:
+            type: DHCP
+    configuration_spec:
+      linux_config:
+        domain: test
+        hostname:
+          fixed_name: myhost
+          type: FIXED
+        script_text: |
+          #!/bin/sh
+          if [ x$1 == x"precustomization" ]; then
+            echo "PRE" >> /tmp/vmware_rest_init_script.log
+            # add any other pre-customization tasks here
+          fi
 
-        if [ x$1 == x"postcustomization" ]; then
-          echo "POST" >> /tmp/vmware_rest_init_script.log
-          # add any other post-customization tasks here
-        fi
+          if [ x$1 == x"postcustomization" ]; then
+            echo "POST" >> /tmp/vmware_rest_init_script.log
+            # add any other post-customization tasks here
+          fi
 
-# Heres a simple example using cloud-init
+# Here is a simple example using cloud-init
 # See also:
 #   https://developer.broadcom.com/xapis/vsphere-automation-api/latest/vcenter/data-structures/Guest_CloudinitConfiguration/
 #   https://knowledge.broadcom.com/external/article/311895/how-to-customize-virtual-machine-using-c.html
@@ -337,33 +337,33 @@ EXAMPLES = r"""
 #   cloud-init optional: userdata as plain-text in raw cloud-init format with no compression / no base64 encoding, maximum 512KB file size
 - name: Customize the VM
   vmware.vmware_rest.vcenter_vm_guest_customization:
-  vm: "{{ my_new_vm.id }}"
-  global_DNS_settings:
-    dns_suffix_list: []
-    dns_servers:
-      - "8.8.8.8"
-  interfaces:
-    - adapter:
-        ipv4:
-        type: DHCP
-  configuration_spec:
-    cloud_config:
-      type: CLOUDINIT
-      cloudinit:
-        metadata: |
-          instance-id: cloud-vm-example-1
-          local-hostname: cloud-vm
-          network:
-            config: disabled
-        userdata: |
-          #cloud-config
-          disable_root: 0
-          write_files:
-            - content: |
-                This is a test
-              path: /root/cloud-init-example
+    vm: "{{ my_new_vm.id }}"
+    global_DNS_settings:
+      dns_suffix_list: []
+      dns_servers:
+        - "8.8.8.8"
+    interfaces:
+      - adapter:
+          ipv4:
+            type: DHCP
+    configuration_spec:
+      cloud_config:
+        type: CLOUDINIT
+        cloudinit:
+          metadata: |
+            instance-id: cloud-vm-example-1
+            local-hostname: cloud-vm
+            network:
+              config: disabled
+          userdata: |
+            #cloud-config
+            disable_root: 0
+            write_files:
+              - content: |
+                  This is a test
+                path: /root/cloud-init-example
 
-# Heres a more complex cloud-init example
+# Here is a more complex cloud-init example
 - name: Set cloud-init variables for customization specification
   ansible.builtin.set_fact:
     metadata_yaml:

--- a/plugins/modules/vcenter_vm_guest_filesystem_directories.py
+++ b/plugins/modules/vcenter_vm_guest_filesystem_directories.py
@@ -115,7 +115,7 @@ options:
         description:
         - 'You can use this optional parameter to set the location of a log file. '
         - 'This file will be used to record the HTTP REST interaction. '
-        - 'The file will be stored on the host that run the module. '
+        - 'The file will be stored on the host that runs the module. '
         - 'If the value is not specified in the task, the value of '
         - environment variable C(VMWARE_REST_LOG_FILE) will be used instead.
         type: str

--- a/plugins/modules/vcenter_vm_guest_identity_info.py
+++ b/plugins/modules/vcenter_vm_guest_identity_info.py
@@ -38,7 +38,7 @@ options:
         description:
         - 'You can use this optional parameter to set the location of a log file. '
         - 'This file will be used to record the HTTP REST interaction. '
-        - 'The file will be stored on the host that run the module. '
+        - 'The file will be stored on the host that runs the module. '
         - 'If the value is not specified in the task, the value of '
         - environment variable C(VMWARE_REST_LOG_FILE) will be used instead.
         type: str

--- a/plugins/modules/vcenter_vm_guest_localfilesystem_info.py
+++ b/plugins/modules/vcenter_vm_guest_localfilesystem_info.py
@@ -39,7 +39,7 @@ options:
         description:
         - 'You can use this optional parameter to set the location of a log file. '
         - 'This file will be used to record the HTTP REST interaction. '
-        - 'The file will be stored on the host that run the module. '
+        - 'The file will be stored on the host that runs the module. '
         - 'If the value is not specified in the task, the value of '
         - environment variable C(VMWARE_REST_LOG_FILE) will be used instead.
         type: str

--- a/plugins/modules/vcenter_vm_guest_networking_info.py
+++ b/plugins/modules/vcenter_vm_guest_networking_info.py
@@ -40,7 +40,7 @@ options:
         description:
         - 'You can use this optional parameter to set the location of a log file. '
         - 'This file will be used to record the HTTP REST interaction. '
-        - 'The file will be stored on the host that run the module. '
+        - 'The file will be stored on the host that runs the module. '
         - 'If the value is not specified in the task, the value of '
         - environment variable C(VMWARE_REST_LOG_FILE) will be used instead.
         type: str

--- a/plugins/modules/vcenter_vm_guest_networking_interfaces_info.py
+++ b/plugins/modules/vcenter_vm_guest_networking_interfaces_info.py
@@ -40,7 +40,7 @@ options:
         description:
         - 'You can use this optional parameter to set the location of a log file. '
         - 'This file will be used to record the HTTP REST interaction. '
-        - 'The file will be stored on the host that run the module. '
+        - 'The file will be stored on the host that runs the module. '
         - 'If the value is not specified in the task, the value of '
         - environment variable C(VMWARE_REST_LOG_FILE) will be used instead.
         type: str

--- a/plugins/modules/vcenter_vm_guest_networking_routes_info.py
+++ b/plugins/modules/vcenter_vm_guest_networking_routes_info.py
@@ -39,7 +39,7 @@ options:
         description:
         - 'You can use this optional parameter to set the location of a log file. '
         - 'This file will be used to record the HTTP REST interaction. '
-        - 'The file will be stored on the host that run the module. '
+        - 'The file will be stored on the host that runs the module. '
         - 'If the value is not specified in the task, the value of '
         - environment variable C(VMWARE_REST_LOG_FILE) will be used instead.
         type: str

--- a/plugins/modules/vcenter_vm_guest_operations_info.py
+++ b/plugins/modules/vcenter_vm_guest_operations_info.py
@@ -38,7 +38,7 @@ options:
         description:
         - 'You can use this optional parameter to set the location of a log file. '
         - 'This file will be used to record the HTTP REST interaction. '
-        - 'The file will be stored on the host that run the module. '
+        - 'The file will be stored on the host that runs the module. '
         - 'If the value is not specified in the task, the value of '
         - environment variable C(VMWARE_REST_LOG_FILE) will be used instead.
         type: str

--- a/plugins/modules/vcenter_vm_guest_power.py
+++ b/plugins/modules/vcenter_vm_guest_power.py
@@ -49,7 +49,7 @@ options:
         description:
         - 'You can use this optional parameter to set the location of a log file. '
         - 'This file will be used to record the HTTP REST interaction. '
-        - 'The file will be stored on the host that run the module. '
+        - 'The file will be stored on the host that runs the module. '
         - 'If the value is not specified in the task, the value of '
         - environment variable C(VMWARE_REST_LOG_FILE) will be used instead.
         type: str

--- a/plugins/modules/vcenter_vm_guest_power_info.py
+++ b/plugins/modules/vcenter_vm_guest_power_info.py
@@ -38,7 +38,7 @@ options:
         description:
         - 'You can use this optional parameter to set the location of a log file. '
         - 'This file will be used to record the HTTP REST interaction. '
-        - 'The file will be stored on the host that run the module. '
+        - 'The file will be stored on the host that runs the module. '
         - 'If the value is not specified in the task, the value of '
         - environment variable C(VMWARE_REST_LOG_FILE) will be used instead.
         type: str

--- a/plugins/modules/vcenter_vm_hardware.py
+++ b/plugins/modules/vcenter_vm_hardware.py
@@ -79,7 +79,7 @@ options:
         description:
         - 'You can use this optional parameter to set the location of a log file. '
         - 'This file will be used to record the HTTP REST interaction. '
-        - 'The file will be stored on the host that run the module. '
+        - 'The file will be stored on the host that runs the module. '
         - 'If the value is not specified in the task, the value of '
         - environment variable C(VMWARE_REST_LOG_FILE) will be used instead.
         type: str

--- a/plugins/modules/vcenter_vm_hardware_adapter_sata.py
+++ b/plugins/modules/vcenter_vm_hardware_adapter_sata.py
@@ -75,7 +75,7 @@ options:
         description:
         - 'You can use this optional parameter to set the location of a log file. '
         - 'This file will be used to record the HTTP REST interaction. '
-        - 'The file will be stored on the host that run the module. '
+        - 'The file will be stored on the host that runs the module. '
         - 'If the value is not specified in the task, the value of '
         - environment variable C(VMWARE_REST_LOG_FILE) will be used instead.
         type: str

--- a/plugins/modules/vcenter_vm_hardware_adapter_sata_info.py
+++ b/plugins/modules/vcenter_vm_hardware_adapter_sata_info.py
@@ -48,7 +48,7 @@ options:
         description:
         - 'You can use this optional parameter to set the location of a log file. '
         - 'This file will be used to record the HTTP REST interaction. '
-        - 'The file will be stored on the host that run the module. '
+        - 'The file will be stored on the host that runs the module. '
         - 'If the value is not specified in the task, the value of '
         - environment variable C(VMWARE_REST_LOG_FILE) will be used instead.
         type: str

--- a/plugins/modules/vcenter_vm_hardware_adapter_scsi.py
+++ b/plugins/modules/vcenter_vm_hardware_adapter_scsi.py
@@ -89,7 +89,7 @@ options:
         description:
         - 'You can use this optional parameter to set the location of a log file. '
         - 'This file will be used to record the HTTP REST interaction. '
-        - 'The file will be stored on the host that run the module. '
+        - 'The file will be stored on the host that runs the module. '
         - 'If the value is not specified in the task, the value of '
         - environment variable C(VMWARE_REST_LOG_FILE) will be used instead.
         type: str

--- a/plugins/modules/vcenter_vm_hardware_adapter_scsi_info.py
+++ b/plugins/modules/vcenter_vm_hardware_adapter_scsi_info.py
@@ -48,7 +48,7 @@ options:
         description:
         - 'You can use this optional parameter to set the location of a log file. '
         - 'This file will be used to record the HTTP REST interaction. '
-        - 'The file will be stored on the host that run the module. '
+        - 'The file will be stored on the host that runs the module. '
         - 'If the value is not specified in the task, the value of '
         - environment variable C(VMWARE_REST_LOG_FILE) will be used instead.
         type: str

--- a/plugins/modules/vcenter_vm_hardware_boot.py
+++ b/plugins/modules/vcenter_vm_hardware_boot.py
@@ -93,7 +93,7 @@ options:
         description:
         - 'You can use this optional parameter to set the location of a log file. '
         - 'This file will be used to record the HTTP REST interaction. '
-        - 'The file will be stored on the host that run the module. '
+        - 'The file will be stored on the host that runs the module. '
         - 'If the value is not specified in the task, the value of '
         - environment variable C(VMWARE_REST_LOG_FILE) will be used instead.
         type: str

--- a/plugins/modules/vcenter_vm_hardware_boot_device.py
+++ b/plugins/modules/vcenter_vm_hardware_boot_device.py
@@ -78,7 +78,7 @@ options:
         description:
         - 'You can use this optional parameter to set the location of a log file. '
         - 'This file will be used to record the HTTP REST interaction. '
-        - 'The file will be stored on the host that run the module. '
+        - 'The file will be stored on the host that runs the module. '
         - 'If the value is not specified in the task, the value of '
         - environment variable C(VMWARE_REST_LOG_FILE) will be used instead.
         type: str

--- a/plugins/modules/vcenter_vm_hardware_boot_device_info.py
+++ b/plugins/modules/vcenter_vm_hardware_boot_device_info.py
@@ -39,7 +39,7 @@ options:
         description:
         - 'You can use this optional parameter to set the location of a log file. '
         - 'This file will be used to record the HTTP REST interaction. '
-        - 'The file will be stored on the host that run the module. '
+        - 'The file will be stored on the host that runs the module. '
         - 'If the value is not specified in the task, the value of '
         - environment variable C(VMWARE_REST_LOG_FILE) will be used instead.
         type: str

--- a/plugins/modules/vcenter_vm_hardware_boot_info.py
+++ b/plugins/modules/vcenter_vm_hardware_boot_info.py
@@ -38,7 +38,7 @@ options:
         description:
         - 'You can use this optional parameter to set the location of a log file. '
         - 'This file will be used to record the HTTP REST interaction. '
-        - 'The file will be stored on the host that run the module. '
+        - 'The file will be stored on the host that runs the module. '
         - 'If the value is not specified in the task, the value of '
         - environment variable C(VMWARE_REST_LOG_FILE) will be used instead.
         type: str

--- a/plugins/modules/vcenter_vm_hardware_cdrom.py
+++ b/plugins/modules/vcenter_vm_hardware_cdrom.py
@@ -134,7 +134,7 @@ options:
         description:
         - 'You can use this optional parameter to set the location of a log file. '
         - 'This file will be used to record the HTTP REST interaction. '
-        - 'The file will be stored on the host that run the module. '
+        - 'The file will be stored on the host that runs the module. '
         - 'If the value is not specified in the task, the value of '
         - environment variable C(VMWARE_REST_LOG_FILE) will be used instead.
         type: str

--- a/plugins/modules/vcenter_vm_hardware_cdrom_info.py
+++ b/plugins/modules/vcenter_vm_hardware_cdrom_info.py
@@ -48,7 +48,7 @@ options:
         description:
         - 'You can use this optional parameter to set the location of a log file. '
         - 'This file will be used to record the HTTP REST interaction. '
-        - 'The file will be stored on the host that run the module. '
+        - 'The file will be stored on the host that runs the module. '
         - 'If the value is not specified in the task, the value of '
         - environment variable C(VMWARE_REST_LOG_FILE) will be used instead.
         type: str

--- a/plugins/modules/vcenter_vm_hardware_cpu.py
+++ b/plugins/modules/vcenter_vm_hardware_cpu.py
@@ -79,7 +79,7 @@ options:
         description:
         - 'You can use this optional parameter to set the location of a log file. '
         - 'This file will be used to record the HTTP REST interaction. '
-        - 'The file will be stored on the host that run the module. '
+        - 'The file will be stored on the host that runs the module. '
         - 'If the value is not specified in the task, the value of '
         - environment variable C(VMWARE_REST_LOG_FILE) will be used instead.
         type: str

--- a/plugins/modules/vcenter_vm_hardware_cpu_info.py
+++ b/plugins/modules/vcenter_vm_hardware_cpu_info.py
@@ -38,7 +38,7 @@ options:
         description:
         - 'You can use this optional parameter to set the location of a log file. '
         - 'This file will be used to record the HTTP REST interaction. '
-        - 'The file will be stored on the host that run the module. '
+        - 'The file will be stored on the host that runs the module. '
         - 'If the value is not specified in the task, the value of '
         - environment variable C(VMWARE_REST_LOG_FILE) will be used instead.
         type: str

--- a/plugins/modules/vcenter_vm_hardware_disk.py
+++ b/plugins/modules/vcenter_vm_hardware_disk.py
@@ -166,7 +166,7 @@ options:
         description:
         - 'You can use this optional parameter to set the location of a log file. '
         - 'This file will be used to record the HTTP REST interaction. '
-        - 'The file will be stored on the host that run the module. '
+        - 'The file will be stored on the host that runs the module. '
         - 'If the value is not specified in the task, the value of '
         - environment variable C(VMWARE_REST_LOG_FILE) will be used instead.
         type: str

--- a/plugins/modules/vcenter_vm_hardware_disk_info.py
+++ b/plugins/modules/vcenter_vm_hardware_disk_info.py
@@ -48,7 +48,7 @@ options:
         description:
         - 'You can use this optional parameter to set the location of a log file. '
         - 'This file will be used to record the HTTP REST interaction. '
-        - 'The file will be stored on the host that run the module. '
+        - 'The file will be stored on the host that runs the module. '
         - 'If the value is not specified in the task, the value of '
         - environment variable C(VMWARE_REST_LOG_FILE) will be used instead.
         type: str

--- a/plugins/modules/vcenter_vm_hardware_ethernet.py
+++ b/plugins/modules/vcenter_vm_hardware_ethernet.py
@@ -151,7 +151,7 @@ options:
         description:
         - 'You can use this optional parameter to set the location of a log file. '
         - 'This file will be used to record the HTTP REST interaction. '
-        - 'The file will be stored on the host that run the module. '
+        - 'The file will be stored on the host that runs the module. '
         - 'If the value is not specified in the task, the value of '
         - environment variable C(VMWARE_REST_LOG_FILE) will be used instead.
         type: str

--- a/plugins/modules/vcenter_vm_hardware_ethernet_info.py
+++ b/plugins/modules/vcenter_vm_hardware_ethernet_info.py
@@ -48,7 +48,7 @@ options:
         description:
         - 'You can use this optional parameter to set the location of a log file. '
         - 'This file will be used to record the HTTP REST interaction. '
-        - 'The file will be stored on the host that run the module. '
+        - 'The file will be stored on the host that runs the module. '
         - 'If the value is not specified in the task, the value of '
         - environment variable C(VMWARE_REST_LOG_FILE) will be used instead.
         type: str

--- a/plugins/modules/vcenter_vm_hardware_floppy.py
+++ b/plugins/modules/vcenter_vm_hardware_floppy.py
@@ -90,7 +90,7 @@ options:
         description:
         - 'You can use this optional parameter to set the location of a log file. '
         - 'This file will be used to record the HTTP REST interaction. '
-        - 'The file will be stored on the host that run the module. '
+        - 'The file will be stored on the host that runs the module. '
         - 'If the value is not specified in the task, the value of '
         - environment variable C(VMWARE_REST_LOG_FILE) will be used instead.
         type: str

--- a/plugins/modules/vcenter_vm_hardware_floppy_info.py
+++ b/plugins/modules/vcenter_vm_hardware_floppy_info.py
@@ -48,7 +48,7 @@ options:
         description:
         - 'You can use this optional parameter to set the location of a log file. '
         - 'This file will be used to record the HTTP REST interaction. '
-        - 'The file will be stored on the host that run the module. '
+        - 'The file will be stored on the host that runs the module. '
         - 'If the value is not specified in the task, the value of '
         - environment variable C(VMWARE_REST_LOG_FILE) will be used instead.
         type: str

--- a/plugins/modules/vcenter_vm_hardware_info.py
+++ b/plugins/modules/vcenter_vm_hardware_info.py
@@ -38,7 +38,7 @@ options:
         description:
         - 'You can use this optional parameter to set the location of a log file. '
         - 'This file will be used to record the HTTP REST interaction. '
-        - 'The file will be stored on the host that run the module. '
+        - 'The file will be stored on the host that runs the module. '
         - 'If the value is not specified in the task, the value of '
         - environment variable C(VMWARE_REST_LOG_FILE) will be used instead.
         type: str

--- a/plugins/modules/vcenter_vm_hardware_memory.py
+++ b/plugins/modules/vcenter_vm_hardware_memory.py
@@ -69,7 +69,7 @@ options:
         description:
         - 'You can use this optional parameter to set the location of a log file. '
         - 'This file will be used to record the HTTP REST interaction. '
-        - 'The file will be stored on the host that run the module. '
+        - 'The file will be stored on the host that runs the module. '
         - 'If the value is not specified in the task, the value of '
         - environment variable C(VMWARE_REST_LOG_FILE) will be used instead.
         type: str

--- a/plugins/modules/vcenter_vm_hardware_memory_info.py
+++ b/plugins/modules/vcenter_vm_hardware_memory_info.py
@@ -38,7 +38,7 @@ options:
         description:
         - 'You can use this optional parameter to set the location of a log file. '
         - 'This file will be used to record the HTTP REST interaction. '
-        - 'The file will be stored on the host that run the module. '
+        - 'The file will be stored on the host that runs the module. '
         - 'If the value is not specified in the task, the value of '
         - environment variable C(VMWARE_REST_LOG_FILE) will be used instead.
         type: str

--- a/plugins/modules/vcenter_vm_hardware_parallel.py
+++ b/plugins/modules/vcenter_vm_hardware_parallel.py
@@ -89,7 +89,7 @@ options:
         description:
         - 'You can use this optional parameter to set the location of a log file. '
         - 'This file will be used to record the HTTP REST interaction. '
-        - 'The file will be stored on the host that run the module. '
+        - 'The file will be stored on the host that runs the module. '
         - 'If the value is not specified in the task, the value of '
         - environment variable C(VMWARE_REST_LOG_FILE) will be used instead.
         type: str

--- a/plugins/modules/vcenter_vm_hardware_parallel_info.py
+++ b/plugins/modules/vcenter_vm_hardware_parallel_info.py
@@ -48,7 +48,7 @@ options:
         description:
         - 'You can use this optional parameter to set the location of a log file. '
         - 'This file will be used to record the HTTP REST interaction. '
-        - 'The file will be stored on the host that run the module. '
+        - 'The file will be stored on the host that runs the module. '
         - 'If the value is not specified in the task, the value of '
         - environment variable C(VMWARE_REST_LOG_FILE) will be used instead.
         type: str

--- a/plugins/modules/vcenter_vm_hardware_serial.py
+++ b/plugins/modules/vcenter_vm_hardware_serial.py
@@ -117,7 +117,7 @@ options:
         description:
         - 'You can use this optional parameter to set the location of a log file. '
         - 'This file will be used to record the HTTP REST interaction. '
-        - 'The file will be stored on the host that run the module. '
+        - 'The file will be stored on the host that runs the module. '
         - 'If the value is not specified in the task, the value of '
         - environment variable C(VMWARE_REST_LOG_FILE) will be used instead.
         type: str

--- a/plugins/modules/vcenter_vm_hardware_serial_info.py
+++ b/plugins/modules/vcenter_vm_hardware_serial_info.py
@@ -48,7 +48,7 @@ options:
         description:
         - 'You can use this optional parameter to set the location of a log file. '
         - 'This file will be used to record the HTTP REST interaction. '
-        - 'The file will be stored on the host that run the module. '
+        - 'The file will be stored on the host that runs the module. '
         - 'If the value is not specified in the task, the value of '
         - environment variable C(VMWARE_REST_LOG_FILE) will be used instead.
         type: str

--- a/plugins/modules/vcenter_vm_info.py
+++ b/plugins/modules/vcenter_vm_info.py
@@ -102,7 +102,7 @@ options:
         description:
         - 'You can use this optional parameter to set the location of a log file. '
         - 'This file will be used to record the HTTP REST interaction. '
-        - 'The file will be stored on the host that run the module. '
+        - 'The file will be stored on the host that runs the module. '
         - 'If the value is not specified in the task, the value of '
         - environment variable C(VMWARE_REST_LOG_FILE) will be used instead.
         type: str

--- a/plugins/modules/vcenter_vm_libraryitem_info.py
+++ b/plugins/modules/vcenter_vm_libraryitem_info.py
@@ -40,7 +40,7 @@ options:
         description:
         - 'You can use this optional parameter to set the location of a log file. '
         - 'This file will be used to record the HTTP REST interaction. '
-        - 'The file will be stored on the host that run the module. '
+        - 'The file will be stored on the host that runs the module. '
         - 'If the value is not specified in the task, the value of '
         - environment variable C(VMWARE_REST_LOG_FILE) will be used instead.
         type: str

--- a/plugins/modules/vcenter_vm_power.py
+++ b/plugins/modules/vcenter_vm_power.py
@@ -48,7 +48,7 @@ options:
         description:
         - 'You can use this optional parameter to set the location of a log file. '
         - 'This file will be used to record the HTTP REST interaction. '
-        - 'The file will be stored on the host that run the module. '
+        - 'The file will be stored on the host that runs the module. '
         - 'If the value is not specified in the task, the value of '
         - environment variable C(VMWARE_REST_LOG_FILE) will be used instead.
         type: str

--- a/plugins/modules/vcenter_vm_power_info.py
+++ b/plugins/modules/vcenter_vm_power_info.py
@@ -38,7 +38,7 @@ options:
         description:
         - 'You can use this optional parameter to set the location of a log file. '
         - 'This file will be used to record the HTTP REST interaction. '
-        - 'The file will be stored on the host that run the module. '
+        - 'The file will be stored on the host that runs the module. '
         - 'If the value is not specified in the task, the value of '
         - environment variable C(VMWARE_REST_LOG_FILE) will be used instead.
         type: str

--- a/plugins/modules/vcenter_vm_storage_policy.py
+++ b/plugins/modules/vcenter_vm_storage_policy.py
@@ -54,7 +54,7 @@ options:
         description:
         - 'You can use this optional parameter to set the location of a log file. '
         - 'This file will be used to record the HTTP REST interaction. '
-        - 'The file will be stored on the host that run the module. '
+        - 'The file will be stored on the host that runs the module. '
         - 'If the value is not specified in the task, the value of '
         - environment variable C(VMWARE_REST_LOG_FILE) will be used instead.
         type: str

--- a/plugins/modules/vcenter_vm_storage_policy_compliance.py
+++ b/plugins/modules/vcenter_vm_storage_policy_compliance.py
@@ -55,7 +55,7 @@ options:
         description:
         - 'You can use this optional parameter to set the location of a log file. '
         - 'This file will be used to record the HTTP REST interaction. '
-        - 'The file will be stored on the host that run the module. '
+        - 'The file will be stored on the host that runs the module. '
         - 'If the value is not specified in the task, the value of '
         - environment variable C(VMWARE_REST_LOG_FILE) will be used instead.
         type: str

--- a/plugins/modules/vcenter_vm_storage_policy_compliance_info.py
+++ b/plugins/modules/vcenter_vm_storage_policy_compliance_info.py
@@ -40,7 +40,7 @@ options:
         description:
         - 'You can use this optional parameter to set the location of a log file. '
         - 'This file will be used to record the HTTP REST interaction. '
-        - 'The file will be stored on the host that run the module. '
+        - 'The file will be stored on the host that runs the module. '
         - 'If the value is not specified in the task, the value of '
         - environment variable C(VMWARE_REST_LOG_FILE) will be used instead.
         type: str

--- a/plugins/modules/vcenter_vm_storage_policy_info.py
+++ b/plugins/modules/vcenter_vm_storage_policy_info.py
@@ -40,7 +40,7 @@ options:
         description:
         - 'You can use this optional parameter to set the location of a log file. '
         - 'This file will be used to record the HTTP REST interaction. '
-        - 'The file will be stored on the host that run the module. '
+        - 'The file will be stored on the host that runs the module. '
         - 'If the value is not specified in the task, the value of '
         - environment variable C(VMWARE_REST_LOG_FILE) will be used instead.
         type: str

--- a/plugins/modules/vcenter_vm_tools.py
+++ b/plugins/modules/vcenter_vm_tools.py
@@ -59,7 +59,7 @@ options:
         description:
         - 'You can use this optional parameter to set the location of a log file. '
         - 'This file will be used to record the HTTP REST interaction. '
-        - 'The file will be stored on the host that run the module. '
+        - 'The file will be stored on the host that runs the module. '
         - 'If the value is not specified in the task, the value of '
         - environment variable C(VMWARE_REST_LOG_FILE) will be used instead.
         type: str

--- a/plugins/modules/vcenter_vm_tools_info.py
+++ b/plugins/modules/vcenter_vm_tools_info.py
@@ -38,7 +38,7 @@ options:
         description:
         - 'You can use this optional parameter to set the location of a log file. '
         - 'This file will be used to record the HTTP REST interaction. '
-        - 'The file will be stored on the host that run the module. '
+        - 'The file will be stored on the host that runs the module. '
         - 'If the value is not specified in the task, the value of '
         - environment variable C(VMWARE_REST_LOG_FILE) will be used instead.
         type: str

--- a/plugins/modules/vcenter_vm_tools_installer.py
+++ b/plugins/modules/vcenter_vm_tools_installer.py
@@ -53,7 +53,7 @@ options:
         description:
         - 'You can use this optional parameter to set the location of a log file. '
         - 'This file will be used to record the HTTP REST interaction. '
-        - 'The file will be stored on the host that run the module. '
+        - 'The file will be stored on the host that runs the module. '
         - 'If the value is not specified in the task, the value of '
         - environment variable C(VMWARE_REST_LOG_FILE) will be used instead.
         type: str

--- a/plugins/modules/vcenter_vm_tools_installer_info.py
+++ b/plugins/modules/vcenter_vm_tools_installer_info.py
@@ -38,7 +38,7 @@ options:
         description:
         - 'You can use this optional parameter to set the location of a log file. '
         - 'This file will be used to record the HTTP REST interaction. '
-        - 'The file will be stored on the host that run the module. '
+        - 'The file will be stored on the host that runs the module. '
         - 'If the value is not specified in the task, the value of '
         - environment variable C(VMWARE_REST_LOG_FILE) will be used instead.
         type: str

--- a/plugins/modules/vcenter_vmtemplate_libraryitems.py
+++ b/plugins/modules/vcenter_vmtemplate_libraryitems.py
@@ -270,7 +270,7 @@ options:
         description:
         - 'You can use this optional parameter to set the location of a log file. '
         - 'This file will be used to record the HTTP REST interaction. '
-        - 'The file will be stored on the host that run the module. '
+        - 'The file will be stored on the host that runs the module. '
         - 'If the value is not specified in the task, the value of '
         - environment variable C(VMWARE_REST_LOG_FILE) will be used instead.
         type: str

--- a/plugins/modules/vcenter_vmtemplate_libraryitems_info.py
+++ b/plugins/modules/vcenter_vmtemplate_libraryitems_info.py
@@ -46,7 +46,7 @@ options:
         description:
         - 'You can use this optional parameter to set the location of a log file. '
         - 'This file will be used to record the HTTP REST interaction. '
-        - 'The file will be stored on the host that run the module. '
+        - 'The file will be stored on the host that runs the module. '
         - 'If the value is not specified in the task, the value of '
         - environment variable C(VMWARE_REST_LOG_FILE) will be used instead.
         type: str


### PR DESCRIPTION
##### SUMMARY
Fixes some grammatical errors in the vcenter_rest_log_file parameter description.
Also fixes some typos and spacing issues in the customization module documentation

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
- vcenter_vm_guest_customization
- vcenter_rest_log_file param