### PR TITLE
deprecate modules with redundant vmware.vmware options

### DIFF
--- a/.github/workflows/docs-pr.yml
+++ b/.github/workflows/docs-pr.yml
@@ -24,16 +24,16 @@ jobs:
       intersphinx-links: |
         ansible_devel:https://docs.ansible.com/ansible-core/devel/
       provide-link-targets: |
-        ansible_collections.vmware.vmware.appliance_info
-        ansible_collections.vmware.vmware.cluster_info
-        ansible_collections.vmware.vmware.content_library_item_info
-        ansible_collections.vmware.vmware.esxi_host
-        ansible_collections.vmware.vmware.local_content_library
-        ansible_collections.vmware.vmware.subscribed_content_library
-        ansible_collections.vmware.vmware.vcsa_settings
-        ansible_collections.vmware.vmware.vm_portgroup_info
-        ansible_collections.vmware.vmware.vm_powerstate
-        ansible_collections.vmware.vmware.vm_resource_info
+        ansible_collections.vmware.vmware.appliance_info_module
+        ansible_collections.vmware.vmware.cluster_info_module
+        ansible_collections.vmware.vmware.content_library_item_info_module
+        ansible_collections.vmware.vmware.esxi_host_module
+        ansible_collections.vmware.vmware.local_content_library_module
+        ansible_collections.vmware.vmware.subscribed_content_library_module
+        ansible_collections.vmware.vmware.vcsa_settings_module
+        ansible_collections.vmware.vmware.vm_portgroup_info_module
+        ansible_collections.vmware.vmware.vm_powerstate_module
+        ansible_collections.vmware.vmware.vm_resource_info_module
 
   build-docs:
     permissions:
@@ -47,16 +47,16 @@ jobs:
       intersphinx-links: |
         ansible_devel:https://docs.ansible.com/ansible-core/devel/
       provide-link-targets: |
-        ansible_collections.vmware.vmware.appliance_info
-        ansible_collections.vmware.vmware.cluster_info
-        ansible_collections.vmware.vmware.content_library_item_info
-        ansible_collections.vmware.vmware.esxi_host
-        ansible_collections.vmware.vmware.local_content_library
-        ansible_collections.vmware.vmware.subscribed_content_library
-        ansible_collections.vmware.vmware.vcsa_settings
-        ansible_collections.vmware.vmware.vm_portgroup_info
-        ansible_collections.vmware.vmware.vm_powerstate
-        ansible_collections.vmware.vmware.vm_resource_info
+        ansible_collections.vmware.vmware.appliance_info_module
+        ansible_collections.vmware.vmware.cluster_info_module
+        ansible_collections.vmware.vmware.content_library_item_info_module
+        ansible_collections.vmware.vmware.esxi_host_module
+        ansible_collections.vmware.vmware.local_content_library_module
+        ansible_collections.vmware.vmware.subscribed_content_library_module
+        ansible_collections.vmware.vmware.vcsa_settings_module
+        ansible_collections.vmware.vmware.vm_portgroup_info_module
+        ansible_collections.vmware.vmware.vm_powerstate_module
+        ansible_collections.vmware.vmware.vm_resource_info_module
 
   # This job requires that the workflow trigger is pull_request_target. However that trigger uses
   # whatever version of the workflow is available on main instead of the feature branch.

--- a/.github/workflows/docs-pr.yml
+++ b/.github/workflows/docs-pr.yml
@@ -24,8 +24,16 @@ jobs:
       intersphinx-links: |
         ansible_devel:https://docs.ansible.com/ansible-core/devel/
       provide-link-targets: |
-        ansible_collections.vmware.vmware.vcsa_settings_module
-        ansible_collections.vmware.vmware.content_library_item_info_module
+        ansible_collections.vmware.vmware.appliance_info
+        ansible_collections.vmware.vmware.cluster_info
+        ansible_collections.vmware.vmware.content_library_item_info
+        ansible_collections.vmware.vmware.esxi_host
+        ansible_collections.vmware.vmware.local_content_library
+        ansible_collections.vmware.vmware.subscribed_content_library
+        ansible_collections.vmware.vmware.vcsa_settings
+        ansible_collections.vmware.vmware.vm_portgroup_info
+        ansible_collections.vmware.vmware.vm_powerstate
+        ansible_collections.vmware.vmware.vm_resource_info
 
   build-docs:
     permissions:
@@ -39,8 +47,16 @@ jobs:
       intersphinx-links: |
         ansible_devel:https://docs.ansible.com/ansible-core/devel/
       provide-link-targets: |
-        ansible_collections.vmware.vmware.vcsa_settings_module
-        ansible_collections.vmware.vmware.content_library_item_info_module
+        ansible_collections.vmware.vmware.appliance_info
+        ansible_collections.vmware.vmware.cluster_info
+        ansible_collections.vmware.vmware.content_library_item_info
+        ansible_collections.vmware.vmware.esxi_host
+        ansible_collections.vmware.vmware.local_content_library
+        ansible_collections.vmware.vmware.subscribed_content_library
+        ansible_collections.vmware.vmware.vcsa_settings
+        ansible_collections.vmware.vmware.vm_portgroup_info
+        ansible_collections.vmware.vmware.vm_powerstate
+        ansible_collections.vmware.vmware.vm_resource_info
 
   # This job requires that the workflow trigger is pull_request_target. However that trigger uses
   # whatever version of the workflow is available on main instead of the feature branch.

--- a/changelogs/fragments/591-deprecate-redundant-modules.yml
+++ b/changelogs/fragments/591-deprecate-redundant-modules.yml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - Deprecated modules with redundant functionality in vmware.vmware. The next major release is currently not planned, so no removal date is provided. See https://github.com/ansible-collections/vmware.vmware_rest/issues/589

--- a/config/modules.yaml
+++ b/config/modules.yaml
@@ -1,24 +1,52 @@
 ---
 - appliance_access_consolecli_info:
+    documentation:
+      deprecated:
+        removed_in: 5.0.0
+        why: This module has been moved to the L(new vmware.vmware collection,https://forum.ansible.com/t/5880)
+        alternative: Use M(vmware.vmware.appliance_info) instead.
 - appliance_access_consolecli:
     documentation:
-      seealso:
-        - module: vmware.vmware.vcsa_settings
+      deprecated:
+        removed_in: 5.0.0
+        why: This module has been moved to the L(new vmware.vmware collection,https://forum.ansible.com/t/5880)
+        alternative: Use M(vmware.vmware.vcsa_settings) instead.
 - appliance_access_dcui_info:
+    documentation:
+      deprecated:
+        removed_in: 5.0.0
+        why: This module has been moved to the L(new vmware.vmware collection,https://forum.ansible.com/t/5880)
+        alternative: Use M(vmware.vmware.appliance_info) instead.
 - appliance_access_dcui:
     documentation:
-      seealso:
-        - module: vmware.vmware.vcsa_settings
+      deprecated:
+        removed_in: 5.0.0
+        why: This module has been moved to the L(new vmware.vmware collection,https://forum.ansible.com/t/5880)
+        alternative: Use M(vmware.vmware.vcsa_settings) instead.
 - appliance_access_shell_info:
+    documentation:
+      deprecated:
+        removed_in: 5.0.0
+        why: This module has been moved to the L(new vmware.vmware collection,https://forum.ansible.com/t/5880)
+        alternative: Use M(vmware.vmware.appliance_info) instead.
 - appliance_access_shell:
     documentation:
-      seealso:
-        - module: vmware.vmware.vcsa_settings
+      deprecated:
+        removed_in: 5.0.0
+        why: This module has been moved to the L(new vmware.vmware collection,https://forum.ansible.com/t/5880)
+        alternative: Use M(vmware.vmware.vcsa_settings) instead.
 - appliance_access_ssh_info:
+    documentation:
+      deprecated:
+        removed_in: 5.0.0
+        why: This module has been moved to the L(new vmware.vmware collection,https://forum.ansible.com/t/5880)
+        alternative: Use M(vmware.vmware.appliance_info) instead.
 - appliance_access_ssh:
     documentation:
-      seealso:
-        - module: vmware.vmware.vcsa_settings
+      deprecated:
+        removed_in: 5.0.0
+        why: This module has been moved to the L(new vmware.vmware collection,https://forum.ansible.com/t/5880)
+        alternative: Use M(vmware.vmware.vcsa_settings) instead.
 - appliance_health_applmgmt_info:
 - appliance_health_database_info:
 - appliance_health_databasestorage_info:
@@ -43,19 +71,53 @@
 - appliance_monitoring_info:
 - appliance_monitoring_query:
 - appliance_networking_dns_domains_info:
+    documentation:
+      deprecated:
+        removed_in: 5.0.0
+        why: This module has been moved to the L(new vmware.vmware collection,https://forum.ansible.com/t/5880)
+        alternative: Use M(vmware.vmware.appliance_info) instead.
 - appliance_networking_dns_domains:
     documentation:
-      seealso:
-        - module: vmware.vmware.vcsa_settings
+      deprecated:
+        removed_in: 5.0.0
+        why: This module has been moved to the L(new vmware.vmware collection,https://forum.ansible.com/t/5880)
+        alternative: Use M(vmware.vmware.vcsa_settings) instead.
 - appliance_networking_dns_hostname_info:
+    documentation:
+      deprecated:
+        removed_in: 5.0.0
+        why: This module has been moved to the L(new vmware.vmware collection,https://forum.ansible.com/t/5880)
+        alternative: Use M(vmware.vmware.appliance_info) instead.
 - appliance_networking_dns_hostname:
+    documentation:
+      deprecated:
+        removed_in: 5.0.0
+        why: This module has been moved to the L(new vmware.vmware collection,https://forum.ansible.com/t/5880)
+        alternative: Use M(vmware.vmware.vcsa_settings) instead.
 - appliance_networking_dns_servers_info:
+    documentation:
+      deprecated:
+        removed_in: 5.0.0
+        why: This module has been moved to the L(new vmware.vmware collection,https://forum.ansible.com/t/5880)
+        alternative: Use M(vmware.vmware.appliance_info) instead.
 - appliance_networking_dns_servers:
     documentation:
-      seealso:
-        - module: vmware.vmware.vcsa_settings
+      deprecated:
+        removed_in: 5.0.0
+        why: This module has been moved to the L(new vmware.vmware collection,https://forum.ansible.com/t/5880)
+        alternative: Use M(vmware.vmware.vcsa_settings) instead.
 - appliance_networking_firewall_inbound_info:
+    documentation:
+      deprecated:
+        removed_in: 5.0.0
+        why: This module has been moved to the L(new vmware.vmware collection,https://forum.ansible.com/t/5880)
+        alternative: Use M(vmware.vmware.appliance_info) instead.
 - appliance_networking_firewall_inbound:
+    documentation:
+      deprecated:
+        removed_in: 5.0.0
+        why: This module has been moved to the L(new vmware.vmware collection,https://forum.ansible.com/t/5880)
+        alternative: Use M(vmware.vmware.vcsa_settings) instead.
 - appliance_networking_info:
 - appliance_networking_interfaces_info:
 - appliance_networking_interfaces_ipv4_info:
@@ -63,54 +125,130 @@
 - appliance_networking_interfaces_ipv6_info:
 - appliance_networking_interfaces_ipv6:
 - appliance_networking_noproxy_info:
+    documentation:
+      deprecated:
+        removed_in: 5.0.0
+        why: This module has been moved to the L(new vmware.vmware collection,https://forum.ansible.com/t/5880)
+        alternative: Use M(vmware.vmware.appliance_info) instead.
 - appliance_networking_noproxy:
+    documentation:
+      deprecated:
+        removed_in: 5.0.0
+        why: This module has been moved to the L(new vmware.vmware collection,https://forum.ansible.com/t/5880)
+        alternative: Use M(vmware.vmware.vcsa_settings) instead.
 - appliance_networking_proxy_info:
+    documentation:
+      deprecated:
+        removed_in: 5.0.0
+        why: This module has been moved to the L(new vmware.vmware collection,https://forum.ansible.com/t/5880)
+        alternative: Use M(vmware.vmware.appliance_info) instead.
 - appliance_networking_proxy:
+    documentation:
+      deprecated:
+        removed_in: 5.0.0
+        why: This module has been moved to the L(new vmware.vmware collection,https://forum.ansible.com/t/5880)
+        alternative: Use M(vmware.vmware.vcsa_settings) instead.
 - appliance_networking:
 - appliance_ntp_info:
+    documentation:
+      deprecated:
+        removed_in: 5.0.0
+        why: This module has been moved to the L(new vmware.vmware collection,https://forum.ansible.com/t/5880)
+        alternative: Use M(vmware.vmware.appliance_info) instead.
 - appliance_ntp:
     documentation:
-      seealso:
-        - module: vmware.vmware.vcsa_settings
+      deprecated:
+        removed_in: 5.0.0
+        why: This module has been moved to the L(new vmware.vmware collection,https://forum.ansible.com/t/5880)
+        alternative: Use M(vmware.vmware.vcsa_settings) instead.
 - appliance_services_info:
 - appliance_services:
 - appliance_shutdown_info:
 - appliance_shutdown:
 - appliance_system_globalfips_info:
+    documentation:
+      deprecated:
+        removed_in: 5.0.0
+        why: This module has been moved to the L(new vmware.vmware collection,https://forum.ansible.com/t/5880)
+        alternative: Use M(vmware.vmware.appliance_info) instead.
 - appliance_system_globalfips:
+    documentation:
+      deprecated:
+        removed_in: 5.0.0
+        why: This module has been moved to the L(new vmware.vmware collection,https://forum.ansible.com/t/5880)
+        alternative: Use M(vmware.vmware.vcsa_settings) instead.
 - appliance_system_storage_info:
 - appliance_system_storage:
 - appliance_system_time_info:
 - appliance_system_time_timezone_info:
+    documentation:
+      deprecated:
+        removed_in: 5.0.0
+        why: This module has been moved to the L(new vmware.vmware collection,https://forum.ansible.com/t/5880)
+        alternative: Use M(vmware.vmware.appliance_info) instead.
 - appliance_system_time_timezone:
     documentation:
-      seealso:
-        - module: vmware.vmware.vcsa_settings
+      deprecated:
+        removed_in: 5.0.0
+        why: This module has been moved to the L(new vmware.vmware collection,https://forum.ansible.com/t/5880)
+        alternative: Use M(vmware.vmware.vcsa_settings) instead.
 - appliance_system_version_info:
 - appliance_timesync_info:
+    documentation:
+      deprecated:
+        removed_in: 5.0.0
+        why: This module has been moved to the L(new vmware.vmware collection,https://forum.ansible.com/t/5880)
+        alternative: Use M(vmware.vmware.appliance_info) instead.
 - appliance_timesync:
     documentation:
-      seealso:
-        - module: vmware.vmware.vcsa_settings
+      deprecated:
+        removed_in: 5.0.0
+        why: This module has been moved to the L(new vmware.vmware collection,https://forum.ansible.com/t/5880)
+        alternative: Use M(vmware.vmware.vcsa_settings) instead.
 - appliance_update_info:
 - appliance_vmon_service_info:
 - appliance_vmon_service:
 - content_library_item_info:
+    documentation:
+      deprecated:
+        removed_in: 5.0.0
+        why: This module has been moved to the L(new vmware.vmware collection,https://forum.ansible.com/t/5880)
+        alternative: Use M(vmware.vmware.content_library_item_info) instead.
 - content_library_info:
 - content_library_subscriptions_info:
 - content_locallibrary_info:
 - content_locallibrary:
+    documentation:
+      deprecated:
+        removed_in: 5.0.0
+        why: This module has been moved to the L(new vmware.vmware collection,https://forum.ansible.com/t/5880)
+        alternative: Use M(vmware.vmware.local_content_library) instead.
 - content_subscribedlibrary_info:
 - content_subscribedlibrary:
+    documentation:
+      deprecated:
+        removed_in: 5.0.0
+        why: This module has been moved to the L(new vmware.vmware collection,https://forum.ansible.com/t/5880)
+        alternative: Use M(vmware.vmware.subscribed_content_library) instead.
 - content_configuration_info:
 - content_configuration:
 - vcenter_cluster_info:
+    documentation:
+      deprecated:
+        removed_in: 5.0.0
+        why: This module has been moved to the L(new vmware.vmware collection,https://forum.ansible.com/t/5880)
+        alternative: Use M(vmware.vmware.cluster_info) instead.
 - vcenter_datacenter_info:
 - vcenter_datacenter:
 - vcenter_datastore_info:
 - vcenter_folder_info:
 - vcenter_host_info:
 - vcenter_host:
+    documentation:
+      deprecated:
+        removed_in: 5.0.0
+        why: This module has been moved to the L(new vmware.vmware collection,https://forum.ansible.com/t/5880)
+        alternative: Use M(vmware.vmware.esxi_host) instead.
 - vcenter_info:
 - vcenter_network_info:
 - vcenter_ovf_libraryitem:
@@ -129,6 +267,11 @@
 - vcenter_vm_guest_localfilesystem_info:
 - vcenter_vm_guest_networking_info:
 - vcenter_vm_guest_networking_interfaces_info:
+    documentation:
+      deprecated:
+        removed_in: 5.0.0
+        why: This module has been moved to the L(new vmware.vmware collection,https://forum.ansible.com/t/5880)
+        alternative: Use M(vmware.vmware.vm_portgroup_info) instead.
 - vcenter_vm_guest_networking_routes_info:
 - vcenter_vm_guest_operations_info:
 - vcenter_vm_guest_power_info:
@@ -139,6 +282,10 @@
         - module: vmware.vmware_rest.vcenter_vm_power
           description: A module to boot, hard shutdown and hard reset guest
       description: Issues a request to the guest operating system asking it to perform a soft shutdown, standby (suspend) or soft reboot. This request returns immediately and does not wait for the guest operating.
+      deprecated:
+        removed_in: 5.0.0
+        why: This module has been moved to the L(new vmware.vmware collection,https://forum.ansible.com/t/5880)
+        alternative: Use M(vmware.vmware.vm_powerstate) instead.
 - vcenter_vm_hardware_adapter_sata_info:
 - vcenter_vm_hardware_adapter_sata:
 - vcenter_vm_hardware_adapter_scsi_info:
@@ -150,6 +297,11 @@
 - vcenter_vm_hardware_cdrom_info:
 - vcenter_vm_hardware_cdrom:
 - vcenter_vm_hardware_cpu_info:
+    documentation:
+      deprecated:
+        removed_in: 5.0.0
+        why: This module has been moved to the L(new vmware.vmware collection,https://forum.ansible.com/t/5880)
+        alternative: Use M(vmware.vmware.vm_resource_info) instead.
 - vcenter_vm_hardware_cpu:
 - vcenter_vm_hardware_disk_info:
 - vcenter_vm_hardware_disk:
@@ -162,6 +314,11 @@
 - vcenter_vm_hardware_floppy:
 - vcenter_vm_hardware_info:
 - vcenter_vm_hardware_memory_info:
+    documentation:
+      deprecated:
+        removed_in: 5.0.0
+        why: This module has been moved to the L(new vmware.vmware collection,https://forum.ansible.com/t/5880)
+        alternative: Use M(vmware.vmware.vm_resource_info) instead.
 - vcenter_vm_hardware_memory:
 - vcenter_vm_hardware_parallel_info:
 - vcenter_vm_hardware_parallel:
@@ -183,6 +340,10 @@
         - module: vmware.vmware_rest.vcenter_vm_guest_power
           description: Issues a request to the guest operating system asking it to perform a soft shutdown, standby (suspend) or soft reboot
       description: Ask the vCenter to boot, force shutdown or force reset a guest.
+      deprecated:
+        removed_in: 5.0.0
+        why: This module has been moved to the L(new vmware.vmware collection,https://forum.ansible.com/t/5880)
+        alternative: Use M(vmware.vmware.vm_powerstate) instead.
 - vcenter_vm:
 - vcenter_vm_storage_policy_compliance_info:
 - vcenter_vm_storage_policy_compliance:
@@ -193,4 +354,9 @@
 - vcenter_vm_tools_installer:
 - vcenter_vm_tools:
 - vcenter_vmtemplate_libraryitems_info:
+    documentation:
+      deprecated:
+        removed_in: 5.0.0
+        why: This module has been moved to the L(new vmware.vmware collection,https://forum.ansible.com/t/5880)
+        alternative: Use M(vmware.vmware.content_library_items_info) instead.
 - vcenter_vmtemplate_libraryitems:

--- a/config/modules.yaml
+++ b/config/modules.yaml
@@ -358,5 +358,5 @@
       deprecated:
         removed_in: 5.0.0
         why: This module has been moved to the L(new vmware.vmware collection,https://forum.ansible.com/t/5880)
-        alternative: Use M(vmware.vmware.content_library_items_info) instead.
+        alternative: Use M(vmware.vmware.content_library_item_info) instead.
 - vcenter_vmtemplate_libraryitems:

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -333,3 +333,8 @@ plugin_routing:
       deprecation:
         removal_version: 5.0.0
         warning_text: Use vmware.vmware.vm_powerstate instead.
+
+    vcenter_vm_libraryitem_info:
+      deprecation:
+        removal_version: 5.0.0
+        warning_text: Use vmware.vmware.content_library_item_info instead.

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -143,3 +143,193 @@ plugin_routing:
       deprecation:
         removal_version: 5.0.0
         warning_text: Use vmware.vmware.content_library_item_info instead.
+
+    vcenter_vmtemplate_libraryitems_info:
+      deprecation:
+        removal_version: 5.0.0
+        warning_text: Use vmware.vmware.content_library_item_info instead.
+
+    vcenter_vm_hardware_memory_info:
+      deprecation:
+        removal_version: 5.0.0
+        warning_text: Use vmware.vmware.vm_resource_info instead.
+
+    vcenter_vm_hardware_cpu_info:
+      deprecation:
+        removal_version: 5.0.0
+        warning_text: Use vmware.vmware.vm_resource_info instead.
+
+    vcenter_vm_guest_networking_interfaces_info:
+      deprecation:
+        removal_version: 5.0.0
+        warning_text: Use vmware.vmware.vm_portgroup_info instead.
+
+    vcenter_host:
+      deprecation:
+        removal_version: 5.0.0
+        warning_text: Use vmware.vmware.esxi_host instead.
+
+    vcenter_cluster_info:
+      deprecation:
+        removal_version: 5.0.0
+        warning_text: Use vmware.vmware.cluster_info instead.
+
+    content_subscribedlibrary:
+      deprecation:
+        removal_version: 5.0.0
+        warning_text: Use vmware.vmware.subscribed_content_library instead.
+
+    content_locallibrary:
+      deprecation:
+        removal_version: 5.0.0
+        warning_text: Use vmware.vmware.local_content_library instead.
+
+    appliance_networking_firewall_inbound:
+      deprecation:
+        removal_version: 5.0.0
+        warning_text: Use vmware.vmware.vcsa_settings instead.
+
+    appliance_networking_firewall_inbound_info:
+      deprecation:
+        removal_version: 5.0.0
+        warning_text: Use vmware.vmware.appliance_info instead.
+
+    appliance_access_consolecli:
+      deprecation:
+        removal_version: 5.0.0
+        warning_text: Use vmware.vmware.vcsa_settings instead.
+
+    appliance_access_consolecli_info:
+      deprecation:
+        removal_version: 5.0.0
+        warning_text: Use vmware.vmware.appliance_info instead.
+
+    appliance_access_ssh:
+      deprecation:
+        removal_version: 5.0.0
+        warning_text: Use vmware.vmware.vcsa_settings instead.
+
+    appliance_access_ssh_info:
+      deprecation:
+        removal_version: 5.0.0
+        warning_text: Use vmware.vmware.appliance_info instead.
+
+    appliance_access_shell:
+      deprecation:
+        removal_version: 5.0.0
+        warning_text: Use vmware.vmware.vcsa_settings instead.
+
+    appliance_access_shell_info:
+      deprecation:
+        removal_version: 5.0.0
+        warning_text: Use vmware.vmware.appliance_info instead.
+
+    appliance_access_dcui:
+      deprecation:
+        removal_version: 5.0.0
+        warning_text: Use vmware.vmware.vcsa_settings instead.
+
+    appliance_access_dcui_info:
+      deprecation:
+        removal_version: 5.0.0
+        warning_text: Use vmware.vmware.appliance_info instead.
+
+    appliance_networking_proxy:
+      deprecation:
+        removal_version: 5.0.0
+        warning_text: Use vmware.vmware.vcsa_settings instead.
+
+    appliance_networking_proxy_info:
+      deprecation:
+        removal_version: 5.0.0
+        warning_text: Use vmware.vmware.appliance_info instead.
+
+    appliance_networking_noproxy:
+      deprecation:
+        removal_version: 5.0.0
+        warning_text: Use vmware.vmware.vcsa_settings instead.
+
+    appliance_networking_noproxy_info:
+      deprecation:
+        removal_version: 5.0.0
+        warning_text: Use vmware.vmware.appliance_info instead.
+
+    appliance_ntp:
+      deprecation:
+        removal_version: 5.0.0
+        warning_text: Use vmware.vmware.vcsa_settings instead.
+
+    appliance_ntp_info:
+      deprecation:
+        removal_version: 5.0.0
+        warning_text: Use vmware.vmware.appliance_info instead.
+
+    appliance_timesync:
+      deprecation:
+        removal_version: 5.0.0
+        warning_text: Use vmware.vmware.vcsa_settings instead.
+
+    appliance_timesync_info:
+      deprecation:
+        removal_version: 5.0.0
+        warning_text: Use vmware.vmware.appliance_info instead.
+
+    appliance_networking_dns_domains:
+      deprecation:
+        removal_version: 5.0.0
+        warning_text: Use vmware.vmware.vcsa_settings instead.
+
+    appliance_networking_dns_domains_info:
+      deprecation:
+        removal_version: 5.0.0
+        warning_text: Use vmware.vmware.appliance_info instead.
+
+    appliance_networking_dns_servers:
+      deprecation:
+        removal_version: 5.0.0
+        warning_text: Use vmware.vmware.vcsa_settings instead.
+
+    appliance_networking_dns_servers_info:
+      deprecation:
+        removal_version: 5.0.0
+        warning_text: Use vmware.vmware.appliance_info instead.
+
+    appliance_networking_dns_hostname:
+      deprecation:
+        removal_version: 5.0.0
+        warning_text: Use vmware.vmware.vcsa_settings instead.
+
+    appliance_networking_dns_hostname_info:
+      deprecation:
+        removal_version: 5.0.0
+        warning_text: Use vmware.vmware.appliance_info instead.
+
+    appliance_system_time_timezone:
+      deprecation:
+        removal_version: 5.0.0
+        warning_text: Use vmware.vmware.vcsa_settings instead.
+
+    appliance_system_time_timezone_info:
+      deprecation:
+        removal_version: 5.0.0
+        warning_text: Use vmware.vmware.appliance_info instead.
+
+    appliance_system_globalfips:
+      deprecation:
+        removal_version: 5.0.0
+        warning_text: Use vmware.vmware.vcsa_settings instead.
+
+    appliance_system_globalfips_info:
+      deprecation:
+        removal_version: 5.0.0
+        warning_text: Use vmware.vmware.appliance_info instead.
+
+    vcenter_vm_guest_power:
+      deprecation:
+        removal_version: 5.0.0
+        warning_text: Use vmware.vmware.vm_powerstate instead.
+
+    vcenter_vm_power:
+      deprecation:
+        removal_version: 5.0.0
+        warning_text: Use vmware.vmware.vm_powerstate instead.

--- a/plugins/modules/appliance_access_consolecli.py
+++ b/plugins/modules/appliance_access_consolecli.py
@@ -11,6 +11,10 @@ DOCUMENTATION = r"""
 module: appliance_access_consolecli
 short_description: Set enabled state of the console-based controlled CLI (TTY1).
 description: Set enabled state of the console-based controlled CLI (TTY1).
+deprecated:
+    removed_in: 5.0.0
+    why: This module has been moved to the L(new vmware.vmware collection,https://forum.ansible.com/t/5880)
+    alternative: Use M(vmware.vmware.vcsa_settings) instead.
 options:
     enabled:
         description:

--- a/plugins/modules/appliance_access_consolecli_info.py
+++ b/plugins/modules/appliance_access_consolecli_info.py
@@ -11,6 +11,10 @@ DOCUMENTATION = r"""
 module: appliance_access_consolecli_info
 short_description: Get enabled state of the console-based controlled CLI (TTY1).
 description: Get enabled state of the console-based controlled CLI (TTY1).
+deprecated:
+    removed_in: 5.0.0
+    why: This module has been moved to the L(new vmware.vmware collection,https://forum.ansible.com/t/5880)
+    alternative: Use M(vmware.vmware.appliance_info) instead.
 options:
     session_timeout:
         description:

--- a/plugins/modules/appliance_access_dcui.py
+++ b/plugins/modules/appliance_access_dcui.py
@@ -11,6 +11,10 @@ DOCUMENTATION = r"""
 module: appliance_access_dcui
 short_description: Set enabled state of Direct Console User Interface (DCUI TTY2).
 description: Set enabled state of Direct Console User Interface (DCUI TTY2).
+deprecated:
+    removed_in: 5.0.0
+    why: This module has been moved to the L(new vmware.vmware collection,https://forum.ansible.com/t/5880)
+    alternative: Use M(vmware.vmware.vcsa_settings) instead.
 options:
     enabled:
         description:
@@ -75,8 +79,6 @@ requirements:
 - vSphere 7.0.3 or greater
 - python >= 3.6
 - aiohttp
-seealso:
--   module: vmware.vmware.vcsa_settings
 notes:
 - Tested on vSphere 7.0.3
 """

--- a/plugins/modules/appliance_access_dcui_info.py
+++ b/plugins/modules/appliance_access_dcui_info.py
@@ -11,6 +11,10 @@ DOCUMENTATION = r"""
 module: appliance_access_dcui_info
 short_description: Get enabled state of Direct Console User Interface (DCUI TTY2).
 description: Get enabled state of Direct Console User Interface (DCUI TTY2).
+deprecated:
+    removed_in: 5.0.0
+    why: This module has been moved to the L(new vmware.vmware collection,https://forum.ansible.com/t/5880)
+    alternative: Use M(vmware.vmware.appliance_info) instead.
 options:
     session_timeout:
         description:

--- a/plugins/modules/appliance_access_shell.py
+++ b/plugins/modules/appliance_access_shell.py
@@ -13,6 +13,10 @@ short_description: Set enabled state of BASH, that is, access to BASH from withi
     the controlled CLI.
 description: Set enabled state of BASH, that is, access to BASH from within the controlled
     CLI.
+deprecated:
+    removed_in: 5.0.0
+    why: This module has been moved to the L(new vmware.vmware collection,https://forum.ansible.com/t/5880)
+    alternative: Use M(vmware.vmware.vcsa_settings) instead.
 options:
     enabled:
         description:
@@ -83,8 +87,6 @@ requirements:
 - vSphere 7.0.3 or greater
 - python >= 3.6
 - aiohttp
-seealso:
--   module: vmware.vmware.vcsa_settings
 notes:
 - Tested on vSphere 7.0.3
 """

--- a/plugins/modules/appliance_access_shell_info.py
+++ b/plugins/modules/appliance_access_shell_info.py
@@ -13,6 +13,10 @@ short_description: Get enabled state of BASH, that is, access to BASH from withi
     the controlled CLI.
 description: Get enabled state of BASH, that is, access to BASH from within the controlled
     CLI.
+deprecated:
+    removed_in: 5.0.0
+    why: This module has been moved to the L(new vmware.vmware collection,https://forum.ansible.com/t/5880)
+    alternative: Use M(vmware.vmware.appliance_info) instead.
 options:
     session_timeout:
         description:

--- a/plugins/modules/appliance_access_ssh.py
+++ b/plugins/modules/appliance_access_ssh.py
@@ -11,6 +11,10 @@ DOCUMENTATION = r"""
 module: appliance_access_ssh
 short_description: Set enabled state of the SSH-based controlled CLI.
 description: Set enabled state of the SSH-based controlled CLI.
+deprecated:
+    removed_in: 5.0.0
+    why: This module has been moved to the L(new vmware.vmware collection,https://forum.ansible.com/t/5880)
+    alternative: Use M(vmware.vmware.vcsa_settings) instead.
 options:
     enabled:
         description:
@@ -75,8 +79,6 @@ requirements:
 - vSphere 7.0.3 or greater
 - python >= 3.6
 - aiohttp
-seealso:
--   module: vmware.vmware.vcsa_settings
 notes:
 - Tested on vSphere 7.0.3
 """

--- a/plugins/modules/appliance_access_ssh_info.py
+++ b/plugins/modules/appliance_access_ssh_info.py
@@ -11,6 +11,10 @@ DOCUMENTATION = r"""
 module: appliance_access_ssh_info
 short_description: Get enabled state of the SSH-based controlled CLI.
 description: Get enabled state of the SSH-based controlled CLI.
+deprecated:
+    removed_in: 5.0.0
+    why: This module has been moved to the L(new vmware.vmware collection,https://forum.ansible.com/t/5880)
+    alternative: Use M(vmware.vmware.appliance_info) instead.
 options:
     session_timeout:
         description:

--- a/plugins/modules/appliance_networking_dns_domains.py
+++ b/plugins/modules/appliance_networking_dns_domains.py
@@ -11,6 +11,10 @@ DOCUMENTATION = r"""
 module: appliance_networking_dns_domains
 short_description: Set DNS search domains.
 description: Set DNS search domains.
+deprecated:
+    removed_in: 5.0.0
+    why: This module has been moved to the L(new vmware.vmware collection,https://forum.ansible.com/t/5880)
+    alternative: Use M(vmware.vmware.vcsa_settings) instead.
 options:
     domain:
         description:
@@ -80,8 +84,6 @@ requirements:
 - vSphere 7.0.3 or greater
 - python >= 3.6
 - aiohttp
-seealso:
--   module: vmware.vmware.vcsa_settings
 notes:
 - Tested on vSphere 7.0.3
 """

--- a/plugins/modules/appliance_networking_dns_domains_info.py
+++ b/plugins/modules/appliance_networking_dns_domains_info.py
@@ -11,6 +11,10 @@ DOCUMENTATION = r"""
 module: appliance_networking_dns_domains_info
 short_description: Get list of DNS search domains.
 description: Get list of DNS search domains.
+deprecated:
+    removed_in: 5.0.0
+    why: This module has been moved to the L(new vmware.vmware collection,https://forum.ansible.com/t/5880)
+    alternative: Use M(vmware.vmware.appliance_info) instead.
 options:
     session_timeout:
         description:

--- a/plugins/modules/appliance_networking_dns_hostname.py
+++ b/plugins/modules/appliance_networking_dns_hostname.py
@@ -11,6 +11,10 @@ DOCUMENTATION = r"""
 module: appliance_networking_dns_hostname
 short_description: Set the Fully Qualified Domain Name.
 description: Set the Fully Qualified Domain Name.
+deprecated:
+    removed_in: 5.0.0
+    why: This module has been moved to the L(new vmware.vmware collection,https://forum.ansible.com/t/5880)
+    alternative: Use M(vmware.vmware.vcsa_settings) instead.
 options:
     name:
         description:

--- a/plugins/modules/appliance_networking_dns_hostname_info.py
+++ b/plugins/modules/appliance_networking_dns_hostname_info.py
@@ -11,6 +11,10 @@ DOCUMENTATION = r"""
 module: appliance_networking_dns_hostname_info
 short_description: Get the Fully Qualified Doman Name.
 description: Get the Fully Qualified Doman Name.
+deprecated:
+    removed_in: 5.0.0
+    why: This module has been moved to the L(new vmware.vmware collection,https://forum.ansible.com/t/5880)
+    alternative: Use M(vmware.vmware.appliance_info) instead.
 options:
     session_timeout:
         description:

--- a/plugins/modules/appliance_networking_dns_servers.py
+++ b/plugins/modules/appliance_networking_dns_servers.py
@@ -12,6 +12,10 @@ module: appliance_networking_dns_servers
 short_description: Set the DNS server configuration
 description: Set the DNS server configuration. If you set the mode argument to "DHCP",
     a DHCP refresh is forced.
+deprecated:
+    removed_in: 5.0.0
+    why: This module has been moved to the L(new vmware.vmware collection,https://forum.ansible.com/t/5880)
+    alternative: Use M(vmware.vmware.vcsa_settings) instead.
 options:
     mode:
         choices:

--- a/plugins/modules/appliance_networking_dns_servers_info.py
+++ b/plugins/modules/appliance_networking_dns_servers_info.py
@@ -11,6 +11,10 @@ DOCUMENTATION = r"""
 module: appliance_networking_dns_servers_info
 short_description: Get DNS server configuration.
 description: Get DNS server configuration.
+deprecated:
+    removed_in: 5.0.0
+    why: This module has been moved to the L(new vmware.vmware collection,https://forum.ansible.com/t/5880)
+    alternative: Use M(vmware.vmware.appliance_info) instead.
 options:
     session_timeout:
         description:

--- a/plugins/modules/appliance_networking_firewall_inbound.py
+++ b/plugins/modules/appliance_networking_firewall_inbound.py
@@ -18,6 +18,10 @@ description: 'Set the ordered list of firewall rules to allow or deny traffic fr
     be as follows:   AddressPrefixInterface NamePolicy   10.112.0.10*REJECT   10.112.0.10nic0ACCEPT   In
     the above example, the first rule drops all packets originating from 10.112.0.1
     and'
+deprecated:
+    removed_in: 5.0.0
+    why: This module has been moved to the L(new vmware.vmware collection,https://forum.ansible.com/t/5880)
+    alternative: Use M(vmware.vmware.vcsa_settings) instead.
 options:
     rules:
         description:

--- a/plugins/modules/appliance_networking_firewall_inbound_info.py
+++ b/plugins/modules/appliance_networking_firewall_inbound_info.py
@@ -14,6 +14,10 @@ description: Get the ordered list of firewall rules. Within the list of traffic 
     rules are processed in order of appearance, from top to bottom. When a connection
     matches a firewall rule, further processing for the connection stops, and the
     appliance ignores any additional firewall rules you have set.
+deprecated:
+    removed_in: 5.0.0
+    why: This module has been moved to the L(new vmware.vmware collection,https://forum.ansible.com/t/5880)
+    alternative: Use M(vmware.vmware.appliance_info) instead.
 options:
     session_timeout:
         description:

--- a/plugins/modules/appliance_networking_noproxy.py
+++ b/plugins/modules/appliance_networking_noproxy.py
@@ -15,6 +15,10 @@ description: Sets servers for which no proxy configuration should be applied. Th
     a logout from appliance or a service restart is required. If IPv4 is enabled,
     "127.0.0.1" and "localhost" will always bypass the proxy (even if they are not
     explicitly configured).
+deprecated:
+    removed_in: 5.0.0
+    why: This module has been moved to the L(new vmware.vmware collection,https://forum.ansible.com/t/5880)
+    alternative: Use M(vmware.vmware.vcsa_settings) instead.
 options:
     servers:
         description:

--- a/plugins/modules/appliance_networking_noproxy_info.py
+++ b/plugins/modules/appliance_networking_noproxy_info.py
@@ -11,6 +11,10 @@ DOCUMENTATION = r"""
 module: appliance_networking_noproxy_info
 short_description: Returns servers for which no proxy configuration will be applied.
 description: Returns servers for which no proxy configuration will be applied.
+deprecated:
+    removed_in: 5.0.0
+    why: This module has been moved to the L(new vmware.vmware collection,https://forum.ansible.com/t/5880)
+    alternative: Use M(vmware.vmware.appliance_info) instead.
 options:
     session_timeout:
         description:

--- a/plugins/modules/appliance_networking_proxy.py
+++ b/plugins/modules/appliance_networking_proxy.py
@@ -13,6 +13,10 @@ short_description: Configures which proxy server to use for the specified protoc
 description: Configures which proxy server to use for the specified protocol. This
     operation sets environment variables for using proxy. In order for this configuration
     to take effect a logout / service restart is required.
+deprecated:
+    removed_in: 5.0.0
+    why: This module has been moved to the L(new vmware.vmware collection,https://forum.ansible.com/t/5880)
+    alternative: Use M(vmware.vmware.vcsa_settings) instead.
 options:
     config:
         description:

--- a/plugins/modules/appliance_networking_proxy_info.py
+++ b/plugins/modules/appliance_networking_proxy_info.py
@@ -11,6 +11,10 @@ DOCUMENTATION = r"""
 module: appliance_networking_proxy_info
 short_description: Gets the proxy configuration for a specific protocol.
 description: Gets the proxy configuration for a specific protocol.
+deprecated:
+    removed_in: 5.0.0
+    why: This module has been moved to the L(new vmware.vmware collection,https://forum.ansible.com/t/5880)
+    alternative: Use M(vmware.vmware.appliance_info) instead.
 options:
     protocol:
         description:

--- a/plugins/modules/appliance_ntp.py
+++ b/plugins/modules/appliance_ntp.py
@@ -15,6 +15,10 @@ description: Set NTP servers. This method updates old NTP servers from configura
     is used internally, the NTP daemon will be restarted to reload given NTP configuration.
     In case NTP based time synchronization is not used, this method only replaces
     servers in the NTP configuration.
+deprecated:
+    removed_in: 5.0.0
+    why: This module has been moved to the L(new vmware.vmware collection,https://forum.ansible.com/t/5880)
+    alternative: Use M(vmware.vmware.vcsa_settings) instead.
 options:
     servers:
         description:
@@ -81,8 +85,6 @@ requirements:
 - vSphere 7.0.3 or greater
 - python >= 3.6
 - aiohttp
-seealso:
--   module: vmware.vmware.vcsa_settings
 notes:
 - Tested on vSphere 7.0.3
 """

--- a/plugins/modules/appliance_ntp_info.py
+++ b/plugins/modules/appliance_ntp_info.py
@@ -15,6 +15,10 @@ description: Get the NTP configuration status. If you run the 'timesync.get' com
     The 'ntp' command always returns the NTP server information, even when the time
     synchronization mode is not set to NTP. If the time synchronization mode is not
     NTP-based, the NTP server status is displayed as down.
+deprecated:
+    removed_in: 5.0.0
+    why: This module has been moved to the L(new vmware.vmware collection,https://forum.ansible.com/t/5880)
+    alternative: Use M(vmware.vmware.appliance_info) instead.
 options:
     session_timeout:
         description:

--- a/plugins/modules/appliance_system_globalfips.py
+++ b/plugins/modules/appliance_system_globalfips.py
@@ -11,6 +11,10 @@ DOCUMENTATION = r"""
 module: appliance_system_globalfips
 short_description: Enable/Disable Global FIPS mode for the appliance
 description: 'Enable/Disable Global FIPS mode for the appliance. '
+deprecated:
+    removed_in: 5.0.0
+    why: This module has been moved to the L(new vmware.vmware collection,https://forum.ansible.com/t/5880)
+    alternative: Use M(vmware.vmware.vcsa_settings) instead.
 options:
     enabled:
         description:

--- a/plugins/modules/appliance_system_globalfips_info.py
+++ b/plugins/modules/appliance_system_globalfips_info.py
@@ -11,6 +11,10 @@ DOCUMENTATION = r"""
 module: appliance_system_globalfips_info
 short_description: Get current appliance FIPS settings.
 description: Get current appliance FIPS settings.
+deprecated:
+    removed_in: 5.0.0
+    why: This module has been moved to the L(new vmware.vmware collection,https://forum.ansible.com/t/5880)
+    alternative: Use M(vmware.vmware.appliance_info) instead.
 options:
     session_timeout:
         description:

--- a/plugins/modules/appliance_system_time_timezone.py
+++ b/plugins/modules/appliance_system_time_timezone.py
@@ -11,6 +11,10 @@ DOCUMENTATION = r"""
 module: appliance_system_time_timezone
 short_description: Set time zone.
 description: Set time zone.
+deprecated:
+    removed_in: 5.0.0
+    why: This module has been moved to the L(new vmware.vmware collection,https://forum.ansible.com/t/5880)
+    alternative: Use M(vmware.vmware.vcsa_settings) instead.
 options:
     name:
         description:
@@ -75,8 +79,6 @@ requirements:
 - vSphere 7.0.3 or greater
 - python >= 3.6
 - aiohttp
-seealso:
--   module: vmware.vmware.vcsa_settings
 notes:
 - Tested on vSphere 7.0.3
 """

--- a/plugins/modules/appliance_system_time_timezone_info.py
+++ b/plugins/modules/appliance_system_time_timezone_info.py
@@ -11,6 +11,10 @@ DOCUMENTATION = r"""
 module: appliance_system_time_timezone_info
 short_description: Get time zone.
 description: Get time zone.
+deprecated:
+    removed_in: 5.0.0
+    why: This module has been moved to the L(new vmware.vmware collection,https://forum.ansible.com/t/5880)
+    alternative: Use M(vmware.vmware.appliance_info) instead.
 options:
     session_timeout:
         description:

--- a/plugins/modules/appliance_timesync.py
+++ b/plugins/modules/appliance_timesync.py
@@ -11,6 +11,10 @@ DOCUMENTATION = r"""
 module: appliance_timesync
 short_description: Set time synchronization mode.
 description: Set time synchronization mode.
+deprecated:
+    removed_in: 5.0.0
+    why: This module has been moved to the L(new vmware.vmware collection,https://forum.ansible.com/t/5880)
+    alternative: Use M(vmware.vmware.vcsa_settings) instead.
 options:
     mode:
         choices:
@@ -80,8 +84,6 @@ requirements:
 - vSphere 7.0.3 or greater
 - python >= 3.6
 - aiohttp
-seealso:
--   module: vmware.vmware.vcsa_settings
 notes:
 - Tested on vSphere 7.0.3
 """

--- a/plugins/modules/appliance_timesync_info.py
+++ b/plugins/modules/appliance_timesync_info.py
@@ -11,6 +11,10 @@ DOCUMENTATION = r"""
 module: appliance_timesync_info
 short_description: Get time synchronization mode.
 description: Get time synchronization mode.
+deprecated:
+    removed_in: 5.0.0
+    why: This module has been moved to the L(new vmware.vmware collection,https://forum.ansible.com/t/5880)
+    alternative: Use M(vmware.vmware.appliance_info) instead.
 options:
     session_timeout:
         description:

--- a/plugins/modules/content_locallibrary.py
+++ b/plugins/modules/content_locallibrary.py
@@ -11,6 +11,10 @@ DOCUMENTATION = r"""
 module: content_locallibrary
 short_description: Creates a new local library.
 description: Creates a new local library.
+deprecated:
+    removed_in: 5.0.0
+    why: This module has been moved to the L(new vmware.vmware collection,https://forum.ansible.com/t/5880)
+    alternative: Use M(vmware.vmware.local_content_library) instead.
 options:
     client_token:
         description:

--- a/plugins/modules/content_subscribedlibrary.py
+++ b/plugins/modules/content_subscribedlibrary.py
@@ -11,6 +11,10 @@ DOCUMENTATION = r"""
 module: content_subscribedlibrary
 short_description: Creates a new subscribed library
 description: 'Creates a new subscribed library. '
+deprecated:
+    removed_in: 5.0.0
+    why: This module has been moved to the L(new vmware.vmware collection,https://forum.ansible.com/t/5880)
+    alternative: Use M(vmware.vmware.subscribed_content_library) instead.
 options:
     client_token:
         description:

--- a/plugins/modules/vcenter_cluster_info.py
+++ b/plugins/modules/vcenter_cluster_info.py
@@ -11,6 +11,10 @@ DOCUMENTATION = r"""
 module: vcenter_cluster_info
 short_description: Retrieves information about the cluster corresponding to cluster.
 description: Retrieves information about the cluster corresponding to cluster.
+deprecated:
+    removed_in: 5.0.0
+    why: This module has been moved to the L(new vmware.vmware collection,https://forum.ansible.com/t/5880)
+    alternative: Use M(vmware.vmware.cluster_info) instead.
 options:
     cluster:
         description:

--- a/plugins/modules/vcenter_host.py
+++ b/plugins/modules/vcenter_host.py
@@ -16,6 +16,10 @@ description: Add a new standalone host in the vCenter inventory. The newly conne
     cannot be verified because the Certificate Authority is not recognized or the
     certificate is self signed, the vCenter Server will fall back to thumbprint verification
     mode as defined by Host.CreateSpec.ThumbprintVerification.
+deprecated:
+    removed_in: 5.0.0
+    why: This module has been moved to the L(new vmware.vmware collection,https://forum.ansible.com/t/5880)
+    alternative: Use M(vmware.vmware.esxi_host) instead.
 options:
     folder:
         description:

--- a/plugins/modules/vcenter_vm_guest_networking_interfaces_info.py
+++ b/plugins/modules/vcenter_vm_guest_networking_interfaces_info.py
@@ -13,6 +13,10 @@ short_description: Returns information about the networking interfaces in the gu
     operating system.
 description: Returns information about the networking interfaces in the guest operating
     system.
+deprecated:
+    removed_in: 5.0.0
+    why: This module has been moved to the L(new vmware.vmware collection,https://forum.ansible.com/t/5880)
+    alternative: Use M(vmware.vmware.vm_portgroup_info) instead.
 options:
     session_timeout:
         description:

--- a/plugins/modules/vcenter_vm_guest_power.py
+++ b/plugins/modules/vcenter_vm_guest_power.py
@@ -14,6 +14,10 @@ short_description: Issues a request to the guest operating system asking it to p
 description: Issues a request to the guest operating system asking it to perform a
     soft shutdown, standby (suspend) or soft reboot. This request returns immediately
     and does not wait for the guest operating.
+deprecated:
+    removed_in: 5.0.0
+    why: This module has been moved to the L(new vmware.vmware collection,https://forum.ansible.com/t/5880)
+    alternative: Use M(vmware.vmware.vm_powerstate) instead.
 options:
     session_timeout:
         description:

--- a/plugins/modules/vcenter_vm_hardware_cpu_info.py
+++ b/plugins/modules/vcenter_vm_hardware_cpu_info.py
@@ -11,6 +11,10 @@ DOCUMENTATION = r"""
 module: vcenter_vm_hardware_cpu_info
 short_description: Returns the CPU-related settings of a virtual machine.
 description: Returns the CPU-related settings of a virtual machine.
+deprecated:
+    removed_in: 5.0.0
+    why: This module has been moved to the L(new vmware.vmware collection,https://forum.ansible.com/t/5880)
+    alternative: Use M(vmware.vmware.vm_resource_info) instead.
 options:
     session_timeout:
         description:

--- a/plugins/modules/vcenter_vm_hardware_memory_info.py
+++ b/plugins/modules/vcenter_vm_hardware_memory_info.py
@@ -11,6 +11,10 @@ DOCUMENTATION = r"""
 module: vcenter_vm_hardware_memory_info
 short_description: Returns the memory-related settings of a virtual machine.
 description: Returns the memory-related settings of a virtual machine.
+deprecated:
+    removed_in: 5.0.0
+    why: This module has been moved to the L(new vmware.vmware collection,https://forum.ansible.com/t/5880)
+    alternative: Use M(vmware.vmware.vm_resource_info) instead.
 options:
     session_timeout:
         description:

--- a/plugins/modules/vcenter_vm_libraryitem_info.py
+++ b/plugins/modules/vcenter_vm_libraryitem_info.py
@@ -13,6 +13,10 @@ short_description: Returns the information about the library item associated wit
     the virtual machine.
 description: Returns the information about the library item associated with the virtual
     machine.
+deprecated:
+    removed_in: 5.0.0
+    why: This module has been moved to the L(new vmware.vmware collection,https://forum.ansible.com/t/5880)
+    alternative: Use M(vmware.vmware.content_library_item_info) instead.
 options:
     session_timeout:
         description:

--- a/plugins/modules/vcenter_vm_power.py
+++ b/plugins/modules/vcenter_vm_power.py
@@ -12,6 +12,10 @@ module: vcenter_vm_power
 short_description: Operate a boot, hard shutdown, hard reset or hard suspend on a
     guest.
 description: Ask the vCenter to boot, force shutdown or force reset a guest.
+deprecated:
+    removed_in: 5.0.0
+    why: This module has been moved to the L(new vmware.vmware collection,https://forum.ansible.com/t/5880)
+    alternative: Use M(vmware.vmware.vm_powerstate) instead.
 options:
     session_timeout:
         description:

--- a/plugins/modules/vcenter_vmtemplate_libraryitems_info.py
+++ b/plugins/modules/vcenter_vmtemplate_libraryitems_info.py
@@ -13,6 +13,10 @@ short_description: Returns information about a virtual machine template containe
     in the library item specified by templateLibraryItem
 description: Returns information about a virtual machine template contained in the
     library item specified by templateLibraryItem
+deprecated:
+    removed_in: 5.0.0
+    why: This module has been moved to the L(new vmware.vmware collection,https://forum.ansible.com/t/5880)
+    alternative: Use M(vmware.vmware.content_library_items_info) instead.
 options:
     session_timeout:
         description:

--- a/plugins/modules/vcenter_vmtemplate_libraryitems_info.py
+++ b/plugins/modules/vcenter_vmtemplate_libraryitems_info.py
@@ -16,7 +16,7 @@ description: Returns information about a virtual machine template contained in t
 deprecated:
     removed_in: 5.0.0
     why: This module has been moved to the L(new vmware.vmware collection,https://forum.ansible.com/t/5880)
-    alternative: Use M(vmware.vmware.content_library_items_info) instead.
+    alternative: Use M(vmware.vmware.content_library_item_info) instead.
 options:
     session_timeout:
         description:


### PR DESCRIPTION
##### SUMMARY
Relates to https://github.com/ansible-collections/vmware.vmware_rest/issues/589

This deprecates modules with vmware.vmware replacements. There is no planned date for release 5, it would be whenever there is a new major update for the vSphere API. However, it does not make sense to support these modules when more maintainable ones are available.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
    vcenter_vmtemplate_libraryitems_info -> vmware.vmware.content_library_item_info
    vcenter_vm_hardware_memory_info -> vmware.vmware.vm_resource_info
    vcenter_vm_hardware_cpu_info -> vmware.vmware.vm_resource_info
    vcenter_vm_guest_networking_interfaces_info -> vmware.vmware.vm_portgroup_info
    vcenter_host -> vmware.vmware.esxi_host
    vcenter_cluster_info -> vmware.vmware.cluster_info
    content_subscribedlibrary -> vmware.vmware.subscribed_content_library
    content_locallibrary -> vmware.vmware.local_content_library
    appliance_networking_firewall_inbound -> vmware.vmware.vcsa_settings
    appliance_networking_firewall_inbound_info -> vmware.vmware.appliance_info
    appliance_access_consolecli -> vmware.vmware.vcsa_settings
    appliance_access_consolecli_info -> vmware.vmware.appliance_info
    appliance_access_ssh -> vmware.vmware.vcsa_settings
    appliance_access_ssh_info -> vmware.vmware.appliance_info
    appliance_access_shell -> vmware.vmware.vcsa_settings
    appliance_access_shell_info -> vmware.vmware.appliance_info
    appliance_access_dcui -> vmware.vmware.vcsa_settings
    appliance_access_dcui_info -> vmware.vmware.appliance_info
    appliance_access_shell -> vmware.vmware.vcsa_settings
    appliance_access_shell_info -> vmware.vmware.appliance_info
    appliance_networking_proxy -> vmware.vmware.vcsa_settings
    appliance_networking_proxy_info -> vmware.vmware.appliance_info
    appliance_networking_noproxy -> vmware.vmware.vcsa_settings
    appliance_networking_noproxy_info -> vmware.vmware.appliance_info
    appliance_ntp -> vmware.vmware.vcsa_settings
    appliance_ntp_info -> vmware.vmware.appliance_info
    appliance_timesync -> vmware.vmware.vcsa_settings
    appliance_timesync_info -> vmware.vmware.appliance_info
    appliance_networking_dns_domains -> vmware.vmware.vcsa_settings
    appliance_networking_dns_domains_info -> vmware.vmware.appliance_info
    appliance_networking_dns_servers -> vmware.vmware.vcsa_settings
    appliance_networking_dns_servers_info -> vmware.vmware.appliance_info
    appliance_networking_dns_hostname -> vmware.vmware.vcsa_settings
    appliance_networking_dns_hostname_info -> vmware.vmware.appliance_info
    appliance_system_time_timezone -> vmware.vmware.vcsa_settings
    appliance_system_time_timezone_info -> vmware.vmware.appliance_info
    appliance_system_globalfips -> vmware.vmware.vcsa_settings
    appliance_system_globalfips_info -> vmware.vmware.appliance_info
    vcenter_vm_guest_power -> vmware.vmware.vm_powerstate
    vcenter_vm_power -> vmware.vmware.vm_powerstate
