### PR TITLE
Fix requirements and vm_moid test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,14 +13,14 @@ install-ansible-collections:
 
 .PHONY: install-python-packages
 install-python-packages:
-	pip3 install -r tests/integration/requirements.txt
+	pip3 install -r tests/integration/requirements.txt --force
 
 .PHONY: remove_aliases
 remove_aliases:
 	@find tests/integration/targets/ -name "aliases" -exec rm -f {} +
 
 .PHONY: eco-vcenter-ci
-eco-vcenter-ci: install-ansible-collections prepare_symlinks remove_aliases
+eco-vcenter-ci: install-python-packages install-ansible-collections prepare_symlinks remove_aliases
 	@[ -f /tmp/vmware_rest_tests_report.txt ] && rm /tmp/vmware_rest_tests_report.txt || true; \
 	@failed=0; \
 	total=0; \

--- a/tests/integration/requirements.yml
+++ b/tests/integration/requirements.yml
@@ -1,2 +1,4 @@
 collections:
   - name: vmware.vmware
+  - name: community.vmware
+  - name: cloud.common

--- a/tests/integration/targets/vmware_rest_lookup_plugin/tasks/test_vm_moid.yml
+++ b/tests/integration/targets/vmware_rest_lookup_plugin/tasks/test_vm_moid.yml
@@ -1,14 +1,8 @@
-- name: Get random VM's info
-  vmware.vmware_rest.vcenter_vm_info:
-    vm: "{{ lookup('vmware.vmware_rest.vm_moid', '/' + vcenter_datacenter + '/' + vcenter_cluster_name + '/')[0] }}"
-  register: vm_info
-
 - name: Lookup VMs
   ansible.builtin.assert:
     that: lookup('vmware.vmware_rest.vm_moid', '/' + vcenter_datacenter + '/' + vcenter_cluster_name + '/' + item)
   loop:
     - "{{ vcenter_host_name }}/"
-    - "{{ vm_info.value.identity.name }}"
     - "{{ vcenter_resource_pool }}/"
 
 - name: Verify number of VMs in a cluster


### PR DESCRIPTION
Changes:
- Added used collections in requirements.yml
- Added install-python-packages step to eco-vcenter-ci workflow
- Removed task with random VM from vm_moid test to prevent failure in case the chosen random name isn't unique