### PR TITLE
deprecate content_library_item_info due to module generation issues

### DIFF
--- a/.github/workflows/docs-pr.yml
+++ b/.github/workflows/docs-pr.yml
@@ -25,6 +25,7 @@ jobs:
         ansible_devel:https://docs.ansible.com/ansible-core/devel/
       provide-link-targets: |
         ansible_collections.vmware.vmware.vcsa_settings_module
+        ansible_collections.vmware.vmware.content_library_item_info_module
 
   build-docs:
     permissions:
@@ -39,6 +40,7 @@ jobs:
         ansible_devel:https://docs.ansible.com/ansible-core/devel/
       provide-link-targets: |
         ansible_collections.vmware.vmware.vcsa_settings_module
+        ansible_collections.vmware.vmware.content_library_item_info_module
 
   # This job requires that the workflow trigger is pull_request_target. However that trigger uses
   # whatever version of the workflow is available on main instead of the feature branch.

--- a/changelogs/fragments/549-deprecate-content_library_item_info.yml
+++ b/changelogs/fragments/549-deprecate-content_library_item_info.yml
@@ -1,3 +1,3 @@
 ---
-trivial:
-  - content_library_item_info - Deprecate module in favor of vmware.vmware.content_library_item_info
+deprecated_features:
+  - content_library_item_info - the module has been deprecated and will be removed in vmware.vmware_rest 5.0.0

--- a/changelogs/fragments/549-deprecate-content_library_item_info.yml
+++ b/changelogs/fragments/549-deprecate-content_library_item_info.yml
@@ -1,0 +1,3 @@
+---
+trivial:
+  - content_library_item_info - Deprecate module in favor of vmware.vmware.content_library_item_info

--- a/config/modules.yaml
+++ b/config/modules.yaml
@@ -168,6 +168,11 @@
 - vcenter_vm_hardware_serial:
 - vcenter_vm_info:
 - vcenter_vm_libraryitem_info:
+    documentation:
+      deprecated:
+        removed_in: 5.0.0
+        why: This module has been moved to the L(new vmware.vmware collection,https://forum.ansible.com/t/5880)
+        alternative: Use M(vmware.vmware.content_library_item_info) instead.
 - vcenter_vm_power_info:
 - vcenter_vm_power:
     documentation:

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -136,3 +136,10 @@ action_groups:
     - vcenter_vm_tools_installer_info
     - vcenter_vm_tools_installer
     - vcenter_vm_tools
+
+plugin_routing:
+  modules:
+    content_library_item_info:
+      deprecation:
+        removal_version: 5.0.0
+        warning_text: Use vmware.vmware.content_library_item_info instead.

--- a/plugins/modules/content_library_item_info.py
+++ b/plugins/modules/content_library_item_info.py
@@ -11,6 +11,10 @@ DOCUMENTATION = r"""
 module: content_library_item_info
 short_description: Returns the ItemModel with the given identifier.
 description: Returns the ItemModel with the given identifier.
+deprecated:
+    removed_in: 5.0.0
+    why: This module has been moved to the L(new vmware.vmware collection,https://forum.ansible.com/t/5880)
+    alternative: Use M(vmware.vmware.content_library_item_info) instead.
 options:
     library_id:
         description:


### PR DESCRIPTION
##### SUMMARY
Fixes issue
https://github.com/ansible-collections/vmware.vmware_rest/issues/540

Deprecate module content_library_item_info in favor of vmware.vmware.content_library_item_info. The module in this collection was not generated correctly, leading to it failing in some use cases. We cannot easily fix this since the issue is in the openapi spec provided by vmware.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
content_library_item_info