### PR TITLE
Disable failing appliance_networking test due to the bug

### DIFF
--- a/tests/integration/targets/vmware_rest_appliance/tasks/main.yml
+++ b/tests/integration/targets/vmware_rest_appliance/tasks/main.yml
@@ -3,14 +3,14 @@
 - import_tasks: appliance_localaccounts.yml
 - import_tasks: appliance_monitoring.yml
 - import_tasks: appliance_networking_dns_hostname.yml
-- import_tasks: appliance_networking.yml
-# - import_tasks: appliance_networking_firewall_inbound.yml
-# - import_tasks: appliance_networking_interfaces_ipv4.yml
-# - import_tasks: appliance_networking_interfaces_ipv6.yml
+# - import_tasks: appliance_networking.yml - There is a bug
+# - import_tasks: appliance_networking_firewall_inbound.yml - There is a bug
+# - import_tasks: appliance_networking_interfaces_ipv4.yml - There is a bug
+# - import_tasks: appliance_networking_interfaces_ipv6.yml - There is a bug
 - import_tasks: appliance_networking_proxy.yml
 # - import_tasks: appliance_services.yml
 # - import_tasks: appliance_shutdown.yml
 - import_tasks: appliance_system.yml
-# - import_tasks: appliance_system_storage.yml
+# - import_tasks: appliance_system_storage.yml - There is a bug
 - import_tasks: appliance_time.yml
 # - import_tasks: appliance_vmon_service.yml


### PR DESCRIPTION
This PR temporarily disables the appliance_networking test that has recently started failing in Shelly's [PR](https://github.com/ansible-collections/vmware.vmware_rest/pull/574). The failure appears to be due to an environmental change, as the test was passing previously without issues.

The failure also revealed a bug in the vmware.vmware_rest.appliance_networking module. Specifically, when attempting to disable IPv6, the error message is misleading, stating:
"Failed to enable ipv6 for network interfaces."

A bug has been opened to track this issue - [link](https://issues.redhat.com/browse/ACA-2087)