### PR TITLE
fix nonsensical path results in lookup plugin

### DIFF
--- a/plugins/plugin_utils/lookup.py
+++ b/plugins/plugin_utils/lookup.py
@@ -187,22 +187,30 @@ class Lookup:
 
         # Resource pools can only be in the vm filter spec
         if self.object_type == "vm":
-            if self.__add_object_to_filter_spec_if_exists(intermediate_object_name, "resource_pool", "resource_pools"):
+            if self.__add_object_to_filter_spec_if_exists(
+                intermediate_object_name, "resource_pool", "resource_pools"
+            ):
                 return
 
         # Clusters can be used in the vm, host, or resource pool filter specs
         if self.object_type in ("vm", "host", "resource_pool"):
-            if self.__add_object_to_filter_spec_if_exists(intermediate_object_name, "cluster", "clusters"):
+            if self.__add_object_to_filter_spec_if_exists(
+                intermediate_object_name, "cluster", "clusters"
+            ):
                 return
 
         # Hosts can be in the filter spec for vms, networks, datastores, or resource pools
         if self.object_type in ("vm", "network", "datastore", "resource_pool"):
-            if self.__add_object_to_filter_spec_if_exists(intermediate_object_name, "host", "hosts"):
+            if self.__add_object_to_filter_spec_if_exists(
+                intermediate_object_name, "host", "hosts"
+            ):
                 return
 
         # Folders can be used in the filter spec for everything except resource pools
         if self.object_type != "resource_pool":
-            if self.__add_object_to_filter_spec_if_exists(intermediate_object_name, "folder", "parent_folders"):
+            if self.__add_object_to_filter_spec_if_exists(
+                intermediate_object_name, "folder", "parent_folders"
+            ):
                 return
 
         raise InvalidVspherePathError(
@@ -219,14 +227,14 @@ class Lookup:
             Datacenter MOID or None
         """
         self._searched_for_datacenter = True
-        result = await self.get_object_moid_by_name_and_type(
-            object_name, "datacenter"
-        )
+        result = await self.get_object_moid_by_name_and_type(object_name, "datacenter")
         if result:
             self.active_filters["datacenters"] = result
             return result
 
-    async def __add_object_to_filter_spec_if_exists(self, object_name, object_type, filter_key):
+    async def __add_object_to_filter_spec_if_exists(
+        self, object_name, object_type, filter_key
+    ):
         """
         Search for an object name as a specific object type. If found, add the object ID to the
         active filter spec.
@@ -237,9 +245,7 @@ class Lookup:
         Returns:
             Object MOID or None
         """
-        result = await self.get_object_moid_by_name_and_type(
-            object_name, object_type
-        )
+        result = await self.get_object_moid_by_name_and_type(object_name, object_type)
         if result:
             self.set_new_filters_with_datacenter({filter_key: result})
             return result

--- a/plugins/plugin_utils/lookup.py
+++ b/plugins/plugin_utils/lookup.py
@@ -103,7 +103,7 @@ class Lookup:
         self.object_type = options["object_type"]
         # this is an internal flag that indicates if we tried to find the datacenter or not
         # if its true, we stop trying and save some api calls.
-        # see process_intermediate_path_part
+        # see add_intermediate_path_part_to_filter_spec
         self._searched_for_datacenter = False
 
     @classmethod
@@ -151,7 +151,7 @@ class Lookup:
                 # were at the end of the object path. Either return the object, or return
                 # all of the objects it contains (for example, the children inside of a folder)
                 if return_all_children:
-                    await self.process_intermediate_path_part(path_part)
+                    await self.add_intermediate_path_part_to_filter_spec(path_part)
                     return await self.get_all_children_in_object()
                 else:
                     return await self.get_object_moid_by_name_and_type(path_part)
@@ -159,77 +159,90 @@ class Lookup:
             else:
                 # were in the middle of an object path, lookup the object at this level
                 # and add it to the filters for the next round of searching
-                await self.process_intermediate_path_part(path_part)
+                await self.add_intermediate_path_part_to_filter_spec(path_part)
                 continue
 
         raise AnsibleLookupError(
             "No objects could be found due to an invalid search path"
         )
 
-    async def process_intermediate_path_part(self, intermediate_object_name):
+    async def add_intermediate_path_part_to_filter_spec(self, intermediate_object_name):
         """
-        Finds and returns the MoID for an object in the middle of a search path. Different vSphere objects can be
-        children of other types of vSphere objects.
-          - VMs could be in a resource pool, a host, or a folder
-          - Networks could be in a host, or in a folder
-          - Hosts could be in a cluster, or in a folder
-          - Datastores could in a host, or in a folder
-          - Resource pools could be in a cluster, or a host
-        We start with the most restrictive searches and progressively expand the search area until something is found.
-        We also update the filters to include the proper object filter for the next round of searches.
+        The intermediate object name is part of the search path that the user provided. This method tries to determine
+        what that intermediate object is based on its name and the type of lookup were doing. If the object is found,
+        its added to the final lookup filter spec.
+        If no object is found, that means the path is invalid for the lookup type, and we raise an error.
+        To find an objects filter spec definition, visit the VMware API docs.
         Params:
             intermediate_object_name: str, The name of the current object to search for
         Returns:
-            str or None, a single MoID or none if nothing was found
+            None
         """
+        # If we havnt searched for a datacenter yet, this is the first item in the path and its likely
+        # the datacenter. If its not, continue the search as normal and dont search for the datacenter
+        # again
         if not self._searched_for_datacenter:
-            self._searched_for_datacenter = True
-            result = await self.get_object_moid_by_name_and_type(
-                intermediate_object_name, "datacenter"
-            )
-            if result:
-                self.active_filters["datacenters"] = result
-                return result
+            if self.__add_datacenter_to_filter_spec_if_exists(intermediate_object_name):
+                return
 
+        # Resource pools can only be in the vm filter spec
         if self.object_type == "vm":
-            result = await self.get_object_moid_by_name_and_type(
-                intermediate_object_name, "resource_pool"
-            )
-            if result:
-                self.set_new_filters_with_datacenter({"resource_pools": result})
-                return result
+            if self.__add_object_to_filter_spec_if_exists(intermediate_object_name, "resource_pool", "resource_pools"):
+                return
 
+        # Clusters can be used in the vm, host, or resource pool filter specs
         if self.object_type in ("vm", "host", "resource_pool"):
-            result = await self.get_object_moid_by_name_and_type(
-                intermediate_object_name, "cluster"
-            )
-            if result:
-                self.set_new_filters_with_datacenter({"clusters": result})
-                return result
+            if self.__add_object_to_filter_spec_if_exists(intermediate_object_name, "cluster", "clusters"):
+                return
 
+        # Hosts can be in the filter spec for vms, networks, datastores, or resource pools
         if self.object_type in ("vm", "network", "datastore", "resource_pool"):
-            result = await self.get_object_moid_by_name_and_type(
-                intermediate_object_name, "host"
-            )
-            if result:
-                self.set_new_filters_with_datacenter({"hosts": result})
-                return result
+            if self.__add_object_to_filter_spec_if_exists(intermediate_object_name, "host", "hosts"):
+                return
 
-        # resource pools cant continue past this point
-        if self.object_type == "resource_pool":
-            raise InvalidVspherePathError(
-                container_name=intermediate_object_name, object_type=self.object_type
-            )
+        # Folders can be used in the filter spec for everything except resource pools
+        if self.object_type != "resource_pool":
+            if self.__add_object_to_filter_spec_if_exists(intermediate_object_name, "folder", "parent_folders"):
+                return
 
-        result = await self.get_object_moid_by_name_and_type(
-            intermediate_object_name, "folder"
+        raise InvalidVspherePathError(
+            container_name=intermediate_object_name, object_type=self.object_type
         )
-        self.set_new_filters_with_datacenter({"parent_folders": result})
-        if not result:
-            raise InvalidVspherePathError(
-                container_name=intermediate_object_name, object_type=self.object_type
-            )
-        return result
+
+    async def __add_datacenter_to_filter_spec_if_exists(self, object_name):
+        """
+        Search for an object name as a datacenter. If found, add the datacenter to the
+        active filter spec.
+        Params:
+            object_name: str, The name of the current object to search for
+        Returns:
+            Datacenter MOID or None
+        """
+        self._searched_for_datacenter = True
+        result = await self.get_object_moid_by_name_and_type(
+            object_name, "datacenter"
+        )
+        if result:
+            self.active_filters["datacenters"] = result
+            return result
+
+    async def __add_object_to_filter_spec_if_exists(self, object_name, object_type, filter_key):
+        """
+        Search for an object name as a specific object type. If found, add the object ID to the
+        active filter spec.
+        Params:
+            object_name: str, The name of the current object to search for
+            object_type: str, The type of object to search for
+            filter_key: str, The key in the filter spec that the result will be stored under
+        Returns:
+            Object MOID or None
+        """
+        result = await self.get_object_moid_by_name_and_type(
+            object_name, object_type
+        )
+        if result:
+            self.set_new_filters_with_datacenter({filter_key: result})
+            return result
 
     async def get_object_moid_by_name_and_type(self, object_name, _object_type=None):
         """

--- a/plugins/plugin_utils/lookup.py
+++ b/plugins/plugin_utils/lookup.py
@@ -23,7 +23,8 @@ class InvalidVspherePathError(Exception):
         self.container_name = container_name
         self.object_type = object_type
         super().__init__(
-            "VSphere object '%s' cannot hold objects of type '%s'" % (container_name, object_type)
+            "VSphere object '%s' cannot hold objects of type '%s'"
+            % (container_name, object_type)
         )
 
 
@@ -216,14 +217,18 @@ class Lookup:
 
         # resource pools cant continue past this point
         if self.object_type == "resource_pool":
-            raise InvalidVspherePathError(container_name=intermediate_object_name, object_type=self.object_type)
+            raise InvalidVspherePathError(
+                container_name=intermediate_object_name, object_type=self.object_type
+            )
 
         result = await self.get_object_moid_by_name_and_type(
             intermediate_object_name, "folder"
         )
         self.set_new_filters_with_datacenter({"parent_folders": result})
         if not result:
-            raise InvalidVspherePathError(container_name=intermediate_object_name, object_type=self.object_type)
+            raise InvalidVspherePathError(
+                container_name=intermediate_object_name, object_type=self.object_type
+            )
         return result
 
     async def get_object_moid_by_name_and_type(self, object_name, _object_type=None):


### PR DESCRIPTION
##### SUMMARY
If someone specifies a path to an object (like a cluster) that cannot contain the lookup object, the plugin ignores the cluster name and just uses the datacenter as a filter.

Ideally, I think we would throw an error telling the user that they are searching for a path the doesnt make sense. But the old plugin output is just an empty string, so I am keeping that output.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
lookup plugins