### PR TITLE
disable turbo mode in modules by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,13 @@ System programmers can enable pipelines to setup, tear down and deploy VMs while
 These modules are based on the [vSphere REST API](https://developer.vmware.com/apis/vsphere-automation/latest/). This API doesn't provide any mechanism to list or clone VM templates when they are stored in a VM folder.
 To circumvent this limitation, you should store your VM templates in a [Content Library](https://docs.vmware.com/en/VMware-vSphere/7.0/com.vmware.vsphere.vm_admin.doc/GUID-254B2CE8-20A8-43F0-90E8-3F6776C2C896.html).
 
+#### Slower execution times
+
+This collection is capable of leveraging a feature of the cloud.common collection called the "turbo server". This is a caching mechanism that speeds up repeated API calls, but it does come with some downsides.
+
+This collection has used turbo mode up until version 4.8.0. With the release of 4.8.0, turbo mode is disabled by default but can be re-enabled using an environment variable. Read more [here](docs/turbo_mode.md).
+
+
 
 ## Requirements
 

--- a/changelogs/fragments/600-disable-turbo-mode.yml
+++ b/changelogs/fragments/600-disable-turbo-mode.yml
@@ -1,0 +1,6 @@
+---
+minor_changes:
+  - >-
+    modules - disable turbo mode for module execution by default. Make it optional
+    to enable it using an environment variable
+    (https://github.com/ansible-collections/vmware.vmware_rest/issues/499)

--- a/changelogs/fragments/600-disable-turbo-mode.yml
+++ b/changelogs/fragments/600-disable-turbo-mode.yml
@@ -1,5 +1,5 @@
 ---
-minor_changes:
+major_changes:
   - >-
     modules - disable turbo mode for module execution by default. Make it optional
     to enable it using an environment variable

--- a/docs/turbo_mode.md
+++ b/docs/turbo_mode.md
@@ -1,0 +1,34 @@
+# vmware.vmware_rest Turbo Mode
+
+This collection is capable of leveraging a feature of the cloud.common collection called the "turbo server". This is basically a caching mechanism that speeds up repeated API calls. This collection has used turbo mode up until version 4.8.0. With the release of 4.8.0, turbo mode is disabled by default but can be re-enabled using an environment variable.
+
+Read more about the turbo server in the cloud.common documentation [here](https://github.com/ansible-collections/cloud.common?tab=readme-ov-file#ansible-turbo-module).
+
+## Enabling or Disabling
+
+By default, the turbo server mode is disabled. You can explicitly enable or disable it using an environment variable.
+If you are executing the playbook using localhost:
+```bash
+export VMWARE_ENABLE_TURBO="true"   # or 1, or True
+ansible-playbook .....
+```
+
+You can also set it in the playbook `environment`:
+```yaml
+- name: Do something
+  hosts: my_host
+  environment:
+    VMWARE_ENABLE_TURBO: true
+  tasks:
+    .....
+```
+
+## Pros and Cons
+
+The turbo server works by creating a local cache of Ansible files on the remote Ansible host. It opens a socket on the host as a mechanism for modules to read and write from the cache. This enables the first module to load whatever librarys are required and setup API connections, store them in the cache, and allow other modules to reuse those resources. <b>It noticeably speeds up module execution time.</b>
+
+Because data needs to be passed through the socket to read/write from the cache, <b>there are restrictions on the type of data that can be returned by modules.</b> Everything needs to be serializable, and not all python objects are by default.
+
+The socket and server also add complexity and additional layers of obfuscation to the Ansible process. <b>Errors during module execution can be mangled or obscured</b> as data is passed through the turbo server socket. Errors will often become completely masked and give unhelpful messages to the user.
+
+Finally, <b>the cache includes many pieces of the module execution process which can hinder execution on multiple resources</b>. For example, since the authentication to a vCenter will be cached, you cannot use one vCenter for a module call and then switch to a second vCenter immediately after. See issue [364](https://github.com/ansible-collections/vmware.vmware_rest/issues/364).

--- a/plugins/modules/appliance_access_consolecli.py
+++ b/plugins/modules/appliance_access_consolecli.py
@@ -109,7 +109,7 @@ from ansible.module_utils.basic import env_fallback
 import os
 
 try:
-    if not os.getenv('VMWARE_ENABLE_TURBO', False):
+    if not os.getenv("VMWARE_ENABLE_TURBO", False):
         raise ImportError()
 
     from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (

--- a/plugins/modules/appliance_access_consolecli.py
+++ b/plugins/modules/appliance_access_consolecli.py
@@ -108,20 +108,21 @@ PAYLOAD_FORMAT = {
 from ansible.module_utils.basic import env_fallback
 import os
 
-try:
-    if not os.getenv("VMWARE_ENABLE_TURBO", False):
-        raise ImportError()
+if os.getenv("VMWARE_ENABLE_TURBO", False):
+    try:
+        from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
+            EmbeddedModuleFailure,
+        )
+        from ansible_collections.cloud.common.plugins.module_utils.turbo.module import (
+            AnsibleTurboModule as AnsibleModule,
+        )
 
-    from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
-        EmbeddedModuleFailure,
-    )
-    from ansible_collections.cloud.common.plugins.module_utils.turbo.module import (
-        AnsibleTurboModule as AnsibleModule,
-    )
-
-    AnsibleModule.collection_name = "vmware.vmware_rest"
-except ImportError:
+        AnsibleModule.collection_name = "vmware.vmware_rest"
+    except ImportError:
+        from ansible.module_utils.basic import AnsibleModule
+else:
     from ansible.module_utils.basic import AnsibleModule
+
 from ansible_collections.vmware.vmware_rest.plugins.module_utils.vmware_rest import (
     exists,
     gen_args,

--- a/plugins/modules/appliance_access_consolecli.py
+++ b/plugins/modules/appliance_access_consolecli.py
@@ -106,8 +106,12 @@ PAYLOAD_FORMAT = {
 }  # pylint: disable=line-too-long
 
 from ansible.module_utils.basic import env_fallback
+import os
 
 try:
+    if not os.getenv('VMWARE_ENABLE_TURBO', False):
+        raise ImportError()
+
     from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
         EmbeddedModuleFailure,
     )

--- a/plugins/modules/appliance_access_consolecli_info.py
+++ b/plugins/modules/appliance_access_consolecli_info.py
@@ -92,8 +92,12 @@ PAYLOAD_FORMAT = {
 }  # pylint: disable=line-too-long
 
 from ansible.module_utils.basic import env_fallback
+import os
 
 try:
+    if not os.getenv('VMWARE_ENABLE_TURBO', False):
+        raise ImportError()
+
     from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
         EmbeddedModuleFailure,
     )
@@ -104,6 +108,7 @@ try:
     AnsibleModule.collection_name = "vmware.vmware_rest"
 except ImportError:
     from ansible.module_utils.basic import AnsibleModule
+
 from ansible_collections.vmware.vmware_rest.plugins.module_utils.vmware_rest import (
     gen_args,
     open_session,

--- a/plugins/modules/appliance_access_consolecli_info.py
+++ b/plugins/modules/appliance_access_consolecli_info.py
@@ -95,7 +95,7 @@ from ansible.module_utils.basic import env_fallback
 import os
 
 try:
-    if not os.getenv('VMWARE_ENABLE_TURBO', False):
+    if not os.getenv("VMWARE_ENABLE_TURBO", False):
         raise ImportError()
 
     from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (

--- a/plugins/modules/appliance_access_consolecli_info.py
+++ b/plugins/modules/appliance_access_consolecli_info.py
@@ -94,19 +94,19 @@ PAYLOAD_FORMAT = {
 from ansible.module_utils.basic import env_fallback
 import os
 
-try:
-    if not os.getenv("VMWARE_ENABLE_TURBO", False):
-        raise ImportError()
+if os.getenv("VMWARE_ENABLE_TURBO", False):
+    try:
+        from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
+            EmbeddedModuleFailure,
+        )
+        from ansible_collections.cloud.common.plugins.module_utils.turbo.module import (
+            AnsibleTurboModule as AnsibleModule,
+        )
 
-    from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
-        EmbeddedModuleFailure,
-    )
-    from ansible_collections.cloud.common.plugins.module_utils.turbo.module import (
-        AnsibleTurboModule as AnsibleModule,
-    )
-
-    AnsibleModule.collection_name = "vmware.vmware_rest"
-except ImportError:
+        AnsibleModule.collection_name = "vmware.vmware_rest"
+    except ImportError:
+        from ansible.module_utils.basic import AnsibleModule
+else:
     from ansible.module_utils.basic import AnsibleModule
 
 from ansible_collections.vmware.vmware_rest.plugins.module_utils.vmware_rest import (

--- a/plugins/modules/appliance_access_dcui.py
+++ b/plugins/modules/appliance_access_dcui.py
@@ -106,20 +106,21 @@ PAYLOAD_FORMAT = {
 from ansible.module_utils.basic import env_fallback
 import os
 
-try:
-    if not os.getenv("VMWARE_ENABLE_TURBO", False):
-        raise ImportError()
+if os.getenv("VMWARE_ENABLE_TURBO", False):
+    try:
+        from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
+            EmbeddedModuleFailure,
+        )
+        from ansible_collections.cloud.common.plugins.module_utils.turbo.module import (
+            AnsibleTurboModule as AnsibleModule,
+        )
 
-    from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
-        EmbeddedModuleFailure,
-    )
-    from ansible_collections.cloud.common.plugins.module_utils.turbo.module import (
-        AnsibleTurboModule as AnsibleModule,
-    )
-
-    AnsibleModule.collection_name = "vmware.vmware_rest"
-except ImportError:
+        AnsibleModule.collection_name = "vmware.vmware_rest"
+    except ImportError:
+        from ansible.module_utils.basic import AnsibleModule
+else:
     from ansible.module_utils.basic import AnsibleModule
+
 from ansible_collections.vmware.vmware_rest.plugins.module_utils.vmware_rest import (
     exists,
     gen_args,

--- a/plugins/modules/appliance_access_dcui.py
+++ b/plugins/modules/appliance_access_dcui.py
@@ -104,8 +104,12 @@ PAYLOAD_FORMAT = {
 }  # pylint: disable=line-too-long
 
 from ansible.module_utils.basic import env_fallback
+import os
 
 try:
+    if not os.getenv('VMWARE_ENABLE_TURBO', False):
+        raise ImportError()
+
     from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
         EmbeddedModuleFailure,
     )

--- a/plugins/modules/appliance_access_dcui.py
+++ b/plugins/modules/appliance_access_dcui.py
@@ -107,7 +107,7 @@ from ansible.module_utils.basic import env_fallback
 import os
 
 try:
-    if not os.getenv('VMWARE_ENABLE_TURBO', False):
+    if not os.getenv("VMWARE_ENABLE_TURBO", False):
         raise ImportError()
 
     from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (

--- a/plugins/modules/appliance_access_dcui_info.py
+++ b/plugins/modules/appliance_access_dcui_info.py
@@ -95,7 +95,7 @@ from ansible.module_utils.basic import env_fallback
 import os
 
 try:
-    if not os.getenv('VMWARE_ENABLE_TURBO', False):
+    if not os.getenv("VMWARE_ENABLE_TURBO", False):
         raise ImportError()
 
     from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (

--- a/plugins/modules/appliance_access_dcui_info.py
+++ b/plugins/modules/appliance_access_dcui_info.py
@@ -94,20 +94,21 @@ PAYLOAD_FORMAT = {
 from ansible.module_utils.basic import env_fallback
 import os
 
-try:
-    if not os.getenv("VMWARE_ENABLE_TURBO", False):
-        raise ImportError()
+if os.getenv("VMWARE_ENABLE_TURBO", False):
+    try:
+        from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
+            EmbeddedModuleFailure,
+        )
+        from ansible_collections.cloud.common.plugins.module_utils.turbo.module import (
+            AnsibleTurboModule as AnsibleModule,
+        )
 
-    from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
-        EmbeddedModuleFailure,
-    )
-    from ansible_collections.cloud.common.plugins.module_utils.turbo.module import (
-        AnsibleTurboModule as AnsibleModule,
-    )
-
-    AnsibleModule.collection_name = "vmware.vmware_rest"
-except ImportError:
+        AnsibleModule.collection_name = "vmware.vmware_rest"
+    except ImportError:
+        from ansible.module_utils.basic import AnsibleModule
+else:
     from ansible.module_utils.basic import AnsibleModule
+
 from ansible_collections.vmware.vmware_rest.plugins.module_utils.vmware_rest import (
     gen_args,
     open_session,

--- a/plugins/modules/appliance_access_dcui_info.py
+++ b/plugins/modules/appliance_access_dcui_info.py
@@ -92,8 +92,12 @@ PAYLOAD_FORMAT = {
 }  # pylint: disable=line-too-long
 
 from ansible.module_utils.basic import env_fallback
+import os
 
 try:
+    if not os.getenv('VMWARE_ENABLE_TURBO', False):
+        raise ImportError()
+
     from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
         EmbeddedModuleFailure,
     )

--- a/plugins/modules/appliance_access_shell.py
+++ b/plugins/modules/appliance_access_shell.py
@@ -127,20 +127,21 @@ PAYLOAD_FORMAT = {
 from ansible.module_utils.basic import env_fallback
 import os
 
-try:
-    if not os.getenv("VMWARE_ENABLE_TURBO", False):
-        raise ImportError()
+if os.getenv("VMWARE_ENABLE_TURBO", False):
+    try:
+        from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
+            EmbeddedModuleFailure,
+        )
+        from ansible_collections.cloud.common.plugins.module_utils.turbo.module import (
+            AnsibleTurboModule as AnsibleModule,
+        )
 
-    from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
-        EmbeddedModuleFailure,
-    )
-    from ansible_collections.cloud.common.plugins.module_utils.turbo.module import (
-        AnsibleTurboModule as AnsibleModule,
-    )
-
-    AnsibleModule.collection_name = "vmware.vmware_rest"
-except ImportError:
+        AnsibleModule.collection_name = "vmware.vmware_rest"
+    except ImportError:
+        from ansible.module_utils.basic import AnsibleModule
+else:
     from ansible.module_utils.basic import AnsibleModule
+
 from ansible_collections.vmware.vmware_rest.plugins.module_utils.vmware_rest import (
     exists,
     gen_args,

--- a/plugins/modules/appliance_access_shell.py
+++ b/plugins/modules/appliance_access_shell.py
@@ -128,7 +128,7 @@ from ansible.module_utils.basic import env_fallback
 import os
 
 try:
-    if not os.getenv('VMWARE_ENABLE_TURBO', False):
+    if not os.getenv("VMWARE_ENABLE_TURBO", False):
         raise ImportError()
 
     from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (

--- a/plugins/modules/appliance_access_shell.py
+++ b/plugins/modules/appliance_access_shell.py
@@ -125,8 +125,12 @@ PAYLOAD_FORMAT = {
 }  # pylint: disable=line-too-long
 
 from ansible.module_utils.basic import env_fallback
+import os
 
 try:
+    if not os.getenv('VMWARE_ENABLE_TURBO', False):
+        raise ImportError()
+
     from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
         EmbeddedModuleFailure,
     )

--- a/plugins/modules/appliance_access_shell_info.py
+++ b/plugins/modules/appliance_access_shell_info.py
@@ -97,8 +97,12 @@ PAYLOAD_FORMAT = {
 }  # pylint: disable=line-too-long
 
 from ansible.module_utils.basic import env_fallback
+import os
 
 try:
+    if not os.getenv('VMWARE_ENABLE_TURBO', False):
+        raise ImportError()
+
     from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
         EmbeddedModuleFailure,
     )

--- a/plugins/modules/appliance_access_shell_info.py
+++ b/plugins/modules/appliance_access_shell_info.py
@@ -99,20 +99,21 @@ PAYLOAD_FORMAT = {
 from ansible.module_utils.basic import env_fallback
 import os
 
-try:
-    if not os.getenv("VMWARE_ENABLE_TURBO", False):
-        raise ImportError()
+if os.getenv("VMWARE_ENABLE_TURBO", False):
+    try:
+        from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
+            EmbeddedModuleFailure,
+        )
+        from ansible_collections.cloud.common.plugins.module_utils.turbo.module import (
+            AnsibleTurboModule as AnsibleModule,
+        )
 
-    from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
-        EmbeddedModuleFailure,
-    )
-    from ansible_collections.cloud.common.plugins.module_utils.turbo.module import (
-        AnsibleTurboModule as AnsibleModule,
-    )
-
-    AnsibleModule.collection_name = "vmware.vmware_rest"
-except ImportError:
+        AnsibleModule.collection_name = "vmware.vmware_rest"
+    except ImportError:
+        from ansible.module_utils.basic import AnsibleModule
+else:
     from ansible.module_utils.basic import AnsibleModule
+
 from ansible_collections.vmware.vmware_rest.plugins.module_utils.vmware_rest import (
     gen_args,
     open_session,

--- a/plugins/modules/appliance_access_shell_info.py
+++ b/plugins/modules/appliance_access_shell_info.py
@@ -100,7 +100,7 @@ from ansible.module_utils.basic import env_fallback
 import os
 
 try:
-    if not os.getenv('VMWARE_ENABLE_TURBO', False):
+    if not os.getenv("VMWARE_ENABLE_TURBO", False):
         raise ImportError()
 
     from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (

--- a/plugins/modules/appliance_access_ssh.py
+++ b/plugins/modules/appliance_access_ssh.py
@@ -108,7 +108,7 @@ from ansible.module_utils.basic import env_fallback
 import os
 
 try:
-    if not os.getenv('VMWARE_ENABLE_TURBO', False):
+    if not os.getenv("VMWARE_ENABLE_TURBO", False):
         raise ImportError()
 
     from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (

--- a/plugins/modules/appliance_access_ssh.py
+++ b/plugins/modules/appliance_access_ssh.py
@@ -107,20 +107,21 @@ PAYLOAD_FORMAT = {
 from ansible.module_utils.basic import env_fallback
 import os
 
-try:
-    if not os.getenv("VMWARE_ENABLE_TURBO", False):
-        raise ImportError()
+if os.getenv("VMWARE_ENABLE_TURBO", False):
+    try:
+        from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
+            EmbeddedModuleFailure,
+        )
+        from ansible_collections.cloud.common.plugins.module_utils.turbo.module import (
+            AnsibleTurboModule as AnsibleModule,
+        )
 
-    from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
-        EmbeddedModuleFailure,
-    )
-    from ansible_collections.cloud.common.plugins.module_utils.turbo.module import (
-        AnsibleTurboModule as AnsibleModule,
-    )
-
-    AnsibleModule.collection_name = "vmware.vmware_rest"
-except ImportError:
+        AnsibleModule.collection_name = "vmware.vmware_rest"
+    except ImportError:
+        from ansible.module_utils.basic import AnsibleModule
+else:
     from ansible.module_utils.basic import AnsibleModule
+
 from ansible_collections.vmware.vmware_rest.plugins.module_utils.vmware_rest import (
     exists,
     gen_args,

--- a/plugins/modules/appliance_access_ssh.py
+++ b/plugins/modules/appliance_access_ssh.py
@@ -105,8 +105,12 @@ PAYLOAD_FORMAT = {
 }  # pylint: disable=line-too-long
 
 from ansible.module_utils.basic import env_fallback
+import os
 
 try:
+    if not os.getenv('VMWARE_ENABLE_TURBO', False):
+        raise ImportError()
+
     from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
         EmbeddedModuleFailure,
     )

--- a/plugins/modules/appliance_access_ssh_info.py
+++ b/plugins/modules/appliance_access_ssh_info.py
@@ -96,7 +96,7 @@ from ansible.module_utils.basic import env_fallback
 import os
 
 try:
-    if not os.getenv('VMWARE_ENABLE_TURBO', False):
+    if not os.getenv("VMWARE_ENABLE_TURBO", False):
         raise ImportError()
 
     from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (

--- a/plugins/modules/appliance_access_ssh_info.py
+++ b/plugins/modules/appliance_access_ssh_info.py
@@ -93,8 +93,12 @@ PAYLOAD_FORMAT = {
 }  # pylint: disable=line-too-long
 
 from ansible.module_utils.basic import env_fallback
+import os
 
 try:
+    if not os.getenv('VMWARE_ENABLE_TURBO', False):
+        raise ImportError()
+
     from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
         EmbeddedModuleFailure,
     )

--- a/plugins/modules/appliance_access_ssh_info.py
+++ b/plugins/modules/appliance_access_ssh_info.py
@@ -95,20 +95,21 @@ PAYLOAD_FORMAT = {
 from ansible.module_utils.basic import env_fallback
 import os
 
-try:
-    if not os.getenv("VMWARE_ENABLE_TURBO", False):
-        raise ImportError()
+if os.getenv("VMWARE_ENABLE_TURBO", False):
+    try:
+        from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
+            EmbeddedModuleFailure,
+        )
+        from ansible_collections.cloud.common.plugins.module_utils.turbo.module import (
+            AnsibleTurboModule as AnsibleModule,
+        )
 
-    from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
-        EmbeddedModuleFailure,
-    )
-    from ansible_collections.cloud.common.plugins.module_utils.turbo.module import (
-        AnsibleTurboModule as AnsibleModule,
-    )
-
-    AnsibleModule.collection_name = "vmware.vmware_rest"
-except ImportError:
+        AnsibleModule.collection_name = "vmware.vmware_rest"
+    except ImportError:
+        from ansible.module_utils.basic import AnsibleModule
+else:
     from ansible.module_utils.basic import AnsibleModule
+
 from ansible_collections.vmware.vmware_rest.plugins.module_utils.vmware_rest import (
     gen_args,
     open_session,

--- a/plugins/modules/appliance_health_applmgmt_info.py
+++ b/plugins/modules/appliance_health_applmgmt_info.py
@@ -91,20 +91,21 @@ PAYLOAD_FORMAT = {
 from ansible.module_utils.basic import env_fallback
 import os
 
-try:
-    if not os.getenv("VMWARE_ENABLE_TURBO", False):
-        raise ImportError()
+if os.getenv("VMWARE_ENABLE_TURBO", False):
+    try:
+        from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
+            EmbeddedModuleFailure,
+        )
+        from ansible_collections.cloud.common.plugins.module_utils.turbo.module import (
+            AnsibleTurboModule as AnsibleModule,
+        )
 
-    from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
-        EmbeddedModuleFailure,
-    )
-    from ansible_collections.cloud.common.plugins.module_utils.turbo.module import (
-        AnsibleTurboModule as AnsibleModule,
-    )
-
-    AnsibleModule.collection_name = "vmware.vmware_rest"
-except ImportError:
+        AnsibleModule.collection_name = "vmware.vmware_rest"
+    except ImportError:
+        from ansible.module_utils.basic import AnsibleModule
+else:
     from ansible.module_utils.basic import AnsibleModule
+
 from ansible_collections.vmware.vmware_rest.plugins.module_utils.vmware_rest import (
     gen_args,
     open_session,

--- a/plugins/modules/appliance_health_applmgmt_info.py
+++ b/plugins/modules/appliance_health_applmgmt_info.py
@@ -92,7 +92,7 @@ from ansible.module_utils.basic import env_fallback
 import os
 
 try:
-    if not os.getenv('VMWARE_ENABLE_TURBO', False):
+    if not os.getenv("VMWARE_ENABLE_TURBO", False):
         raise ImportError()
 
     from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (

--- a/plugins/modules/appliance_health_applmgmt_info.py
+++ b/plugins/modules/appliance_health_applmgmt_info.py
@@ -89,8 +89,12 @@ PAYLOAD_FORMAT = {
 }  # pylint: disable=line-too-long
 
 from ansible.module_utils.basic import env_fallback
+import os
 
 try:
+    if not os.getenv('VMWARE_ENABLE_TURBO', False):
+        raise ImportError()
+
     from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
         EmbeddedModuleFailure,
     )

--- a/plugins/modules/appliance_health_database_info.py
+++ b/plugins/modules/appliance_health_database_info.py
@@ -85,20 +85,21 @@ PAYLOAD_FORMAT = {
 from ansible.module_utils.basic import env_fallback
 import os
 
-try:
-    if not os.getenv("VMWARE_ENABLE_TURBO", False):
-        raise ImportError()
+if os.getenv("VMWARE_ENABLE_TURBO", False):
+    try:
+        from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
+            EmbeddedModuleFailure,
+        )
+        from ansible_collections.cloud.common.plugins.module_utils.turbo.module import (
+            AnsibleTurboModule as AnsibleModule,
+        )
 
-    from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
-        EmbeddedModuleFailure,
-    )
-    from ansible_collections.cloud.common.plugins.module_utils.turbo.module import (
-        AnsibleTurboModule as AnsibleModule,
-    )
-
-    AnsibleModule.collection_name = "vmware.vmware_rest"
-except ImportError:
+        AnsibleModule.collection_name = "vmware.vmware_rest"
+    except ImportError:
+        from ansible.module_utils.basic import AnsibleModule
+else:
     from ansible.module_utils.basic import AnsibleModule
+
 from ansible_collections.vmware.vmware_rest.plugins.module_utils.vmware_rest import (
     gen_args,
     open_session,

--- a/plugins/modules/appliance_health_database_info.py
+++ b/plugins/modules/appliance_health_database_info.py
@@ -86,7 +86,7 @@ from ansible.module_utils.basic import env_fallback
 import os
 
 try:
-    if not os.getenv('VMWARE_ENABLE_TURBO', False):
+    if not os.getenv("VMWARE_ENABLE_TURBO", False):
         raise ImportError()
 
     from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (

--- a/plugins/modules/appliance_health_database_info.py
+++ b/plugins/modules/appliance_health_database_info.py
@@ -83,8 +83,12 @@ PAYLOAD_FORMAT = {
 }  # pylint: disable=line-too-long
 
 from ansible.module_utils.basic import env_fallback
+import os
 
 try:
+    if not os.getenv('VMWARE_ENABLE_TURBO', False):
+        raise ImportError()
+
     from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
         EmbeddedModuleFailure,
     )

--- a/plugins/modules/appliance_health_databasestorage_info.py
+++ b/plugins/modules/appliance_health_databasestorage_info.py
@@ -91,20 +91,21 @@ PAYLOAD_FORMAT = {
 from ansible.module_utils.basic import env_fallback
 import os
 
-try:
-    if not os.getenv("VMWARE_ENABLE_TURBO", False):
-        raise ImportError()
+if os.getenv("VMWARE_ENABLE_TURBO", False):
+    try:
+        from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
+            EmbeddedModuleFailure,
+        )
+        from ansible_collections.cloud.common.plugins.module_utils.turbo.module import (
+            AnsibleTurboModule as AnsibleModule,
+        )
 
-    from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
-        EmbeddedModuleFailure,
-    )
-    from ansible_collections.cloud.common.plugins.module_utils.turbo.module import (
-        AnsibleTurboModule as AnsibleModule,
-    )
-
-    AnsibleModule.collection_name = "vmware.vmware_rest"
-except ImportError:
+        AnsibleModule.collection_name = "vmware.vmware_rest"
+    except ImportError:
+        from ansible.module_utils.basic import AnsibleModule
+else:
     from ansible.module_utils.basic import AnsibleModule
+
 from ansible_collections.vmware.vmware_rest.plugins.module_utils.vmware_rest import (
     gen_args,
     open_session,

--- a/plugins/modules/appliance_health_databasestorage_info.py
+++ b/plugins/modules/appliance_health_databasestorage_info.py
@@ -92,7 +92,7 @@ from ansible.module_utils.basic import env_fallback
 import os
 
 try:
-    if not os.getenv('VMWARE_ENABLE_TURBO', False):
+    if not os.getenv("VMWARE_ENABLE_TURBO", False):
         raise ImportError()
 
     from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (

--- a/plugins/modules/appliance_health_databasestorage_info.py
+++ b/plugins/modules/appliance_health_databasestorage_info.py
@@ -89,8 +89,12 @@ PAYLOAD_FORMAT = {
 }  # pylint: disable=line-too-long
 
 from ansible.module_utils.basic import env_fallback
+import os
 
 try:
+    if not os.getenv('VMWARE_ENABLE_TURBO', False):
+        raise ImportError()
+
     from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
         EmbeddedModuleFailure,
     )

--- a/plugins/modules/appliance_health_load_info.py
+++ b/plugins/modules/appliance_health_load_info.py
@@ -91,20 +91,21 @@ PAYLOAD_FORMAT = {
 from ansible.module_utils.basic import env_fallback
 import os
 
-try:
-    if not os.getenv("VMWARE_ENABLE_TURBO", False):
-        raise ImportError()
+if os.getenv("VMWARE_ENABLE_TURBO", False):
+    try:
+        from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
+            EmbeddedModuleFailure,
+        )
+        from ansible_collections.cloud.common.plugins.module_utils.turbo.module import (
+            AnsibleTurboModule as AnsibleModule,
+        )
 
-    from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
-        EmbeddedModuleFailure,
-    )
-    from ansible_collections.cloud.common.plugins.module_utils.turbo.module import (
-        AnsibleTurboModule as AnsibleModule,
-    )
-
-    AnsibleModule.collection_name = "vmware.vmware_rest"
-except ImportError:
+        AnsibleModule.collection_name = "vmware.vmware_rest"
+    except ImportError:
+        from ansible.module_utils.basic import AnsibleModule
+else:
     from ansible.module_utils.basic import AnsibleModule
+
 from ansible_collections.vmware.vmware_rest.plugins.module_utils.vmware_rest import (
     gen_args,
     open_session,

--- a/plugins/modules/appliance_health_load_info.py
+++ b/plugins/modules/appliance_health_load_info.py
@@ -92,7 +92,7 @@ from ansible.module_utils.basic import env_fallback
 import os
 
 try:
-    if not os.getenv('VMWARE_ENABLE_TURBO', False):
+    if not os.getenv("VMWARE_ENABLE_TURBO", False):
         raise ImportError()
 
     from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (

--- a/plugins/modules/appliance_health_load_info.py
+++ b/plugins/modules/appliance_health_load_info.py
@@ -89,8 +89,12 @@ PAYLOAD_FORMAT = {
 }  # pylint: disable=line-too-long
 
 from ansible.module_utils.basic import env_fallback
+import os
 
 try:
+    if not os.getenv('VMWARE_ENABLE_TURBO', False):
+        raise ImportError()
+
     from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
         EmbeddedModuleFailure,
     )

--- a/plugins/modules/appliance_health_mem_info.py
+++ b/plugins/modules/appliance_health_mem_info.py
@@ -93,7 +93,7 @@ from ansible.module_utils.basic import env_fallback
 import os
 
 try:
-    if not os.getenv('VMWARE_ENABLE_TURBO', False):
+    if not os.getenv("VMWARE_ENABLE_TURBO", False):
         raise ImportError()
 
     from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (

--- a/plugins/modules/appliance_health_mem_info.py
+++ b/plugins/modules/appliance_health_mem_info.py
@@ -92,20 +92,21 @@ PAYLOAD_FORMAT = {
 from ansible.module_utils.basic import env_fallback
 import os
 
-try:
-    if not os.getenv("VMWARE_ENABLE_TURBO", False):
-        raise ImportError()
+if os.getenv("VMWARE_ENABLE_TURBO", False):
+    try:
+        from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
+            EmbeddedModuleFailure,
+        )
+        from ansible_collections.cloud.common.plugins.module_utils.turbo.module import (
+            AnsibleTurboModule as AnsibleModule,
+        )
 
-    from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
-        EmbeddedModuleFailure,
-    )
-    from ansible_collections.cloud.common.plugins.module_utils.turbo.module import (
-        AnsibleTurboModule as AnsibleModule,
-    )
-
-    AnsibleModule.collection_name = "vmware.vmware_rest"
-except ImportError:
+        AnsibleModule.collection_name = "vmware.vmware_rest"
+    except ImportError:
+        from ansible.module_utils.basic import AnsibleModule
+else:
     from ansible.module_utils.basic import AnsibleModule
+
 from ansible_collections.vmware.vmware_rest.plugins.module_utils.vmware_rest import (
     gen_args,
     open_session,

--- a/plugins/modules/appliance_health_mem_info.py
+++ b/plugins/modules/appliance_health_mem_info.py
@@ -90,8 +90,12 @@ PAYLOAD_FORMAT = {
 }  # pylint: disable=line-too-long
 
 from ansible.module_utils.basic import env_fallback
+import os
 
 try:
+    if not os.getenv('VMWARE_ENABLE_TURBO', False):
+        raise ImportError()
+
     from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
         EmbeddedModuleFailure,
     )

--- a/plugins/modules/appliance_health_softwarepackages_info.py
+++ b/plugins/modules/appliance_health_softwarepackages_info.py
@@ -94,8 +94,12 @@ PAYLOAD_FORMAT = {
 }  # pylint: disable=line-too-long
 
 from ansible.module_utils.basic import env_fallback
+import os
 
 try:
+    if not os.getenv('VMWARE_ENABLE_TURBO', False):
+        raise ImportError()
+
     from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
         EmbeddedModuleFailure,
     )

--- a/plugins/modules/appliance_health_softwarepackages_info.py
+++ b/plugins/modules/appliance_health_softwarepackages_info.py
@@ -97,7 +97,7 @@ from ansible.module_utils.basic import env_fallback
 import os
 
 try:
-    if not os.getenv('VMWARE_ENABLE_TURBO', False):
+    if not os.getenv("VMWARE_ENABLE_TURBO", False):
         raise ImportError()
 
     from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (

--- a/plugins/modules/appliance_health_softwarepackages_info.py
+++ b/plugins/modules/appliance_health_softwarepackages_info.py
@@ -96,20 +96,21 @@ PAYLOAD_FORMAT = {
 from ansible.module_utils.basic import env_fallback
 import os
 
-try:
-    if not os.getenv("VMWARE_ENABLE_TURBO", False):
-        raise ImportError()
+if os.getenv("VMWARE_ENABLE_TURBO", False):
+    try:
+        from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
+            EmbeddedModuleFailure,
+        )
+        from ansible_collections.cloud.common.plugins.module_utils.turbo.module import (
+            AnsibleTurboModule as AnsibleModule,
+        )
 
-    from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
-        EmbeddedModuleFailure,
-    )
-    from ansible_collections.cloud.common.plugins.module_utils.turbo.module import (
-        AnsibleTurboModule as AnsibleModule,
-    )
-
-    AnsibleModule.collection_name = "vmware.vmware_rest"
-except ImportError:
+        AnsibleModule.collection_name = "vmware.vmware_rest"
+    except ImportError:
+        from ansible.module_utils.basic import AnsibleModule
+else:
     from ansible.module_utils.basic import AnsibleModule
+
 from ansible_collections.vmware.vmware_rest.plugins.module_utils.vmware_rest import (
     gen_args,
     open_session,

--- a/plugins/modules/appliance_health_storage_info.py
+++ b/plugins/modules/appliance_health_storage_info.py
@@ -91,20 +91,21 @@ PAYLOAD_FORMAT = {
 from ansible.module_utils.basic import env_fallback
 import os
 
-try:
-    if not os.getenv("VMWARE_ENABLE_TURBO", False):
-        raise ImportError()
+if os.getenv("VMWARE_ENABLE_TURBO", False):
+    try:
+        from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
+            EmbeddedModuleFailure,
+        )
+        from ansible_collections.cloud.common.plugins.module_utils.turbo.module import (
+            AnsibleTurboModule as AnsibleModule,
+        )
 
-    from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
-        EmbeddedModuleFailure,
-    )
-    from ansible_collections.cloud.common.plugins.module_utils.turbo.module import (
-        AnsibleTurboModule as AnsibleModule,
-    )
-
-    AnsibleModule.collection_name = "vmware.vmware_rest"
-except ImportError:
+        AnsibleModule.collection_name = "vmware.vmware_rest"
+    except ImportError:
+        from ansible.module_utils.basic import AnsibleModule
+else:
     from ansible.module_utils.basic import AnsibleModule
+
 from ansible_collections.vmware.vmware_rest.plugins.module_utils.vmware_rest import (
     gen_args,
     open_session,

--- a/plugins/modules/appliance_health_storage_info.py
+++ b/plugins/modules/appliance_health_storage_info.py
@@ -92,7 +92,7 @@ from ansible.module_utils.basic import env_fallback
 import os
 
 try:
-    if not os.getenv('VMWARE_ENABLE_TURBO', False):
+    if not os.getenv("VMWARE_ENABLE_TURBO", False):
         raise ImportError()
 
     from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (

--- a/plugins/modules/appliance_health_storage_info.py
+++ b/plugins/modules/appliance_health_storage_info.py
@@ -89,8 +89,12 @@ PAYLOAD_FORMAT = {
 }  # pylint: disable=line-too-long
 
 from ansible.module_utils.basic import env_fallback
+import os
 
 try:
+    if not os.getenv('VMWARE_ENABLE_TURBO', False):
+        raise ImportError()
+
     from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
         EmbeddedModuleFailure,
     )

--- a/plugins/modules/appliance_health_swap_info.py
+++ b/plugins/modules/appliance_health_swap_info.py
@@ -91,20 +91,21 @@ PAYLOAD_FORMAT = {
 from ansible.module_utils.basic import env_fallback
 import os
 
-try:
-    if not os.getenv("VMWARE_ENABLE_TURBO", False):
-        raise ImportError()
+if os.getenv("VMWARE_ENABLE_TURBO", False):
+    try:
+        from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
+            EmbeddedModuleFailure,
+        )
+        from ansible_collections.cloud.common.plugins.module_utils.turbo.module import (
+            AnsibleTurboModule as AnsibleModule,
+        )
 
-    from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
-        EmbeddedModuleFailure,
-    )
-    from ansible_collections.cloud.common.plugins.module_utils.turbo.module import (
-        AnsibleTurboModule as AnsibleModule,
-    )
-
-    AnsibleModule.collection_name = "vmware.vmware_rest"
-except ImportError:
+        AnsibleModule.collection_name = "vmware.vmware_rest"
+    except ImportError:
+        from ansible.module_utils.basic import AnsibleModule
+else:
     from ansible.module_utils.basic import AnsibleModule
+
 from ansible_collections.vmware.vmware_rest.plugins.module_utils.vmware_rest import (
     gen_args,
     open_session,

--- a/plugins/modules/appliance_health_swap_info.py
+++ b/plugins/modules/appliance_health_swap_info.py
@@ -92,7 +92,7 @@ from ansible.module_utils.basic import env_fallback
 import os
 
 try:
-    if not os.getenv('VMWARE_ENABLE_TURBO', False):
+    if not os.getenv("VMWARE_ENABLE_TURBO", False):
         raise ImportError()
 
     from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (

--- a/plugins/modules/appliance_health_swap_info.py
+++ b/plugins/modules/appliance_health_swap_info.py
@@ -89,8 +89,12 @@ PAYLOAD_FORMAT = {
 }  # pylint: disable=line-too-long
 
 from ansible.module_utils.basic import env_fallback
+import os
 
 try:
+    if not os.getenv('VMWARE_ENABLE_TURBO', False):
+        raise ImportError()
+
     from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
         EmbeddedModuleFailure,
     )

--- a/plugins/modules/appliance_health_system_info.py
+++ b/plugins/modules/appliance_health_system_info.py
@@ -91,20 +91,21 @@ PAYLOAD_FORMAT = {
 from ansible.module_utils.basic import env_fallback
 import os
 
-try:
-    if not os.getenv("VMWARE_ENABLE_TURBO", False):
-        raise ImportError()
+if os.getenv("VMWARE_ENABLE_TURBO", False):
+    try:
+        from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
+            EmbeddedModuleFailure,
+        )
+        from ansible_collections.cloud.common.plugins.module_utils.turbo.module import (
+            AnsibleTurboModule as AnsibleModule,
+        )
 
-    from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
-        EmbeddedModuleFailure,
-    )
-    from ansible_collections.cloud.common.plugins.module_utils.turbo.module import (
-        AnsibleTurboModule as AnsibleModule,
-    )
-
-    AnsibleModule.collection_name = "vmware.vmware_rest"
-except ImportError:
+        AnsibleModule.collection_name = "vmware.vmware_rest"
+    except ImportError:
+        from ansible.module_utils.basic import AnsibleModule
+else:
     from ansible.module_utils.basic import AnsibleModule
+
 from ansible_collections.vmware.vmware_rest.plugins.module_utils.vmware_rest import (
     gen_args,
     open_session,

--- a/plugins/modules/appliance_health_system_info.py
+++ b/plugins/modules/appliance_health_system_info.py
@@ -92,7 +92,7 @@ from ansible.module_utils.basic import env_fallback
 import os
 
 try:
-    if not os.getenv('VMWARE_ENABLE_TURBO', False):
+    if not os.getenv("VMWARE_ENABLE_TURBO", False):
         raise ImportError()
 
     from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (

--- a/plugins/modules/appliance_health_system_info.py
+++ b/plugins/modules/appliance_health_system_info.py
@@ -89,8 +89,12 @@ PAYLOAD_FORMAT = {
 }  # pylint: disable=line-too-long
 
 from ansible.module_utils.basic import env_fallback
+import os
 
 try:
+    if not os.getenv('VMWARE_ENABLE_TURBO', False):
+        raise ImportError()
+
     from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
         EmbeddedModuleFailure,
     )

--- a/plugins/modules/appliance_infraprofile_configs.py
+++ b/plugins/modules/appliance_infraprofile_configs.py
@@ -196,20 +196,21 @@ PAYLOAD_FORMAT = {
 from ansible.module_utils.basic import env_fallback
 import os
 
-try:
-    if not os.getenv("VMWARE_ENABLE_TURBO", False):
-        raise ImportError()
+if os.getenv("VMWARE_ENABLE_TURBO", False):
+    try:
+        from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
+            EmbeddedModuleFailure,
+        )
+        from ansible_collections.cloud.common.plugins.module_utils.turbo.module import (
+            AnsibleTurboModule as AnsibleModule,
+        )
 
-    from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
-        EmbeddedModuleFailure,
-    )
-    from ansible_collections.cloud.common.plugins.module_utils.turbo.module import (
-        AnsibleTurboModule as AnsibleModule,
-    )
-
-    AnsibleModule.collection_name = "vmware.vmware_rest"
-except ImportError:
+        AnsibleModule.collection_name = "vmware.vmware_rest"
+    except ImportError:
+        from ansible.module_utils.basic import AnsibleModule
+else:
     from ansible.module_utils.basic import AnsibleModule
+
 from ansible_collections.vmware.vmware_rest.plugins.module_utils.vmware_rest import (
     exists,
     gen_args,

--- a/plugins/modules/appliance_infraprofile_configs.py
+++ b/plugins/modules/appliance_infraprofile_configs.py
@@ -194,8 +194,12 @@ PAYLOAD_FORMAT = {
 }  # pylint: disable=line-too-long
 
 from ansible.module_utils.basic import env_fallback
+import os
 
 try:
+    if not os.getenv('VMWARE_ENABLE_TURBO', False):
+        raise ImportError()
+
     from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
         EmbeddedModuleFailure,
     )

--- a/plugins/modules/appliance_infraprofile_configs.py
+++ b/plugins/modules/appliance_infraprofile_configs.py
@@ -197,7 +197,7 @@ from ansible.module_utils.basic import env_fallback
 import os
 
 try:
-    if not os.getenv('VMWARE_ENABLE_TURBO', False):
+    if not os.getenv("VMWARE_ENABLE_TURBO", False):
         raise ImportError()
 
     from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (

--- a/plugins/modules/appliance_infraprofile_configs_info.py
+++ b/plugins/modules/appliance_infraprofile_configs_info.py
@@ -95,8 +95,12 @@ PAYLOAD_FORMAT = {
 }  # pylint: disable=line-too-long
 
 from ansible.module_utils.basic import env_fallback
+import os
 
 try:
+    if not os.getenv('VMWARE_ENABLE_TURBO', False):
+        raise ImportError()
+
     from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
         EmbeddedModuleFailure,
     )

--- a/plugins/modules/appliance_infraprofile_configs_info.py
+++ b/plugins/modules/appliance_infraprofile_configs_info.py
@@ -97,20 +97,21 @@ PAYLOAD_FORMAT = {
 from ansible.module_utils.basic import env_fallback
 import os
 
-try:
-    if not os.getenv("VMWARE_ENABLE_TURBO", False):
-        raise ImportError()
+if os.getenv("VMWARE_ENABLE_TURBO", False):
+    try:
+        from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
+            EmbeddedModuleFailure,
+        )
+        from ansible_collections.cloud.common.plugins.module_utils.turbo.module import (
+            AnsibleTurboModule as AnsibleModule,
+        )
 
-    from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
-        EmbeddedModuleFailure,
-    )
-    from ansible_collections.cloud.common.plugins.module_utils.turbo.module import (
-        AnsibleTurboModule as AnsibleModule,
-    )
-
-    AnsibleModule.collection_name = "vmware.vmware_rest"
-except ImportError:
+        AnsibleModule.collection_name = "vmware.vmware_rest"
+    except ImportError:
+        from ansible.module_utils.basic import AnsibleModule
+else:
     from ansible.module_utils.basic import AnsibleModule
+
 from ansible_collections.vmware.vmware_rest.plugins.module_utils.vmware_rest import (
     gen_args,
     open_session,

--- a/plugins/modules/appliance_infraprofile_configs_info.py
+++ b/plugins/modules/appliance_infraprofile_configs_info.py
@@ -98,7 +98,7 @@ from ansible.module_utils.basic import env_fallback
 import os
 
 try:
-    if not os.getenv('VMWARE_ENABLE_TURBO', False):
+    if not os.getenv("VMWARE_ENABLE_TURBO", False):
         raise ImportError()
 
     from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (

--- a/plugins/modules/appliance_localaccounts_globalpolicy.py
+++ b/plugins/modules/appliance_localaccounts_globalpolicy.py
@@ -124,7 +124,7 @@ from ansible.module_utils.basic import env_fallback
 import os
 
 try:
-    if not os.getenv('VMWARE_ENABLE_TURBO', False):
+    if not os.getenv("VMWARE_ENABLE_TURBO", False):
         raise ImportError()
 
     from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (

--- a/plugins/modules/appliance_localaccounts_globalpolicy.py
+++ b/plugins/modules/appliance_localaccounts_globalpolicy.py
@@ -123,20 +123,21 @@ PAYLOAD_FORMAT = {
 from ansible.module_utils.basic import env_fallback
 import os
 
-try:
-    if not os.getenv("VMWARE_ENABLE_TURBO", False):
-        raise ImportError()
+if os.getenv("VMWARE_ENABLE_TURBO", False):
+    try:
+        from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
+            EmbeddedModuleFailure,
+        )
+        from ansible_collections.cloud.common.plugins.module_utils.turbo.module import (
+            AnsibleTurboModule as AnsibleModule,
+        )
 
-    from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
-        EmbeddedModuleFailure,
-    )
-    from ansible_collections.cloud.common.plugins.module_utils.turbo.module import (
-        AnsibleTurboModule as AnsibleModule,
-    )
-
-    AnsibleModule.collection_name = "vmware.vmware_rest"
-except ImportError:
+        AnsibleModule.collection_name = "vmware.vmware_rest"
+    except ImportError:
+        from ansible.module_utils.basic import AnsibleModule
+else:
     from ansible.module_utils.basic import AnsibleModule
+
 from ansible_collections.vmware.vmware_rest.plugins.module_utils.vmware_rest import (
     exists,
     gen_args,

--- a/plugins/modules/appliance_localaccounts_globalpolicy.py
+++ b/plugins/modules/appliance_localaccounts_globalpolicy.py
@@ -121,8 +121,12 @@ PAYLOAD_FORMAT = {
 }  # pylint: disable=line-too-long
 
 from ansible.module_utils.basic import env_fallback
+import os
 
 try:
+    if not os.getenv('VMWARE_ENABLE_TURBO', False):
+        raise ImportError()
+
     from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
         EmbeddedModuleFailure,
     )

--- a/plugins/modules/appliance_localaccounts_globalpolicy_info.py
+++ b/plugins/modules/appliance_localaccounts_globalpolicy_info.py
@@ -95,7 +95,7 @@ from ansible.module_utils.basic import env_fallback
 import os
 
 try:
-    if not os.getenv('VMWARE_ENABLE_TURBO', False):
+    if not os.getenv("VMWARE_ENABLE_TURBO", False):
         raise ImportError()
 
     from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (

--- a/plugins/modules/appliance_localaccounts_globalpolicy_info.py
+++ b/plugins/modules/appliance_localaccounts_globalpolicy_info.py
@@ -94,20 +94,21 @@ PAYLOAD_FORMAT = {
 from ansible.module_utils.basic import env_fallback
 import os
 
-try:
-    if not os.getenv("VMWARE_ENABLE_TURBO", False):
-        raise ImportError()
+if os.getenv("VMWARE_ENABLE_TURBO", False):
+    try:
+        from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
+            EmbeddedModuleFailure,
+        )
+        from ansible_collections.cloud.common.plugins.module_utils.turbo.module import (
+            AnsibleTurboModule as AnsibleModule,
+        )
 
-    from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
-        EmbeddedModuleFailure,
-    )
-    from ansible_collections.cloud.common.plugins.module_utils.turbo.module import (
-        AnsibleTurboModule as AnsibleModule,
-    )
-
-    AnsibleModule.collection_name = "vmware.vmware_rest"
-except ImportError:
+        AnsibleModule.collection_name = "vmware.vmware_rest"
+    except ImportError:
+        from ansible.module_utils.basic import AnsibleModule
+else:
     from ansible.module_utils.basic import AnsibleModule
+
 from ansible_collections.vmware.vmware_rest.plugins.module_utils.vmware_rest import (
     gen_args,
     open_session,

--- a/plugins/modules/appliance_localaccounts_globalpolicy_info.py
+++ b/plugins/modules/appliance_localaccounts_globalpolicy_info.py
@@ -92,8 +92,12 @@ PAYLOAD_FORMAT = {
 }  # pylint: disable=line-too-long
 
 from ansible.module_utils.basic import env_fallback
+import os
 
 try:
+    if not os.getenv('VMWARE_ENABLE_TURBO', False):
+        raise ImportError()
+
     from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
         EmbeddedModuleFailure,
     )

--- a/plugins/modules/appliance_localaccounts_info.py
+++ b/plugins/modules/appliance_localaccounts_info.py
@@ -124,20 +124,21 @@ PAYLOAD_FORMAT = {
 from ansible.module_utils.basic import env_fallback
 import os
 
-try:
-    if not os.getenv("VMWARE_ENABLE_TURBO", False):
-        raise ImportError()
+if os.getenv("VMWARE_ENABLE_TURBO", False):
+    try:
+        from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
+            EmbeddedModuleFailure,
+        )
+        from ansible_collections.cloud.common.plugins.module_utils.turbo.module import (
+            AnsibleTurboModule as AnsibleModule,
+        )
 
-    from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
-        EmbeddedModuleFailure,
-    )
-    from ansible_collections.cloud.common.plugins.module_utils.turbo.module import (
-        AnsibleTurboModule as AnsibleModule,
-    )
-
-    AnsibleModule.collection_name = "vmware.vmware_rest"
-except ImportError:
+        AnsibleModule.collection_name = "vmware.vmware_rest"
+    except ImportError:
+        from ansible.module_utils.basic import AnsibleModule
+else:
     from ansible.module_utils.basic import AnsibleModule
+
 from ansible_collections.vmware.vmware_rest.plugins.module_utils.vmware_rest import (
     build_full_device_list,
     exists,

--- a/plugins/modules/appliance_localaccounts_info.py
+++ b/plugins/modules/appliance_localaccounts_info.py
@@ -122,8 +122,12 @@ PAYLOAD_FORMAT = {
 }  # pylint: disable=line-too-long
 
 from ansible.module_utils.basic import env_fallback
+import os
 
 try:
+    if not os.getenv('VMWARE_ENABLE_TURBO', False):
+        raise ImportError()
+
     from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
         EmbeddedModuleFailure,
     )

--- a/plugins/modules/appliance_localaccounts_info.py
+++ b/plugins/modules/appliance_localaccounts_info.py
@@ -125,7 +125,7 @@ from ansible.module_utils.basic import env_fallback
 import os
 
 try:
-    if not os.getenv('VMWARE_ENABLE_TURBO', False):
+    if not os.getenv("VMWARE_ENABLE_TURBO", False):
         raise ImportError()
 
     from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (

--- a/plugins/modules/appliance_monitoring_info.py
+++ b/plugins/modules/appliance_monitoring_info.py
@@ -918,8 +918,12 @@ PAYLOAD_FORMAT = {
 }  # pylint: disable=line-too-long
 
 from ansible.module_utils.basic import env_fallback
+import os
 
 try:
+    if not os.getenv('VMWARE_ENABLE_TURBO', False):
+        raise ImportError()
+
     from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
         EmbeddedModuleFailure,
     )

--- a/plugins/modules/appliance_monitoring_info.py
+++ b/plugins/modules/appliance_monitoring_info.py
@@ -921,7 +921,7 @@ from ansible.module_utils.basic import env_fallback
 import os
 
 try:
-    if not os.getenv('VMWARE_ENABLE_TURBO', False):
+    if not os.getenv("VMWARE_ENABLE_TURBO", False):
         raise ImportError()
 
     from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (

--- a/plugins/modules/appliance_monitoring_info.py
+++ b/plugins/modules/appliance_monitoring_info.py
@@ -920,20 +920,21 @@ PAYLOAD_FORMAT = {
 from ansible.module_utils.basic import env_fallback
 import os
 
-try:
-    if not os.getenv("VMWARE_ENABLE_TURBO", False):
-        raise ImportError()
+if os.getenv("VMWARE_ENABLE_TURBO", False):
+    try:
+        from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
+            EmbeddedModuleFailure,
+        )
+        from ansible_collections.cloud.common.plugins.module_utils.turbo.module import (
+            AnsibleTurboModule as AnsibleModule,
+        )
 
-    from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
-        EmbeddedModuleFailure,
-    )
-    from ansible_collections.cloud.common.plugins.module_utils.turbo.module import (
-        AnsibleTurboModule as AnsibleModule,
-    )
-
-    AnsibleModule.collection_name = "vmware.vmware_rest"
-except ImportError:
+        AnsibleModule.collection_name = "vmware.vmware_rest"
+    except ImportError:
+        from ansible.module_utils.basic import AnsibleModule
+else:
     from ansible.module_utils.basic import AnsibleModule
+
 from ansible_collections.vmware.vmware_rest.plugins.module_utils.vmware_rest import (
     build_full_device_list,
     exists,

--- a/plugins/modules/appliance_monitoring_query.py
+++ b/plugins/modules/appliance_monitoring_query.py
@@ -167,20 +167,21 @@ PAYLOAD_FORMAT = {
 from ansible.module_utils.basic import env_fallback
 import os
 
-try:
-    if not os.getenv("VMWARE_ENABLE_TURBO", False):
-        raise ImportError()
+if os.getenv("VMWARE_ENABLE_TURBO", False):
+    try:
+        from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
+            EmbeddedModuleFailure,
+        )
+        from ansible_collections.cloud.common.plugins.module_utils.turbo.module import (
+            AnsibleTurboModule as AnsibleModule,
+        )
 
-    from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
-        EmbeddedModuleFailure,
-    )
-    from ansible_collections.cloud.common.plugins.module_utils.turbo.module import (
-        AnsibleTurboModule as AnsibleModule,
-    )
-
-    AnsibleModule.collection_name = "vmware.vmware_rest"
-except ImportError:
+        AnsibleModule.collection_name = "vmware.vmware_rest"
+    except ImportError:
+        from ansible.module_utils.basic import AnsibleModule
+else:
     from ansible.module_utils.basic import AnsibleModule
+
 from ansible_collections.vmware.vmware_rest.plugins.module_utils.vmware_rest import (
     exists,
     gen_args,

--- a/plugins/modules/appliance_monitoring_query.py
+++ b/plugins/modules/appliance_monitoring_query.py
@@ -165,8 +165,12 @@ PAYLOAD_FORMAT = {
 }  # pylint: disable=line-too-long
 
 from ansible.module_utils.basic import env_fallback
+import os
 
 try:
+    if not os.getenv('VMWARE_ENABLE_TURBO', False):
+        raise ImportError()
+
     from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
         EmbeddedModuleFailure,
     )

--- a/plugins/modules/appliance_monitoring_query.py
+++ b/plugins/modules/appliance_monitoring_query.py
@@ -168,7 +168,7 @@ from ansible.module_utils.basic import env_fallback
 import os
 
 try:
-    if not os.getenv('VMWARE_ENABLE_TURBO', False):
+    if not os.getenv("VMWARE_ENABLE_TURBO", False):
         raise ImportError()
 
     from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (

--- a/plugins/modules/appliance_networking.py
+++ b/plugins/modules/appliance_networking.py
@@ -112,20 +112,21 @@ PAYLOAD_FORMAT = {
 from ansible.module_utils.basic import env_fallback
 import os
 
-try:
-    if not os.getenv("VMWARE_ENABLE_TURBO", False):
-        raise ImportError()
+if os.getenv("VMWARE_ENABLE_TURBO", False):
+    try:
+        from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
+            EmbeddedModuleFailure,
+        )
+        from ansible_collections.cloud.common.plugins.module_utils.turbo.module import (
+            AnsibleTurboModule as AnsibleModule,
+        )
 
-    from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
-        EmbeddedModuleFailure,
-    )
-    from ansible_collections.cloud.common.plugins.module_utils.turbo.module import (
-        AnsibleTurboModule as AnsibleModule,
-    )
-
-    AnsibleModule.collection_name = "vmware.vmware_rest"
-except ImportError:
+        AnsibleModule.collection_name = "vmware.vmware_rest"
+    except ImportError:
+        from ansible.module_utils.basic import AnsibleModule
+else:
     from ansible.module_utils.basic import AnsibleModule
+
 from ansible_collections.vmware.vmware_rest.plugins.module_utils.vmware_rest import (
     exists,
     gen_args,

--- a/plugins/modules/appliance_networking.py
+++ b/plugins/modules/appliance_networking.py
@@ -113,7 +113,7 @@ from ansible.module_utils.basic import env_fallback
 import os
 
 try:
-    if not os.getenv('VMWARE_ENABLE_TURBO', False):
+    if not os.getenv("VMWARE_ENABLE_TURBO", False):
         raise ImportError()
 
     from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (

--- a/plugins/modules/appliance_networking.py
+++ b/plugins/modules/appliance_networking.py
@@ -110,8 +110,12 @@ PAYLOAD_FORMAT = {
 }  # pylint: disable=line-too-long
 
 from ansible.module_utils.basic import env_fallback
+import os
 
 try:
+    if not os.getenv('VMWARE_ENABLE_TURBO', False):
+        raise ImportError()
+
     from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
         EmbeddedModuleFailure,
     )

--- a/plugins/modules/appliance_networking_dns_domains.py
+++ b/plugins/modules/appliance_networking_dns_domains.py
@@ -120,20 +120,21 @@ PAYLOAD_FORMAT = {
 from ansible.module_utils.basic import env_fallback
 import os
 
-try:
-    if not os.getenv("VMWARE_ENABLE_TURBO", False):
-        raise ImportError()
+if os.getenv("VMWARE_ENABLE_TURBO", False):
+    try:
+        from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
+            EmbeddedModuleFailure,
+        )
+        from ansible_collections.cloud.common.plugins.module_utils.turbo.module import (
+            AnsibleTurboModule as AnsibleModule,
+        )
 
-    from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
-        EmbeddedModuleFailure,
-    )
-    from ansible_collections.cloud.common.plugins.module_utils.turbo.module import (
-        AnsibleTurboModule as AnsibleModule,
-    )
-
-    AnsibleModule.collection_name = "vmware.vmware_rest"
-except ImportError:
+        AnsibleModule.collection_name = "vmware.vmware_rest"
+    except ImportError:
+        from ansible.module_utils.basic import AnsibleModule
+else:
     from ansible.module_utils.basic import AnsibleModule
+
 from ansible_collections.vmware.vmware_rest.plugins.module_utils.vmware_rest import (
     exists,
     gen_args,

--- a/plugins/modules/appliance_networking_dns_domains.py
+++ b/plugins/modules/appliance_networking_dns_domains.py
@@ -121,7 +121,7 @@ from ansible.module_utils.basic import env_fallback
 import os
 
 try:
-    if not os.getenv('VMWARE_ENABLE_TURBO', False):
+    if not os.getenv("VMWARE_ENABLE_TURBO", False):
         raise ImportError()
 
     from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (

--- a/plugins/modules/appliance_networking_dns_domains.py
+++ b/plugins/modules/appliance_networking_dns_domains.py
@@ -118,8 +118,12 @@ PAYLOAD_FORMAT = {
 }  # pylint: disable=line-too-long
 
 from ansible.module_utils.basic import env_fallback
+import os
 
 try:
+    if not os.getenv('VMWARE_ENABLE_TURBO', False):
+        raise ImportError()
+
     from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
         EmbeddedModuleFailure,
     )

--- a/plugins/modules/appliance_networking_dns_domains_info.py
+++ b/plugins/modules/appliance_networking_dns_domains_info.py
@@ -96,7 +96,7 @@ from ansible.module_utils.basic import env_fallback
 import os
 
 try:
-    if not os.getenv('VMWARE_ENABLE_TURBO', False):
+    if not os.getenv("VMWARE_ENABLE_TURBO", False):
         raise ImportError()
 
     from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (

--- a/plugins/modules/appliance_networking_dns_domains_info.py
+++ b/plugins/modules/appliance_networking_dns_domains_info.py
@@ -93,8 +93,12 @@ PAYLOAD_FORMAT = {
 }  # pylint: disable=line-too-long
 
 from ansible.module_utils.basic import env_fallback
+import os
 
 try:
+    if not os.getenv('VMWARE_ENABLE_TURBO', False):
+        raise ImportError()
+
     from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
         EmbeddedModuleFailure,
     )

--- a/plugins/modules/appliance_networking_dns_domains_info.py
+++ b/plugins/modules/appliance_networking_dns_domains_info.py
@@ -95,20 +95,21 @@ PAYLOAD_FORMAT = {
 from ansible.module_utils.basic import env_fallback
 import os
 
-try:
-    if not os.getenv("VMWARE_ENABLE_TURBO", False):
-        raise ImportError()
+if os.getenv("VMWARE_ENABLE_TURBO", False):
+    try:
+        from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
+            EmbeddedModuleFailure,
+        )
+        from ansible_collections.cloud.common.plugins.module_utils.turbo.module import (
+            AnsibleTurboModule as AnsibleModule,
+        )
 
-    from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
-        EmbeddedModuleFailure,
-    )
-    from ansible_collections.cloud.common.plugins.module_utils.turbo.module import (
-        AnsibleTurboModule as AnsibleModule,
-    )
-
-    AnsibleModule.collection_name = "vmware.vmware_rest"
-except ImportError:
+        AnsibleModule.collection_name = "vmware.vmware_rest"
+    except ImportError:
+        from ansible.module_utils.basic import AnsibleModule
+else:
     from ansible.module_utils.basic import AnsibleModule
+
 from ansible_collections.vmware.vmware_rest.plugins.module_utils.vmware_rest import (
     gen_args,
     open_session,

--- a/plugins/modules/appliance_networking_dns_hostname.py
+++ b/plugins/modules/appliance_networking_dns_hostname.py
@@ -112,8 +112,12 @@ PAYLOAD_FORMAT = {
 }  # pylint: disable=line-too-long
 
 from ansible.module_utils.basic import env_fallback
+import os
 
 try:
+    if not os.getenv('VMWARE_ENABLE_TURBO', False):
+        raise ImportError()
+
     from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
         EmbeddedModuleFailure,
     )

--- a/plugins/modules/appliance_networking_dns_hostname.py
+++ b/plugins/modules/appliance_networking_dns_hostname.py
@@ -115,7 +115,7 @@ from ansible.module_utils.basic import env_fallback
 import os
 
 try:
-    if not os.getenv('VMWARE_ENABLE_TURBO', False):
+    if not os.getenv("VMWARE_ENABLE_TURBO", False):
         raise ImportError()
 
     from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (

--- a/plugins/modules/appliance_networking_dns_hostname.py
+++ b/plugins/modules/appliance_networking_dns_hostname.py
@@ -114,20 +114,21 @@ PAYLOAD_FORMAT = {
 from ansible.module_utils.basic import env_fallback
 import os
 
-try:
-    if not os.getenv("VMWARE_ENABLE_TURBO", False):
-        raise ImportError()
+if os.getenv("VMWARE_ENABLE_TURBO", False):
+    try:
+        from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
+            EmbeddedModuleFailure,
+        )
+        from ansible_collections.cloud.common.plugins.module_utils.turbo.module import (
+            AnsibleTurboModule as AnsibleModule,
+        )
 
-    from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
-        EmbeddedModuleFailure,
-    )
-    from ansible_collections.cloud.common.plugins.module_utils.turbo.module import (
-        AnsibleTurboModule as AnsibleModule,
-    )
-
-    AnsibleModule.collection_name = "vmware.vmware_rest"
-except ImportError:
+        AnsibleModule.collection_name = "vmware.vmware_rest"
+    except ImportError:
+        from ansible.module_utils.basic import AnsibleModule
+else:
     from ansible.module_utils.basic import AnsibleModule
+
 from ansible_collections.vmware.vmware_rest.plugins.module_utils.vmware_rest import (
     exists,
     gen_args,

--- a/plugins/modules/appliance_networking_dns_hostname_info.py
+++ b/plugins/modules/appliance_networking_dns_hostname_info.py
@@ -96,7 +96,7 @@ from ansible.module_utils.basic import env_fallback
 import os
 
 try:
-    if not os.getenv('VMWARE_ENABLE_TURBO', False):
+    if not os.getenv("VMWARE_ENABLE_TURBO", False):
         raise ImportError()
 
     from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (

--- a/plugins/modules/appliance_networking_dns_hostname_info.py
+++ b/plugins/modules/appliance_networking_dns_hostname_info.py
@@ -93,8 +93,12 @@ PAYLOAD_FORMAT = {
 }  # pylint: disable=line-too-long
 
 from ansible.module_utils.basic import env_fallback
+import os
 
 try:
+    if not os.getenv('VMWARE_ENABLE_TURBO', False):
+        raise ImportError()
+
     from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
         EmbeddedModuleFailure,
     )

--- a/plugins/modules/appliance_networking_dns_hostname_info.py
+++ b/plugins/modules/appliance_networking_dns_hostname_info.py
@@ -95,20 +95,21 @@ PAYLOAD_FORMAT = {
 from ansible.module_utils.basic import env_fallback
 import os
 
-try:
-    if not os.getenv("VMWARE_ENABLE_TURBO", False):
-        raise ImportError()
+if os.getenv("VMWARE_ENABLE_TURBO", False):
+    try:
+        from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
+            EmbeddedModuleFailure,
+        )
+        from ansible_collections.cloud.common.plugins.module_utils.turbo.module import (
+            AnsibleTurboModule as AnsibleModule,
+        )
 
-    from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
-        EmbeddedModuleFailure,
-    )
-    from ansible_collections.cloud.common.plugins.module_utils.turbo.module import (
-        AnsibleTurboModule as AnsibleModule,
-    )
-
-    AnsibleModule.collection_name = "vmware.vmware_rest"
-except ImportError:
+        AnsibleModule.collection_name = "vmware.vmware_rest"
+    except ImportError:
+        from ansible.module_utils.basic import AnsibleModule
+else:
     from ansible.module_utils.basic import AnsibleModule
+
 from ansible_collections.vmware.vmware_rest.plugins.module_utils.vmware_rest import (
     gen_args,
     open_session,

--- a/plugins/modules/appliance_networking_dns_servers.py
+++ b/plugins/modules/appliance_networking_dns_servers.py
@@ -154,20 +154,21 @@ PAYLOAD_FORMAT = {
 from ansible.module_utils.basic import env_fallback
 import os
 
-try:
-    if not os.getenv("VMWARE_ENABLE_TURBO", False):
-        raise ImportError()
+if os.getenv("VMWARE_ENABLE_TURBO", False):
+    try:
+        from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
+            EmbeddedModuleFailure,
+        )
+        from ansible_collections.cloud.common.plugins.module_utils.turbo.module import (
+            AnsibleTurboModule as AnsibleModule,
+        )
 
-    from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
-        EmbeddedModuleFailure,
-    )
-    from ansible_collections.cloud.common.plugins.module_utils.turbo.module import (
-        AnsibleTurboModule as AnsibleModule,
-    )
-
-    AnsibleModule.collection_name = "vmware.vmware_rest"
-except ImportError:
+        AnsibleModule.collection_name = "vmware.vmware_rest"
+    except ImportError:
+        from ansible.module_utils.basic import AnsibleModule
+else:
     from ansible.module_utils.basic import AnsibleModule
+
 from ansible_collections.vmware.vmware_rest.plugins.module_utils.vmware_rest import (
     exists,
     gen_args,

--- a/plugins/modules/appliance_networking_dns_servers.py
+++ b/plugins/modules/appliance_networking_dns_servers.py
@@ -155,7 +155,7 @@ from ansible.module_utils.basic import env_fallback
 import os
 
 try:
-    if not os.getenv('VMWARE_ENABLE_TURBO', False):
+    if not os.getenv("VMWARE_ENABLE_TURBO", False):
         raise ImportError()
 
     from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (

--- a/plugins/modules/appliance_networking_dns_servers.py
+++ b/plugins/modules/appliance_networking_dns_servers.py
@@ -152,8 +152,12 @@ PAYLOAD_FORMAT = {
 }  # pylint: disable=line-too-long
 
 from ansible.module_utils.basic import env_fallback
+import os
 
 try:
+    if not os.getenv('VMWARE_ENABLE_TURBO', False):
+        raise ImportError()
+
     from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
         EmbeddedModuleFailure,
     )

--- a/plugins/modules/appliance_networking_dns_servers_info.py
+++ b/plugins/modules/appliance_networking_dns_servers_info.py
@@ -98,20 +98,21 @@ PAYLOAD_FORMAT = {
 from ansible.module_utils.basic import env_fallback
 import os
 
-try:
-    if not os.getenv("VMWARE_ENABLE_TURBO", False):
-        raise ImportError()
+if os.getenv("VMWARE_ENABLE_TURBO", False):
+    try:
+        from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
+            EmbeddedModuleFailure,
+        )
+        from ansible_collections.cloud.common.plugins.module_utils.turbo.module import (
+            AnsibleTurboModule as AnsibleModule,
+        )
 
-    from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
-        EmbeddedModuleFailure,
-    )
-    from ansible_collections.cloud.common.plugins.module_utils.turbo.module import (
-        AnsibleTurboModule as AnsibleModule,
-    )
-
-    AnsibleModule.collection_name = "vmware.vmware_rest"
-except ImportError:
+        AnsibleModule.collection_name = "vmware.vmware_rest"
+    except ImportError:
+        from ansible.module_utils.basic import AnsibleModule
+else:
     from ansible.module_utils.basic import AnsibleModule
+
 from ansible_collections.vmware.vmware_rest.plugins.module_utils.vmware_rest import (
     gen_args,
     open_session,

--- a/plugins/modules/appliance_networking_dns_servers_info.py
+++ b/plugins/modules/appliance_networking_dns_servers_info.py
@@ -96,8 +96,12 @@ PAYLOAD_FORMAT = {
 }  # pylint: disable=line-too-long
 
 from ansible.module_utils.basic import env_fallback
+import os
 
 try:
+    if not os.getenv('VMWARE_ENABLE_TURBO', False):
+        raise ImportError()
+
     from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
         EmbeddedModuleFailure,
     )

--- a/plugins/modules/appliance_networking_dns_servers_info.py
+++ b/plugins/modules/appliance_networking_dns_servers_info.py
@@ -99,7 +99,7 @@ from ansible.module_utils.basic import env_fallback
 import os
 
 try:
-    if not os.getenv('VMWARE_ENABLE_TURBO', False):
+    if not os.getenv("VMWARE_ENABLE_TURBO", False):
         raise ImportError()
 
     from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (

--- a/plugins/modules/appliance_networking_firewall_inbound.py
+++ b/plugins/modules/appliance_networking_firewall_inbound.py
@@ -146,20 +146,21 @@ PAYLOAD_FORMAT = {
 from ansible.module_utils.basic import env_fallback
 import os
 
-try:
-    if not os.getenv("VMWARE_ENABLE_TURBO", False):
-        raise ImportError()
+if os.getenv("VMWARE_ENABLE_TURBO", False):
+    try:
+        from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
+            EmbeddedModuleFailure,
+        )
+        from ansible_collections.cloud.common.plugins.module_utils.turbo.module import (
+            AnsibleTurboModule as AnsibleModule,
+        )
 
-    from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
-        EmbeddedModuleFailure,
-    )
-    from ansible_collections.cloud.common.plugins.module_utils.turbo.module import (
-        AnsibleTurboModule as AnsibleModule,
-    )
-
-    AnsibleModule.collection_name = "vmware.vmware_rest"
-except ImportError:
+        AnsibleModule.collection_name = "vmware.vmware_rest"
+    except ImportError:
+        from ansible.module_utils.basic import AnsibleModule
+else:
     from ansible.module_utils.basic import AnsibleModule
+
 from ansible_collections.vmware.vmware_rest.plugins.module_utils.vmware_rest import (
     exists,
     gen_args,

--- a/plugins/modules/appliance_networking_firewall_inbound.py
+++ b/plugins/modules/appliance_networking_firewall_inbound.py
@@ -144,8 +144,12 @@ PAYLOAD_FORMAT = {
 }  # pylint: disable=line-too-long
 
 from ansible.module_utils.basic import env_fallback
+import os
 
 try:
+    if not os.getenv('VMWARE_ENABLE_TURBO', False):
+        raise ImportError()
+
     from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
         EmbeddedModuleFailure,
     )

--- a/plugins/modules/appliance_networking_firewall_inbound.py
+++ b/plugins/modules/appliance_networking_firewall_inbound.py
@@ -147,7 +147,7 @@ from ansible.module_utils.basic import env_fallback
 import os
 
 try:
-    if not os.getenv('VMWARE_ENABLE_TURBO', False):
+    if not os.getenv("VMWARE_ENABLE_TURBO", False):
         raise ImportError()
 
     from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (

--- a/plugins/modules/appliance_networking_firewall_inbound_info.py
+++ b/plugins/modules/appliance_networking_firewall_inbound_info.py
@@ -98,20 +98,21 @@ PAYLOAD_FORMAT = {
 from ansible.module_utils.basic import env_fallback
 import os
 
-try:
-    if not os.getenv("VMWARE_ENABLE_TURBO", False):
-        raise ImportError()
+if os.getenv("VMWARE_ENABLE_TURBO", False):
+    try:
+        from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
+            EmbeddedModuleFailure,
+        )
+        from ansible_collections.cloud.common.plugins.module_utils.turbo.module import (
+            AnsibleTurboModule as AnsibleModule,
+        )
 
-    from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
-        EmbeddedModuleFailure,
-    )
-    from ansible_collections.cloud.common.plugins.module_utils.turbo.module import (
-        AnsibleTurboModule as AnsibleModule,
-    )
-
-    AnsibleModule.collection_name = "vmware.vmware_rest"
-except ImportError:
+        AnsibleModule.collection_name = "vmware.vmware_rest"
+    except ImportError:
+        from ansible.module_utils.basic import AnsibleModule
+else:
     from ansible.module_utils.basic import AnsibleModule
+
 from ansible_collections.vmware.vmware_rest.plugins.module_utils.vmware_rest import (
     gen_args,
     open_session,

--- a/plugins/modules/appliance_networking_firewall_inbound_info.py
+++ b/plugins/modules/appliance_networking_firewall_inbound_info.py
@@ -96,8 +96,12 @@ PAYLOAD_FORMAT = {
 }  # pylint: disable=line-too-long
 
 from ansible.module_utils.basic import env_fallback
+import os
 
 try:
+    if not os.getenv('VMWARE_ENABLE_TURBO', False):
+        raise ImportError()
+
     from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
         EmbeddedModuleFailure,
     )

--- a/plugins/modules/appliance_networking_firewall_inbound_info.py
+++ b/plugins/modules/appliance_networking_firewall_inbound_info.py
@@ -99,7 +99,7 @@ from ansible.module_utils.basic import env_fallback
 import os
 
 try:
-    if not os.getenv('VMWARE_ENABLE_TURBO', False):
+    if not os.getenv("VMWARE_ENABLE_TURBO", False):
         raise ImportError()
 
     from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (

--- a/plugins/modules/appliance_networking_info.py
+++ b/plugins/modules/appliance_networking_info.py
@@ -119,7 +119,7 @@ from ansible.module_utils.basic import env_fallback
 import os
 
 try:
-    if not os.getenv('VMWARE_ENABLE_TURBO', False):
+    if not os.getenv("VMWARE_ENABLE_TURBO", False):
         raise ImportError()
 
     from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (

--- a/plugins/modules/appliance_networking_info.py
+++ b/plugins/modules/appliance_networking_info.py
@@ -118,20 +118,21 @@ PAYLOAD_FORMAT = {
 from ansible.module_utils.basic import env_fallback
 import os
 
-try:
-    if not os.getenv("VMWARE_ENABLE_TURBO", False):
-        raise ImportError()
+if os.getenv("VMWARE_ENABLE_TURBO", False):
+    try:
+        from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
+            EmbeddedModuleFailure,
+        )
+        from ansible_collections.cloud.common.plugins.module_utils.turbo.module import (
+            AnsibleTurboModule as AnsibleModule,
+        )
 
-    from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
-        EmbeddedModuleFailure,
-    )
-    from ansible_collections.cloud.common.plugins.module_utils.turbo.module import (
-        AnsibleTurboModule as AnsibleModule,
-    )
-
-    AnsibleModule.collection_name = "vmware.vmware_rest"
-except ImportError:
+        AnsibleModule.collection_name = "vmware.vmware_rest"
+    except ImportError:
+        from ansible.module_utils.basic import AnsibleModule
+else:
     from ansible.module_utils.basic import AnsibleModule
+
 from ansible_collections.vmware.vmware_rest.plugins.module_utils.vmware_rest import (
     gen_args,
     open_session,

--- a/plugins/modules/appliance_networking_info.py
+++ b/plugins/modules/appliance_networking_info.py
@@ -116,8 +116,12 @@ PAYLOAD_FORMAT = {
 }  # pylint: disable=line-too-long
 
 from ansible.module_utils.basic import env_fallback
+import os
 
 try:
+    if not os.getenv('VMWARE_ENABLE_TURBO', False):
+        raise ImportError()
+
     from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
         EmbeddedModuleFailure,
     )

--- a/plugins/modules/appliance_networking_interfaces_info.py
+++ b/plugins/modules/appliance_networking_interfaces_info.py
@@ -128,7 +128,7 @@ from ansible.module_utils.basic import env_fallback
 import os
 
 try:
-    if not os.getenv('VMWARE_ENABLE_TURBO', False):
+    if not os.getenv("VMWARE_ENABLE_TURBO", False):
         raise ImportError()
 
     from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (

--- a/plugins/modules/appliance_networking_interfaces_info.py
+++ b/plugins/modules/appliance_networking_interfaces_info.py
@@ -127,20 +127,21 @@ PAYLOAD_FORMAT = {
 from ansible.module_utils.basic import env_fallback
 import os
 
-try:
-    if not os.getenv("VMWARE_ENABLE_TURBO", False):
-        raise ImportError()
+if os.getenv("VMWARE_ENABLE_TURBO", False):
+    try:
+        from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
+            EmbeddedModuleFailure,
+        )
+        from ansible_collections.cloud.common.plugins.module_utils.turbo.module import (
+            AnsibleTurboModule as AnsibleModule,
+        )
 
-    from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
-        EmbeddedModuleFailure,
-    )
-    from ansible_collections.cloud.common.plugins.module_utils.turbo.module import (
-        AnsibleTurboModule as AnsibleModule,
-    )
-
-    AnsibleModule.collection_name = "vmware.vmware_rest"
-except ImportError:
+        AnsibleModule.collection_name = "vmware.vmware_rest"
+    except ImportError:
+        from ansible.module_utils.basic import AnsibleModule
+else:
     from ansible.module_utils.basic import AnsibleModule
+
 from ansible_collections.vmware.vmware_rest.plugins.module_utils.vmware_rest import (
     build_full_device_list,
     exists,

--- a/plugins/modules/appliance_networking_interfaces_info.py
+++ b/plugins/modules/appliance_networking_interfaces_info.py
@@ -125,8 +125,12 @@ PAYLOAD_FORMAT = {
 }  # pylint: disable=line-too-long
 
 from ansible.module_utils.basic import env_fallback
+import os
 
 try:
+    if not os.getenv('VMWARE_ENABLE_TURBO', False):
+        raise ImportError()
+
     from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
         EmbeddedModuleFailure,
     )

--- a/plugins/modules/appliance_networking_interfaces_ipv4.py
+++ b/plugins/modules/appliance_networking_interfaces_ipv4.py
@@ -160,7 +160,7 @@ from ansible.module_utils.basic import env_fallback
 import os
 
 try:
-    if not os.getenv('VMWARE_ENABLE_TURBO', False):
+    if not os.getenv("VMWARE_ENABLE_TURBO", False):
         raise ImportError()
 
     from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (

--- a/plugins/modules/appliance_networking_interfaces_ipv4.py
+++ b/plugins/modules/appliance_networking_interfaces_ipv4.py
@@ -157,8 +157,12 @@ PAYLOAD_FORMAT = {
 }  # pylint: disable=line-too-long
 
 from ansible.module_utils.basic import env_fallback
+import os
 
 try:
+    if not os.getenv('VMWARE_ENABLE_TURBO', False):
+        raise ImportError()
+
     from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
         EmbeddedModuleFailure,
     )

--- a/plugins/modules/appliance_networking_interfaces_ipv4.py
+++ b/plugins/modules/appliance_networking_interfaces_ipv4.py
@@ -159,20 +159,21 @@ PAYLOAD_FORMAT = {
 from ansible.module_utils.basic import env_fallback
 import os
 
-try:
-    if not os.getenv("VMWARE_ENABLE_TURBO", False):
-        raise ImportError()
+if os.getenv("VMWARE_ENABLE_TURBO", False):
+    try:
+        from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
+            EmbeddedModuleFailure,
+        )
+        from ansible_collections.cloud.common.plugins.module_utils.turbo.module import (
+            AnsibleTurboModule as AnsibleModule,
+        )
 
-    from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
-        EmbeddedModuleFailure,
-    )
-    from ansible_collections.cloud.common.plugins.module_utils.turbo.module import (
-        AnsibleTurboModule as AnsibleModule,
-    )
-
-    AnsibleModule.collection_name = "vmware.vmware_rest"
-except ImportError:
+        AnsibleModule.collection_name = "vmware.vmware_rest"
+    except ImportError:
+        from ansible.module_utils.basic import AnsibleModule
+else:
     from ansible.module_utils.basic import AnsibleModule
+
 from ansible_collections.vmware.vmware_rest.plugins.module_utils.vmware_rest import (
     exists,
     gen_args,

--- a/plugins/modules/appliance_networking_interfaces_ipv4_info.py
+++ b/plugins/modules/appliance_networking_interfaces_ipv4_info.py
@@ -104,7 +104,7 @@ from ansible.module_utils.basic import env_fallback
 import os
 
 try:
-    if not os.getenv('VMWARE_ENABLE_TURBO', False):
+    if not os.getenv("VMWARE_ENABLE_TURBO", False):
         raise ImportError()
 
     from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (

--- a/plugins/modules/appliance_networking_interfaces_ipv4_info.py
+++ b/plugins/modules/appliance_networking_interfaces_ipv4_info.py
@@ -101,8 +101,12 @@ PAYLOAD_FORMAT = {
 }  # pylint: disable=line-too-long
 
 from ansible.module_utils.basic import env_fallback
+import os
 
 try:
+    if not os.getenv('VMWARE_ENABLE_TURBO', False):
+        raise ImportError()
+
     from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
         EmbeddedModuleFailure,
     )

--- a/plugins/modules/appliance_networking_interfaces_ipv4_info.py
+++ b/plugins/modules/appliance_networking_interfaces_ipv4_info.py
@@ -103,20 +103,21 @@ PAYLOAD_FORMAT = {
 from ansible.module_utils.basic import env_fallback
 import os
 
-try:
-    if not os.getenv("VMWARE_ENABLE_TURBO", False):
-        raise ImportError()
+if os.getenv("VMWARE_ENABLE_TURBO", False):
+    try:
+        from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
+            EmbeddedModuleFailure,
+        )
+        from ansible_collections.cloud.common.plugins.module_utils.turbo.module import (
+            AnsibleTurboModule as AnsibleModule,
+        )
 
-    from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
-        EmbeddedModuleFailure,
-    )
-    from ansible_collections.cloud.common.plugins.module_utils.turbo.module import (
-        AnsibleTurboModule as AnsibleModule,
-    )
-
-    AnsibleModule.collection_name = "vmware.vmware_rest"
-except ImportError:
+        AnsibleModule.collection_name = "vmware.vmware_rest"
+    except ImportError:
+        from ansible.module_utils.basic import AnsibleModule
+else:
     from ansible.module_utils.basic import AnsibleModule
+
 from ansible_collections.vmware.vmware_rest.plugins.module_utils.vmware_rest import (
     gen_args,
     open_session,

--- a/plugins/modules/appliance_networking_interfaces_ipv6.py
+++ b/plugins/modules/appliance_networking_interfaces_ipv6.py
@@ -157,20 +157,21 @@ PAYLOAD_FORMAT = {
 from ansible.module_utils.basic import env_fallback
 import os
 
-try:
-    if not os.getenv("VMWARE_ENABLE_TURBO", False):
-        raise ImportError()
+if os.getenv("VMWARE_ENABLE_TURBO", False):
+    try:
+        from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
+            EmbeddedModuleFailure,
+        )
+        from ansible_collections.cloud.common.plugins.module_utils.turbo.module import (
+            AnsibleTurboModule as AnsibleModule,
+        )
 
-    from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
-        EmbeddedModuleFailure,
-    )
-    from ansible_collections.cloud.common.plugins.module_utils.turbo.module import (
-        AnsibleTurboModule as AnsibleModule,
-    )
-
-    AnsibleModule.collection_name = "vmware.vmware_rest"
-except ImportError:
+        AnsibleModule.collection_name = "vmware.vmware_rest"
+    except ImportError:
+        from ansible.module_utils.basic import AnsibleModule
+else:
     from ansible.module_utils.basic import AnsibleModule
+
 from ansible_collections.vmware.vmware_rest.plugins.module_utils.vmware_rest import (
     exists,
     gen_args,

--- a/plugins/modules/appliance_networking_interfaces_ipv6.py
+++ b/plugins/modules/appliance_networking_interfaces_ipv6.py
@@ -155,8 +155,12 @@ PAYLOAD_FORMAT = {
 }  # pylint: disable=line-too-long
 
 from ansible.module_utils.basic import env_fallback
+import os
 
 try:
+    if not os.getenv('VMWARE_ENABLE_TURBO', False):
+        raise ImportError()
+
     from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
         EmbeddedModuleFailure,
     )

--- a/plugins/modules/appliance_networking_interfaces_ipv6.py
+++ b/plugins/modules/appliance_networking_interfaces_ipv6.py
@@ -158,7 +158,7 @@ from ansible.module_utils.basic import env_fallback
 import os
 
 try:
-    if not os.getenv('VMWARE_ENABLE_TURBO', False):
+    if not os.getenv("VMWARE_ENABLE_TURBO", False):
         raise ImportError()
 
     from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (

--- a/plugins/modules/appliance_networking_interfaces_ipv6_info.py
+++ b/plugins/modules/appliance_networking_interfaces_ipv6_info.py
@@ -108,7 +108,7 @@ from ansible.module_utils.basic import env_fallback
 import os
 
 try:
-    if not os.getenv('VMWARE_ENABLE_TURBO', False):
+    if not os.getenv("VMWARE_ENABLE_TURBO", False):
         raise ImportError()
 
     from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (

--- a/plugins/modules/appliance_networking_interfaces_ipv6_info.py
+++ b/plugins/modules/appliance_networking_interfaces_ipv6_info.py
@@ -107,20 +107,21 @@ PAYLOAD_FORMAT = {
 from ansible.module_utils.basic import env_fallback
 import os
 
-try:
-    if not os.getenv("VMWARE_ENABLE_TURBO", False):
-        raise ImportError()
+if os.getenv("VMWARE_ENABLE_TURBO", False):
+    try:
+        from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
+            EmbeddedModuleFailure,
+        )
+        from ansible_collections.cloud.common.plugins.module_utils.turbo.module import (
+            AnsibleTurboModule as AnsibleModule,
+        )
 
-    from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
-        EmbeddedModuleFailure,
-    )
-    from ansible_collections.cloud.common.plugins.module_utils.turbo.module import (
-        AnsibleTurboModule as AnsibleModule,
-    )
-
-    AnsibleModule.collection_name = "vmware.vmware_rest"
-except ImportError:
+        AnsibleModule.collection_name = "vmware.vmware_rest"
+    except ImportError:
+        from ansible.module_utils.basic import AnsibleModule
+else:
     from ansible.module_utils.basic import AnsibleModule
+
 from ansible_collections.vmware.vmware_rest.plugins.module_utils.vmware_rest import (
     gen_args,
     open_session,

--- a/plugins/modules/appliance_networking_interfaces_ipv6_info.py
+++ b/plugins/modules/appliance_networking_interfaces_ipv6_info.py
@@ -105,8 +105,12 @@ PAYLOAD_FORMAT = {
 }  # pylint: disable=line-too-long
 
 from ansible.module_utils.basic import env_fallback
+import os
 
 try:
+    if not os.getenv('VMWARE_ENABLE_TURBO', False):
+        raise ImportError()
+
     from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
         EmbeddedModuleFailure,
     )

--- a/plugins/modules/appliance_networking_noproxy.py
+++ b/plugins/modules/appliance_networking_noproxy.py
@@ -122,7 +122,7 @@ from ansible.module_utils.basic import env_fallback
 import os
 
 try:
-    if not os.getenv('VMWARE_ENABLE_TURBO', False):
+    if not os.getenv("VMWARE_ENABLE_TURBO", False):
         raise ImportError()
 
     from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (

--- a/plugins/modules/appliance_networking_noproxy.py
+++ b/plugins/modules/appliance_networking_noproxy.py
@@ -121,20 +121,21 @@ PAYLOAD_FORMAT = {
 from ansible.module_utils.basic import env_fallback
 import os
 
-try:
-    if not os.getenv("VMWARE_ENABLE_TURBO", False):
-        raise ImportError()
+if os.getenv("VMWARE_ENABLE_TURBO", False):
+    try:
+        from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
+            EmbeddedModuleFailure,
+        )
+        from ansible_collections.cloud.common.plugins.module_utils.turbo.module import (
+            AnsibleTurboModule as AnsibleModule,
+        )
 
-    from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
-        EmbeddedModuleFailure,
-    )
-    from ansible_collections.cloud.common.plugins.module_utils.turbo.module import (
-        AnsibleTurboModule as AnsibleModule,
-    )
-
-    AnsibleModule.collection_name = "vmware.vmware_rest"
-except ImportError:
+        AnsibleModule.collection_name = "vmware.vmware_rest"
+    except ImportError:
+        from ansible.module_utils.basic import AnsibleModule
+else:
     from ansible.module_utils.basic import AnsibleModule
+
 from ansible_collections.vmware.vmware_rest.plugins.module_utils.vmware_rest import (
     exists,
     gen_args,

--- a/plugins/modules/appliance_networking_noproxy.py
+++ b/plugins/modules/appliance_networking_noproxy.py
@@ -119,8 +119,12 @@ PAYLOAD_FORMAT = {
 }  # pylint: disable=line-too-long
 
 from ansible.module_utils.basic import env_fallback
+import os
 
 try:
+    if not os.getenv('VMWARE_ENABLE_TURBO', False):
+        raise ImportError()
+
     from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
         EmbeddedModuleFailure,
     )

--- a/plugins/modules/appliance_networking_noproxy_info.py
+++ b/plugins/modules/appliance_networking_noproxy_info.py
@@ -96,7 +96,7 @@ from ansible.module_utils.basic import env_fallback
 import os
 
 try:
-    if not os.getenv('VMWARE_ENABLE_TURBO', False):
+    if not os.getenv("VMWARE_ENABLE_TURBO", False):
         raise ImportError()
 
     from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (

--- a/plugins/modules/appliance_networking_noproxy_info.py
+++ b/plugins/modules/appliance_networking_noproxy_info.py
@@ -93,8 +93,12 @@ PAYLOAD_FORMAT = {
 }  # pylint: disable=line-too-long
 
 from ansible.module_utils.basic import env_fallback
+import os
 
 try:
+    if not os.getenv('VMWARE_ENABLE_TURBO', False):
+        raise ImportError()
+
     from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
         EmbeddedModuleFailure,
     )

--- a/plugins/modules/appliance_networking_noproxy_info.py
+++ b/plugins/modules/appliance_networking_noproxy_info.py
@@ -95,20 +95,21 @@ PAYLOAD_FORMAT = {
 from ansible.module_utils.basic import env_fallback
 import os
 
-try:
-    if not os.getenv("VMWARE_ENABLE_TURBO", False):
-        raise ImportError()
+if os.getenv("VMWARE_ENABLE_TURBO", False):
+    try:
+        from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
+            EmbeddedModuleFailure,
+        )
+        from ansible_collections.cloud.common.plugins.module_utils.turbo.module import (
+            AnsibleTurboModule as AnsibleModule,
+        )
 
-    from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
-        EmbeddedModuleFailure,
-    )
-    from ansible_collections.cloud.common.plugins.module_utils.turbo.module import (
-        AnsibleTurboModule as AnsibleModule,
-    )
-
-    AnsibleModule.collection_name = "vmware.vmware_rest"
-except ImportError:
+        AnsibleModule.collection_name = "vmware.vmware_rest"
+    except ImportError:
+        from ansible.module_utils.basic import AnsibleModule
+else:
     from ansible.module_utils.basic import AnsibleModule
+
 from ansible_collections.vmware.vmware_rest.plugins.module_utils.vmware_rest import (
     gen_args,
     open_session,

--- a/plugins/modules/appliance_networking_proxy.py
+++ b/plugins/modules/appliance_networking_proxy.py
@@ -187,8 +187,12 @@ PAYLOAD_FORMAT = {
 }  # pylint: disable=line-too-long
 
 from ansible.module_utils.basic import env_fallback
+import os
 
 try:
+    if not os.getenv('VMWARE_ENABLE_TURBO', False):
+        raise ImportError()
+
     from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
         EmbeddedModuleFailure,
     )

--- a/plugins/modules/appliance_networking_proxy.py
+++ b/plugins/modules/appliance_networking_proxy.py
@@ -190,7 +190,7 @@ from ansible.module_utils.basic import env_fallback
 import os
 
 try:
-    if not os.getenv('VMWARE_ENABLE_TURBO', False):
+    if not os.getenv("VMWARE_ENABLE_TURBO", False):
         raise ImportError()
 
     from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (

--- a/plugins/modules/appliance_networking_proxy.py
+++ b/plugins/modules/appliance_networking_proxy.py
@@ -189,20 +189,21 @@ PAYLOAD_FORMAT = {
 from ansible.module_utils.basic import env_fallback
 import os
 
-try:
-    if not os.getenv("VMWARE_ENABLE_TURBO", False):
-        raise ImportError()
+if os.getenv("VMWARE_ENABLE_TURBO", False):
+    try:
+        from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
+            EmbeddedModuleFailure,
+        )
+        from ansible_collections.cloud.common.plugins.module_utils.turbo.module import (
+            AnsibleTurboModule as AnsibleModule,
+        )
 
-    from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
-        EmbeddedModuleFailure,
-    )
-    from ansible_collections.cloud.common.plugins.module_utils.turbo.module import (
-        AnsibleTurboModule as AnsibleModule,
-    )
-
-    AnsibleModule.collection_name = "vmware.vmware_rest"
-except ImportError:
+        AnsibleModule.collection_name = "vmware.vmware_rest"
+    except ImportError:
+        from ansible.module_utils.basic import AnsibleModule
+else:
     from ansible.module_utils.basic import AnsibleModule
+
 from ansible_collections.vmware.vmware_rest.plugins.module_utils.vmware_rest import (
     exists,
     gen_args,

--- a/plugins/modules/appliance_networking_proxy_info.py
+++ b/plugins/modules/appliance_networking_proxy_info.py
@@ -112,20 +112,21 @@ PAYLOAD_FORMAT = {
 from ansible.module_utils.basic import env_fallback
 import os
 
-try:
-    if not os.getenv("VMWARE_ENABLE_TURBO", False):
-        raise ImportError()
+if os.getenv("VMWARE_ENABLE_TURBO", False):
+    try:
+        from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
+            EmbeddedModuleFailure,
+        )
+        from ansible_collections.cloud.common.plugins.module_utils.turbo.module import (
+            AnsibleTurboModule as AnsibleModule,
+        )
 
-    from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
-        EmbeddedModuleFailure,
-    )
-    from ansible_collections.cloud.common.plugins.module_utils.turbo.module import (
-        AnsibleTurboModule as AnsibleModule,
-    )
-
-    AnsibleModule.collection_name = "vmware.vmware_rest"
-except ImportError:
+        AnsibleModule.collection_name = "vmware.vmware_rest"
+    except ImportError:
+        from ansible.module_utils.basic import AnsibleModule
+else:
     from ansible.module_utils.basic import AnsibleModule
+
 from ansible_collections.vmware.vmware_rest.plugins.module_utils.vmware_rest import (
     build_full_device_list,
     exists,

--- a/plugins/modules/appliance_networking_proxy_info.py
+++ b/plugins/modules/appliance_networking_proxy_info.py
@@ -113,7 +113,7 @@ from ansible.module_utils.basic import env_fallback
 import os
 
 try:
-    if not os.getenv('VMWARE_ENABLE_TURBO', False):
+    if not os.getenv("VMWARE_ENABLE_TURBO", False):
         raise ImportError()
 
     from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (

--- a/plugins/modules/appliance_networking_proxy_info.py
+++ b/plugins/modules/appliance_networking_proxy_info.py
@@ -110,8 +110,12 @@ PAYLOAD_FORMAT = {
 }  # pylint: disable=line-too-long
 
 from ansible.module_utils.basic import env_fallback
+import os
 
 try:
+    if not os.getenv('VMWARE_ENABLE_TURBO', False):
+        raise ImportError()
+
     from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
         EmbeddedModuleFailure,
     )

--- a/plugins/modules/appliance_ntp.py
+++ b/plugins/modules/appliance_ntp.py
@@ -127,20 +127,21 @@ PAYLOAD_FORMAT = {
 from ansible.module_utils.basic import env_fallback
 import os
 
-try:
-    if not os.getenv("VMWARE_ENABLE_TURBO", False):
-        raise ImportError()
+if os.getenv("VMWARE_ENABLE_TURBO", False):
+    try:
+        from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
+            EmbeddedModuleFailure,
+        )
+        from ansible_collections.cloud.common.plugins.module_utils.turbo.module import (
+            AnsibleTurboModule as AnsibleModule,
+        )
 
-    from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
-        EmbeddedModuleFailure,
-    )
-    from ansible_collections.cloud.common.plugins.module_utils.turbo.module import (
-        AnsibleTurboModule as AnsibleModule,
-    )
-
-    AnsibleModule.collection_name = "vmware.vmware_rest"
-except ImportError:
+        AnsibleModule.collection_name = "vmware.vmware_rest"
+    except ImportError:
+        from ansible.module_utils.basic import AnsibleModule
+else:
     from ansible.module_utils.basic import AnsibleModule
+
 from ansible_collections.vmware.vmware_rest.plugins.module_utils.vmware_rest import (
     exists,
     gen_args,

--- a/plugins/modules/appliance_ntp.py
+++ b/plugins/modules/appliance_ntp.py
@@ -128,7 +128,7 @@ from ansible.module_utils.basic import env_fallback
 import os
 
 try:
-    if not os.getenv('VMWARE_ENABLE_TURBO', False):
+    if not os.getenv("VMWARE_ENABLE_TURBO", False):
         raise ImportError()
 
     from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (

--- a/plugins/modules/appliance_ntp.py
+++ b/plugins/modules/appliance_ntp.py
@@ -125,8 +125,12 @@ PAYLOAD_FORMAT = {
 }  # pylint: disable=line-too-long
 
 from ansible.module_utils.basic import env_fallback
+import os
 
 try:
+    if not os.getenv('VMWARE_ENABLE_TURBO', False):
+        raise ImportError()
+
     from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
         EmbeddedModuleFailure,
     )

--- a/plugins/modules/appliance_ntp_info.py
+++ b/plugins/modules/appliance_ntp_info.py
@@ -104,7 +104,7 @@ from ansible.module_utils.basic import env_fallback
 import os
 
 try:
-    if not os.getenv('VMWARE_ENABLE_TURBO', False):
+    if not os.getenv("VMWARE_ENABLE_TURBO", False):
         raise ImportError()
 
     from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (

--- a/plugins/modules/appliance_ntp_info.py
+++ b/plugins/modules/appliance_ntp_info.py
@@ -101,8 +101,12 @@ PAYLOAD_FORMAT = {
 }  # pylint: disable=line-too-long
 
 from ansible.module_utils.basic import env_fallback
+import os
 
 try:
+    if not os.getenv('VMWARE_ENABLE_TURBO', False):
+        raise ImportError()
+
     from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
         EmbeddedModuleFailure,
     )

--- a/plugins/modules/appliance_ntp_info.py
+++ b/plugins/modules/appliance_ntp_info.py
@@ -103,20 +103,21 @@ PAYLOAD_FORMAT = {
 from ansible.module_utils.basic import env_fallback
 import os
 
-try:
-    if not os.getenv("VMWARE_ENABLE_TURBO", False):
-        raise ImportError()
+if os.getenv("VMWARE_ENABLE_TURBO", False):
+    try:
+        from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
+            EmbeddedModuleFailure,
+        )
+        from ansible_collections.cloud.common.plugins.module_utils.turbo.module import (
+            AnsibleTurboModule as AnsibleModule,
+        )
 
-    from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
-        EmbeddedModuleFailure,
-    )
-    from ansible_collections.cloud.common.plugins.module_utils.turbo.module import (
-        AnsibleTurboModule as AnsibleModule,
-    )
-
-    AnsibleModule.collection_name = "vmware.vmware_rest"
-except ImportError:
+        AnsibleModule.collection_name = "vmware.vmware_rest"
+    except ImportError:
+        from ansible.module_utils.basic import AnsibleModule
+else:
     from ansible.module_utils.basic import AnsibleModule
+
 from ansible_collections.vmware.vmware_rest.plugins.module_utils.vmware_rest import (
     gen_args,
     open_session,

--- a/plugins/modules/appliance_services.py
+++ b/plugins/modules/appliance_services.py
@@ -122,20 +122,21 @@ PAYLOAD_FORMAT = {
 from ansible.module_utils.basic import env_fallback
 import os
 
-try:
-    if not os.getenv("VMWARE_ENABLE_TURBO", False):
-        raise ImportError()
+if os.getenv("VMWARE_ENABLE_TURBO", False):
+    try:
+        from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
+            EmbeddedModuleFailure,
+        )
+        from ansible_collections.cloud.common.plugins.module_utils.turbo.module import (
+            AnsibleTurboModule as AnsibleModule,
+        )
 
-    from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
-        EmbeddedModuleFailure,
-    )
-    from ansible_collections.cloud.common.plugins.module_utils.turbo.module import (
-        AnsibleTurboModule as AnsibleModule,
-    )
-
-    AnsibleModule.collection_name = "vmware.vmware_rest"
-except ImportError:
+        AnsibleModule.collection_name = "vmware.vmware_rest"
+    except ImportError:
+        from ansible.module_utils.basic import AnsibleModule
+else:
     from ansible.module_utils.basic import AnsibleModule
+
 from ansible_collections.vmware.vmware_rest.plugins.module_utils.vmware_rest import (
     exists,
     gen_args,

--- a/plugins/modules/appliance_services.py
+++ b/plugins/modules/appliance_services.py
@@ -123,7 +123,7 @@ from ansible.module_utils.basic import env_fallback
 import os
 
 try:
-    if not os.getenv('VMWARE_ENABLE_TURBO', False):
+    if not os.getenv("VMWARE_ENABLE_TURBO", False):
         raise ImportError()
 
     from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (

--- a/plugins/modules/appliance_services.py
+++ b/plugins/modules/appliance_services.py
@@ -120,8 +120,12 @@ PAYLOAD_FORMAT = {
 }  # pylint: disable=line-too-long
 
 from ansible.module_utils.basic import env_fallback
+import os
 
 try:
+    if not os.getenv('VMWARE_ENABLE_TURBO', False):
+        raise ImportError()
+
     from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
         EmbeddedModuleFailure,
     )

--- a/plugins/modules/appliance_services_info.py
+++ b/plugins/modules/appliance_services_info.py
@@ -106,20 +106,21 @@ PAYLOAD_FORMAT = {
 from ansible.module_utils.basic import env_fallback
 import os
 
-try:
-    if not os.getenv("VMWARE_ENABLE_TURBO", False):
-        raise ImportError()
+if os.getenv("VMWARE_ENABLE_TURBO", False):
+    try:
+        from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
+            EmbeddedModuleFailure,
+        )
+        from ansible_collections.cloud.common.plugins.module_utils.turbo.module import (
+            AnsibleTurboModule as AnsibleModule,
+        )
 
-    from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
-        EmbeddedModuleFailure,
-    )
-    from ansible_collections.cloud.common.plugins.module_utils.turbo.module import (
-        AnsibleTurboModule as AnsibleModule,
-    )
-
-    AnsibleModule.collection_name = "vmware.vmware_rest"
-except ImportError:
+        AnsibleModule.collection_name = "vmware.vmware_rest"
+    except ImportError:
+        from ansible.module_utils.basic import AnsibleModule
+else:
     from ansible.module_utils.basic import AnsibleModule
+
 from ansible_collections.vmware.vmware_rest.plugins.module_utils.vmware_rest import (
     build_full_device_list,
     exists,

--- a/plugins/modules/appliance_services_info.py
+++ b/plugins/modules/appliance_services_info.py
@@ -104,8 +104,12 @@ PAYLOAD_FORMAT = {
 }  # pylint: disable=line-too-long
 
 from ansible.module_utils.basic import env_fallback
+import os
 
 try:
+    if not os.getenv('VMWARE_ENABLE_TURBO', False):
+        raise ImportError()
+
     from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
         EmbeddedModuleFailure,
     )

--- a/plugins/modules/appliance_services_info.py
+++ b/plugins/modules/appliance_services_info.py
@@ -107,7 +107,7 @@ from ansible.module_utils.basic import env_fallback
 import os
 
 try:
-    if not os.getenv('VMWARE_ENABLE_TURBO', False):
+    if not os.getenv("VMWARE_ENABLE_TURBO", False):
         raise ImportError()
 
     from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (

--- a/plugins/modules/appliance_shutdown.py
+++ b/plugins/modules/appliance_shutdown.py
@@ -135,7 +135,7 @@ from ansible.module_utils.basic import env_fallback
 import os
 
 try:
-    if not os.getenv('VMWARE_ENABLE_TURBO', False):
+    if not os.getenv("VMWARE_ENABLE_TURBO", False):
         raise ImportError()
 
     from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (

--- a/plugins/modules/appliance_shutdown.py
+++ b/plugins/modules/appliance_shutdown.py
@@ -134,20 +134,21 @@ PAYLOAD_FORMAT = {
 from ansible.module_utils.basic import env_fallback
 import os
 
-try:
-    if not os.getenv("VMWARE_ENABLE_TURBO", False):
-        raise ImportError()
+if os.getenv("VMWARE_ENABLE_TURBO", False):
+    try:
+        from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
+            EmbeddedModuleFailure,
+        )
+        from ansible_collections.cloud.common.plugins.module_utils.turbo.module import (
+            AnsibleTurboModule as AnsibleModule,
+        )
 
-    from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
-        EmbeddedModuleFailure,
-    )
-    from ansible_collections.cloud.common.plugins.module_utils.turbo.module import (
-        AnsibleTurboModule as AnsibleModule,
-    )
-
-    AnsibleModule.collection_name = "vmware.vmware_rest"
-except ImportError:
+        AnsibleModule.collection_name = "vmware.vmware_rest"
+    except ImportError:
+        from ansible.module_utils.basic import AnsibleModule
+else:
     from ansible.module_utils.basic import AnsibleModule
+
 from ansible_collections.vmware.vmware_rest.plugins.module_utils.vmware_rest import (
     exists,
     gen_args,

--- a/plugins/modules/appliance_shutdown.py
+++ b/plugins/modules/appliance_shutdown.py
@@ -132,8 +132,12 @@ PAYLOAD_FORMAT = {
 }  # pylint: disable=line-too-long
 
 from ansible.module_utils.basic import env_fallback
+import os
 
 try:
+    if not os.getenv('VMWARE_ENABLE_TURBO', False):
+        raise ImportError()
+
     from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
         EmbeddedModuleFailure,
     )

--- a/plugins/modules/appliance_shutdown_info.py
+++ b/plugins/modules/appliance_shutdown_info.py
@@ -98,20 +98,21 @@ PAYLOAD_FORMAT = {
 from ansible.module_utils.basic import env_fallback
 import os
 
-try:
-    if not os.getenv("VMWARE_ENABLE_TURBO", False):
-        raise ImportError()
+if os.getenv("VMWARE_ENABLE_TURBO", False):
+    try:
+        from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
+            EmbeddedModuleFailure,
+        )
+        from ansible_collections.cloud.common.plugins.module_utils.turbo.module import (
+            AnsibleTurboModule as AnsibleModule,
+        )
 
-    from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
-        EmbeddedModuleFailure,
-    )
-    from ansible_collections.cloud.common.plugins.module_utils.turbo.module import (
-        AnsibleTurboModule as AnsibleModule,
-    )
-
-    AnsibleModule.collection_name = "vmware.vmware_rest"
-except ImportError:
+        AnsibleModule.collection_name = "vmware.vmware_rest"
+    except ImportError:
+        from ansible.module_utils.basic import AnsibleModule
+else:
     from ansible.module_utils.basic import AnsibleModule
+
 from ansible_collections.vmware.vmware_rest.plugins.module_utils.vmware_rest import (
     gen_args,
     open_session,

--- a/plugins/modules/appliance_shutdown_info.py
+++ b/plugins/modules/appliance_shutdown_info.py
@@ -96,8 +96,12 @@ PAYLOAD_FORMAT = {
 }  # pylint: disable=line-too-long
 
 from ansible.module_utils.basic import env_fallback
+import os
 
 try:
+    if not os.getenv('VMWARE_ENABLE_TURBO', False):
+        raise ImportError()
+
     from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
         EmbeddedModuleFailure,
     )

--- a/plugins/modules/appliance_shutdown_info.py
+++ b/plugins/modules/appliance_shutdown_info.py
@@ -99,7 +99,7 @@ from ansible.module_utils.basic import env_fallback
 import os
 
 try:
-    if not os.getenv('VMWARE_ENABLE_TURBO', False):
+    if not os.getenv("VMWARE_ENABLE_TURBO", False):
         raise ImportError()
 
     from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (

--- a/plugins/modules/appliance_system_globalfips.py
+++ b/plugins/modules/appliance_system_globalfips.py
@@ -95,8 +95,12 @@ PAYLOAD_FORMAT = {
 }  # pylint: disable=line-too-long
 
 from ansible.module_utils.basic import env_fallback
+import os
 
 try:
+    if not os.getenv('VMWARE_ENABLE_TURBO', False):
+        raise ImportError()
+
     from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
         EmbeddedModuleFailure,
     )

--- a/plugins/modules/appliance_system_globalfips.py
+++ b/plugins/modules/appliance_system_globalfips.py
@@ -98,7 +98,7 @@ from ansible.module_utils.basic import env_fallback
 import os
 
 try:
-    if not os.getenv('VMWARE_ENABLE_TURBO', False):
+    if not os.getenv("VMWARE_ENABLE_TURBO", False):
         raise ImportError()
 
     from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (

--- a/plugins/modules/appliance_system_globalfips.py
+++ b/plugins/modules/appliance_system_globalfips.py
@@ -97,20 +97,21 @@ PAYLOAD_FORMAT = {
 from ansible.module_utils.basic import env_fallback
 import os
 
-try:
-    if not os.getenv("VMWARE_ENABLE_TURBO", False):
-        raise ImportError()
+if os.getenv("VMWARE_ENABLE_TURBO", False):
+    try:
+        from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
+            EmbeddedModuleFailure,
+        )
+        from ansible_collections.cloud.common.plugins.module_utils.turbo.module import (
+            AnsibleTurboModule as AnsibleModule,
+        )
 
-    from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
-        EmbeddedModuleFailure,
-    )
-    from ansible_collections.cloud.common.plugins.module_utils.turbo.module import (
-        AnsibleTurboModule as AnsibleModule,
-    )
-
-    AnsibleModule.collection_name = "vmware.vmware_rest"
-except ImportError:
+        AnsibleModule.collection_name = "vmware.vmware_rest"
+    except ImportError:
+        from ansible.module_utils.basic import AnsibleModule
+else:
     from ansible.module_utils.basic import AnsibleModule
+
 from ansible_collections.vmware.vmware_rest.plugins.module_utils.vmware_rest import (
     open_session,
     prepare_payload,

--- a/plugins/modules/appliance_system_globalfips_info.py
+++ b/plugins/modules/appliance_system_globalfips_info.py
@@ -84,8 +84,12 @@ PAYLOAD_FORMAT = {
 }  # pylint: disable=line-too-long
 
 from ansible.module_utils.basic import env_fallback
+import os
 
 try:
+    if not os.getenv('VMWARE_ENABLE_TURBO', False):
+        raise ImportError()
+
     from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
         EmbeddedModuleFailure,
     )

--- a/plugins/modules/appliance_system_globalfips_info.py
+++ b/plugins/modules/appliance_system_globalfips_info.py
@@ -86,20 +86,21 @@ PAYLOAD_FORMAT = {
 from ansible.module_utils.basic import env_fallback
 import os
 
-try:
-    if not os.getenv("VMWARE_ENABLE_TURBO", False):
-        raise ImportError()
+if os.getenv("VMWARE_ENABLE_TURBO", False):
+    try:
+        from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
+            EmbeddedModuleFailure,
+        )
+        from ansible_collections.cloud.common.plugins.module_utils.turbo.module import (
+            AnsibleTurboModule as AnsibleModule,
+        )
 
-    from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
-        EmbeddedModuleFailure,
-    )
-    from ansible_collections.cloud.common.plugins.module_utils.turbo.module import (
-        AnsibleTurboModule as AnsibleModule,
-    )
-
-    AnsibleModule.collection_name = "vmware.vmware_rest"
-except ImportError:
+        AnsibleModule.collection_name = "vmware.vmware_rest"
+    except ImportError:
+        from ansible.module_utils.basic import AnsibleModule
+else:
     from ansible.module_utils.basic import AnsibleModule
+
 from ansible_collections.vmware.vmware_rest.plugins.module_utils.vmware_rest import (
     gen_args,
     open_session,

--- a/plugins/modules/appliance_system_globalfips_info.py
+++ b/plugins/modules/appliance_system_globalfips_info.py
@@ -87,7 +87,7 @@ from ansible.module_utils.basic import env_fallback
 import os
 
 try:
-    if not os.getenv('VMWARE_ENABLE_TURBO', False):
+    if not os.getenv("VMWARE_ENABLE_TURBO", False):
         raise ImportError()
 
     from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (

--- a/plugins/modules/appliance_system_storage.py
+++ b/plugins/modules/appliance_system_storage.py
@@ -110,7 +110,7 @@ from ansible.module_utils.basic import env_fallback
 import os
 
 try:
-    if not os.getenv('VMWARE_ENABLE_TURBO', False):
+    if not os.getenv("VMWARE_ENABLE_TURBO", False):
         raise ImportError()
 
     from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (

--- a/plugins/modules/appliance_system_storage.py
+++ b/plugins/modules/appliance_system_storage.py
@@ -109,20 +109,21 @@ PAYLOAD_FORMAT = {
 from ansible.module_utils.basic import env_fallback
 import os
 
-try:
-    if not os.getenv("VMWARE_ENABLE_TURBO", False):
-        raise ImportError()
+if os.getenv("VMWARE_ENABLE_TURBO", False):
+    try:
+        from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
+            EmbeddedModuleFailure,
+        )
+        from ansible_collections.cloud.common.plugins.module_utils.turbo.module import (
+            AnsibleTurboModule as AnsibleModule,
+        )
 
-    from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
-        EmbeddedModuleFailure,
-    )
-    from ansible_collections.cloud.common.plugins.module_utils.turbo.module import (
-        AnsibleTurboModule as AnsibleModule,
-    )
-
-    AnsibleModule.collection_name = "vmware.vmware_rest"
-except ImportError:
+        AnsibleModule.collection_name = "vmware.vmware_rest"
+    except ImportError:
+        from ansible.module_utils.basic import AnsibleModule
+else:
     from ansible.module_utils.basic import AnsibleModule
+
 from ansible_collections.vmware.vmware_rest.plugins.module_utils.vmware_rest import (
     exists,
     gen_args,

--- a/plugins/modules/appliance_system_storage.py
+++ b/plugins/modules/appliance_system_storage.py
@@ -107,8 +107,12 @@ PAYLOAD_FORMAT = {
 }  # pylint: disable=line-too-long
 
 from ansible.module_utils.basic import env_fallback
+import os
 
 try:
+    if not os.getenv('VMWARE_ENABLE_TURBO', False):
+        raise ImportError()
+
     from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
         EmbeddedModuleFailure,
     )

--- a/plugins/modules/appliance_system_storage_info.py
+++ b/plugins/modules/appliance_system_storage_info.py
@@ -91,20 +91,21 @@ PAYLOAD_FORMAT = {
 from ansible.module_utils.basic import env_fallback
 import os
 
-try:
-    if not os.getenv("VMWARE_ENABLE_TURBO", False):
-        raise ImportError()
+if os.getenv("VMWARE_ENABLE_TURBO", False):
+    try:
+        from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
+            EmbeddedModuleFailure,
+        )
+        from ansible_collections.cloud.common.plugins.module_utils.turbo.module import (
+            AnsibleTurboModule as AnsibleModule,
+        )
 
-    from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
-        EmbeddedModuleFailure,
-    )
-    from ansible_collections.cloud.common.plugins.module_utils.turbo.module import (
-        AnsibleTurboModule as AnsibleModule,
-    )
-
-    AnsibleModule.collection_name = "vmware.vmware_rest"
-except ImportError:
+        AnsibleModule.collection_name = "vmware.vmware_rest"
+    except ImportError:
+        from ansible.module_utils.basic import AnsibleModule
+else:
     from ansible.module_utils.basic import AnsibleModule
+
 from ansible_collections.vmware.vmware_rest.plugins.module_utils.vmware_rest import (
     gen_args,
     open_session,

--- a/plugins/modules/appliance_system_storage_info.py
+++ b/plugins/modules/appliance_system_storage_info.py
@@ -92,7 +92,7 @@ from ansible.module_utils.basic import env_fallback
 import os
 
 try:
-    if not os.getenv('VMWARE_ENABLE_TURBO', False):
+    if not os.getenv("VMWARE_ENABLE_TURBO", False):
         raise ImportError()
 
     from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (

--- a/plugins/modules/appliance_system_storage_info.py
+++ b/plugins/modules/appliance_system_storage_info.py
@@ -89,8 +89,12 @@ PAYLOAD_FORMAT = {
 }  # pylint: disable=line-too-long
 
 from ansible.module_utils.basic import env_fallback
+import os
 
 try:
+    if not os.getenv('VMWARE_ENABLE_TURBO', False):
+        raise ImportError()
+
     from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
         EmbeddedModuleFailure,
     )

--- a/plugins/modules/appliance_system_time_info.py
+++ b/plugins/modules/appliance_system_time_info.py
@@ -96,7 +96,7 @@ from ansible.module_utils.basic import env_fallback
 import os
 
 try:
-    if not os.getenv('VMWARE_ENABLE_TURBO', False):
+    if not os.getenv("VMWARE_ENABLE_TURBO", False):
         raise ImportError()
 
     from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (

--- a/plugins/modules/appliance_system_time_info.py
+++ b/plugins/modules/appliance_system_time_info.py
@@ -93,8 +93,12 @@ PAYLOAD_FORMAT = {
 }  # pylint: disable=line-too-long
 
 from ansible.module_utils.basic import env_fallback
+import os
 
 try:
+    if not os.getenv('VMWARE_ENABLE_TURBO', False):
+        raise ImportError()
+
     from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
         EmbeddedModuleFailure,
     )

--- a/plugins/modules/appliance_system_time_info.py
+++ b/plugins/modules/appliance_system_time_info.py
@@ -95,20 +95,21 @@ PAYLOAD_FORMAT = {
 from ansible.module_utils.basic import env_fallback
 import os
 
-try:
-    if not os.getenv("VMWARE_ENABLE_TURBO", False):
-        raise ImportError()
+if os.getenv("VMWARE_ENABLE_TURBO", False):
+    try:
+        from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
+            EmbeddedModuleFailure,
+        )
+        from ansible_collections.cloud.common.plugins.module_utils.turbo.module import (
+            AnsibleTurboModule as AnsibleModule,
+        )
 
-    from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
-        EmbeddedModuleFailure,
-    )
-    from ansible_collections.cloud.common.plugins.module_utils.turbo.module import (
-        AnsibleTurboModule as AnsibleModule,
-    )
-
-    AnsibleModule.collection_name = "vmware.vmware_rest"
-except ImportError:
+        AnsibleModule.collection_name = "vmware.vmware_rest"
+    except ImportError:
+        from ansible.module_utils.basic import AnsibleModule
+else:
     from ansible.module_utils.basic import AnsibleModule
+
 from ansible_collections.vmware.vmware_rest.plugins.module_utils.vmware_rest import (
     gen_args,
     open_session,

--- a/plugins/modules/appliance_system_time_timezone.py
+++ b/plugins/modules/appliance_system_time_timezone.py
@@ -108,7 +108,7 @@ from ansible.module_utils.basic import env_fallback
 import os
 
 try:
-    if not os.getenv('VMWARE_ENABLE_TURBO', False):
+    if not os.getenv("VMWARE_ENABLE_TURBO", False):
         raise ImportError()
 
     from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (

--- a/plugins/modules/appliance_system_time_timezone.py
+++ b/plugins/modules/appliance_system_time_timezone.py
@@ -107,20 +107,21 @@ PAYLOAD_FORMAT = {
 from ansible.module_utils.basic import env_fallback
 import os
 
-try:
-    if not os.getenv("VMWARE_ENABLE_TURBO", False):
-        raise ImportError()
+if os.getenv("VMWARE_ENABLE_TURBO", False):
+    try:
+        from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
+            EmbeddedModuleFailure,
+        )
+        from ansible_collections.cloud.common.plugins.module_utils.turbo.module import (
+            AnsibleTurboModule as AnsibleModule,
+        )
 
-    from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
-        EmbeddedModuleFailure,
-    )
-    from ansible_collections.cloud.common.plugins.module_utils.turbo.module import (
-        AnsibleTurboModule as AnsibleModule,
-    )
-
-    AnsibleModule.collection_name = "vmware.vmware_rest"
-except ImportError:
+        AnsibleModule.collection_name = "vmware.vmware_rest"
+    except ImportError:
+        from ansible.module_utils.basic import AnsibleModule
+else:
     from ansible.module_utils.basic import AnsibleModule
+
 from ansible_collections.vmware.vmware_rest.plugins.module_utils.vmware_rest import (
     exists,
     gen_args,

--- a/plugins/modules/appliance_system_time_timezone.py
+++ b/plugins/modules/appliance_system_time_timezone.py
@@ -105,8 +105,12 @@ PAYLOAD_FORMAT = {
 }  # pylint: disable=line-too-long
 
 from ansible.module_utils.basic import env_fallback
+import os
 
 try:
+    if not os.getenv('VMWARE_ENABLE_TURBO', False):
+        raise ImportError()
+
     from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
         EmbeddedModuleFailure,
     )

--- a/plugins/modules/appliance_system_time_timezone_info.py
+++ b/plugins/modules/appliance_system_time_timezone_info.py
@@ -96,7 +96,7 @@ from ansible.module_utils.basic import env_fallback
 import os
 
 try:
-    if not os.getenv('VMWARE_ENABLE_TURBO', False):
+    if not os.getenv("VMWARE_ENABLE_TURBO", False):
         raise ImportError()
 
     from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (

--- a/plugins/modules/appliance_system_time_timezone_info.py
+++ b/plugins/modules/appliance_system_time_timezone_info.py
@@ -93,8 +93,12 @@ PAYLOAD_FORMAT = {
 }  # pylint: disable=line-too-long
 
 from ansible.module_utils.basic import env_fallback
+import os
 
 try:
+    if not os.getenv('VMWARE_ENABLE_TURBO', False):
+        raise ImportError()
+
     from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
         EmbeddedModuleFailure,
     )

--- a/plugins/modules/appliance_system_time_timezone_info.py
+++ b/plugins/modules/appliance_system_time_timezone_info.py
@@ -95,20 +95,21 @@ PAYLOAD_FORMAT = {
 from ansible.module_utils.basic import env_fallback
 import os
 
-try:
-    if not os.getenv("VMWARE_ENABLE_TURBO", False):
-        raise ImportError()
+if os.getenv("VMWARE_ENABLE_TURBO", False):
+    try:
+        from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
+            EmbeddedModuleFailure,
+        )
+        from ansible_collections.cloud.common.plugins.module_utils.turbo.module import (
+            AnsibleTurboModule as AnsibleModule,
+        )
 
-    from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
-        EmbeddedModuleFailure,
-    )
-    from ansible_collections.cloud.common.plugins.module_utils.turbo.module import (
-        AnsibleTurboModule as AnsibleModule,
-    )
-
-    AnsibleModule.collection_name = "vmware.vmware_rest"
-except ImportError:
+        AnsibleModule.collection_name = "vmware.vmware_rest"
+    except ImportError:
+        from ansible.module_utils.basic import AnsibleModule
+else:
     from ansible.module_utils.basic import AnsibleModule
+
 from ansible_collections.vmware.vmware_rest.plugins.module_utils.vmware_rest import (
     gen_args,
     open_session,

--- a/plugins/modules/appliance_system_version_info.py
+++ b/plugins/modules/appliance_system_version_info.py
@@ -98,20 +98,21 @@ PAYLOAD_FORMAT = {
 from ansible.module_utils.basic import env_fallback
 import os
 
-try:
-    if not os.getenv("VMWARE_ENABLE_TURBO", False):
-        raise ImportError()
+if os.getenv("VMWARE_ENABLE_TURBO", False):
+    try:
+        from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
+            EmbeddedModuleFailure,
+        )
+        from ansible_collections.cloud.common.plugins.module_utils.turbo.module import (
+            AnsibleTurboModule as AnsibleModule,
+        )
 
-    from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
-        EmbeddedModuleFailure,
-    )
-    from ansible_collections.cloud.common.plugins.module_utils.turbo.module import (
-        AnsibleTurboModule as AnsibleModule,
-    )
-
-    AnsibleModule.collection_name = "vmware.vmware_rest"
-except ImportError:
+        AnsibleModule.collection_name = "vmware.vmware_rest"
+    except ImportError:
+        from ansible.module_utils.basic import AnsibleModule
+else:
     from ansible.module_utils.basic import AnsibleModule
+
 from ansible_collections.vmware.vmware_rest.plugins.module_utils.vmware_rest import (
     gen_args,
     open_session,

--- a/plugins/modules/appliance_system_version_info.py
+++ b/plugins/modules/appliance_system_version_info.py
@@ -96,8 +96,12 @@ PAYLOAD_FORMAT = {
 }  # pylint: disable=line-too-long
 
 from ansible.module_utils.basic import env_fallback
+import os
 
 try:
+    if not os.getenv('VMWARE_ENABLE_TURBO', False):
+        raise ImportError()
+
     from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
         EmbeddedModuleFailure,
     )

--- a/plugins/modules/appliance_system_version_info.py
+++ b/plugins/modules/appliance_system_version_info.py
@@ -99,7 +99,7 @@ from ansible.module_utils.basic import env_fallback
 import os
 
 try:
-    if not os.getenv('VMWARE_ENABLE_TURBO', False):
+    if not os.getenv("VMWARE_ENABLE_TURBO", False):
         raise ImportError()
 
     from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (

--- a/plugins/modules/appliance_timesync.py
+++ b/plugins/modules/appliance_timesync.py
@@ -112,7 +112,7 @@ from ansible.module_utils.basic import env_fallback
 import os
 
 try:
-    if not os.getenv('VMWARE_ENABLE_TURBO', False):
+    if not os.getenv("VMWARE_ENABLE_TURBO", False):
         raise ImportError()
 
     from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (

--- a/plugins/modules/appliance_timesync.py
+++ b/plugins/modules/appliance_timesync.py
@@ -109,8 +109,12 @@ PAYLOAD_FORMAT = {
 }  # pylint: disable=line-too-long
 
 from ansible.module_utils.basic import env_fallback
+import os
 
 try:
+    if not os.getenv('VMWARE_ENABLE_TURBO', False):
+        raise ImportError()
+
     from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
         EmbeddedModuleFailure,
     )

--- a/plugins/modules/appliance_timesync.py
+++ b/plugins/modules/appliance_timesync.py
@@ -111,20 +111,21 @@ PAYLOAD_FORMAT = {
 from ansible.module_utils.basic import env_fallback
 import os
 
-try:
-    if not os.getenv("VMWARE_ENABLE_TURBO", False):
-        raise ImportError()
+if os.getenv("VMWARE_ENABLE_TURBO", False):
+    try:
+        from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
+            EmbeddedModuleFailure,
+        )
+        from ansible_collections.cloud.common.plugins.module_utils.turbo.module import (
+            AnsibleTurboModule as AnsibleModule,
+        )
 
-    from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
-        EmbeddedModuleFailure,
-    )
-    from ansible_collections.cloud.common.plugins.module_utils.turbo.module import (
-        AnsibleTurboModule as AnsibleModule,
-    )
-
-    AnsibleModule.collection_name = "vmware.vmware_rest"
-except ImportError:
+        AnsibleModule.collection_name = "vmware.vmware_rest"
+    except ImportError:
+        from ansible.module_utils.basic import AnsibleModule
+else:
     from ansible.module_utils.basic import AnsibleModule
+
 from ansible_collections.vmware.vmware_rest.plugins.module_utils.vmware_rest import (
     exists,
     gen_args,

--- a/plugins/modules/appliance_timesync_info.py
+++ b/plugins/modules/appliance_timesync_info.py
@@ -96,7 +96,7 @@ from ansible.module_utils.basic import env_fallback
 import os
 
 try:
-    if not os.getenv('VMWARE_ENABLE_TURBO', False):
+    if not os.getenv("VMWARE_ENABLE_TURBO", False):
         raise ImportError()
 
     from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (

--- a/plugins/modules/appliance_timesync_info.py
+++ b/plugins/modules/appliance_timesync_info.py
@@ -93,8 +93,12 @@ PAYLOAD_FORMAT = {
 }  # pylint: disable=line-too-long
 
 from ansible.module_utils.basic import env_fallback
+import os
 
 try:
+    if not os.getenv('VMWARE_ENABLE_TURBO', False):
+        raise ImportError()
+
     from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
         EmbeddedModuleFailure,
     )

--- a/plugins/modules/appliance_timesync_info.py
+++ b/plugins/modules/appliance_timesync_info.py
@@ -95,20 +95,21 @@ PAYLOAD_FORMAT = {
 from ansible.module_utils.basic import env_fallback
 import os
 
-try:
-    if not os.getenv("VMWARE_ENABLE_TURBO", False):
-        raise ImportError()
+if os.getenv("VMWARE_ENABLE_TURBO", False):
+    try:
+        from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
+            EmbeddedModuleFailure,
+        )
+        from ansible_collections.cloud.common.plugins.module_utils.turbo.module import (
+            AnsibleTurboModule as AnsibleModule,
+        )
 
-    from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
-        EmbeddedModuleFailure,
-    )
-    from ansible_collections.cloud.common.plugins.module_utils.turbo.module import (
-        AnsibleTurboModule as AnsibleModule,
-    )
-
-    AnsibleModule.collection_name = "vmware.vmware_rest"
-except ImportError:
+        AnsibleModule.collection_name = "vmware.vmware_rest"
+    except ImportError:
+        from ansible.module_utils.basic import AnsibleModule
+else:
     from ansible.module_utils.basic import AnsibleModule
+
 from ansible_collections.vmware.vmware_rest.plugins.module_utils.vmware_rest import (
     gen_args,
     open_session,

--- a/plugins/modules/appliance_update_info.py
+++ b/plugins/modules/appliance_update_info.py
@@ -93,20 +93,21 @@ PAYLOAD_FORMAT = {
 from ansible.module_utils.basic import env_fallback
 import os
 
-try:
-    if not os.getenv("VMWARE_ENABLE_TURBO", False):
-        raise ImportError()
+if os.getenv("VMWARE_ENABLE_TURBO", False):
+    try:
+        from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
+            EmbeddedModuleFailure,
+        )
+        from ansible_collections.cloud.common.plugins.module_utils.turbo.module import (
+            AnsibleTurboModule as AnsibleModule,
+        )
 
-    from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
-        EmbeddedModuleFailure,
-    )
-    from ansible_collections.cloud.common.plugins.module_utils.turbo.module import (
-        AnsibleTurboModule as AnsibleModule,
-    )
-
-    AnsibleModule.collection_name = "vmware.vmware_rest"
-except ImportError:
+        AnsibleModule.collection_name = "vmware.vmware_rest"
+    except ImportError:
+        from ansible.module_utils.basic import AnsibleModule
+else:
     from ansible.module_utils.basic import AnsibleModule
+
 from ansible_collections.vmware.vmware_rest.plugins.module_utils.vmware_rest import (
     gen_args,
     open_session,

--- a/plugins/modules/appliance_update_info.py
+++ b/plugins/modules/appliance_update_info.py
@@ -94,7 +94,7 @@ from ansible.module_utils.basic import env_fallback
 import os
 
 try:
-    if not os.getenv('VMWARE_ENABLE_TURBO', False):
+    if not os.getenv("VMWARE_ENABLE_TURBO", False):
         raise ImportError()
 
     from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (

--- a/plugins/modules/appliance_update_info.py
+++ b/plugins/modules/appliance_update_info.py
@@ -91,8 +91,12 @@ PAYLOAD_FORMAT = {
 }  # pylint: disable=line-too-long
 
 from ansible.module_utils.basic import env_fallback
+import os
 
 try:
+    if not os.getenv('VMWARE_ENABLE_TURBO', False):
+        raise ImportError()
+
     from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
         EmbeddedModuleFailure,
     )

--- a/plugins/modules/appliance_vmon_service.py
+++ b/plugins/modules/appliance_vmon_service.py
@@ -132,7 +132,7 @@ from ansible.module_utils.basic import env_fallback
 import os
 
 try:
-    if not os.getenv('VMWARE_ENABLE_TURBO', False):
+    if not os.getenv("VMWARE_ENABLE_TURBO", False):
         raise ImportError()
 
     from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (

--- a/plugins/modules/appliance_vmon_service.py
+++ b/plugins/modules/appliance_vmon_service.py
@@ -131,20 +131,21 @@ PAYLOAD_FORMAT = {
 from ansible.module_utils.basic import env_fallback
 import os
 
-try:
-    if not os.getenv("VMWARE_ENABLE_TURBO", False):
-        raise ImportError()
+if os.getenv("VMWARE_ENABLE_TURBO", False):
+    try:
+        from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
+            EmbeddedModuleFailure,
+        )
+        from ansible_collections.cloud.common.plugins.module_utils.turbo.module import (
+            AnsibleTurboModule as AnsibleModule,
+        )
 
-    from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
-        EmbeddedModuleFailure,
-    )
-    from ansible_collections.cloud.common.plugins.module_utils.turbo.module import (
-        AnsibleTurboModule as AnsibleModule,
-    )
-
-    AnsibleModule.collection_name = "vmware.vmware_rest"
-except ImportError:
+        AnsibleModule.collection_name = "vmware.vmware_rest"
+    except ImportError:
+        from ansible.module_utils.basic import AnsibleModule
+else:
     from ansible.module_utils.basic import AnsibleModule
+
 from ansible_collections.vmware.vmware_rest.plugins.module_utils.vmware_rest import (
     exists,
     gen_args,

--- a/plugins/modules/appliance_vmon_service.py
+++ b/plugins/modules/appliance_vmon_service.py
@@ -129,8 +129,12 @@ PAYLOAD_FORMAT = {
 }  # pylint: disable=line-too-long
 
 from ansible.module_utils.basic import env_fallback
+import os
 
 try:
+    if not os.getenv('VMWARE_ENABLE_TURBO', False):
+        raise ImportError()
+
     from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
         EmbeddedModuleFailure,
     )

--- a/plugins/modules/appliance_vmon_service_info.py
+++ b/plugins/modules/appliance_vmon_service_info.py
@@ -478,7 +478,7 @@ from ansible.module_utils.basic import env_fallback
 import os
 
 try:
-    if not os.getenv('VMWARE_ENABLE_TURBO', False):
+    if not os.getenv("VMWARE_ENABLE_TURBO", False):
         raise ImportError()
 
     from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (

--- a/plugins/modules/appliance_vmon_service_info.py
+++ b/plugins/modules/appliance_vmon_service_info.py
@@ -475,8 +475,12 @@ PAYLOAD_FORMAT = {
 }  # pylint: disable=line-too-long
 
 from ansible.module_utils.basic import env_fallback
+import os
 
 try:
+    if not os.getenv('VMWARE_ENABLE_TURBO', False):
+        raise ImportError()
+
     from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
         EmbeddedModuleFailure,
     )

--- a/plugins/modules/appliance_vmon_service_info.py
+++ b/plugins/modules/appliance_vmon_service_info.py
@@ -477,20 +477,21 @@ PAYLOAD_FORMAT = {
 from ansible.module_utils.basic import env_fallback
 import os
 
-try:
-    if not os.getenv("VMWARE_ENABLE_TURBO", False):
-        raise ImportError()
+if os.getenv("VMWARE_ENABLE_TURBO", False):
+    try:
+        from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
+            EmbeddedModuleFailure,
+        )
+        from ansible_collections.cloud.common.plugins.module_utils.turbo.module import (
+            AnsibleTurboModule as AnsibleModule,
+        )
 
-    from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
-        EmbeddedModuleFailure,
-    )
-    from ansible_collections.cloud.common.plugins.module_utils.turbo.module import (
-        AnsibleTurboModule as AnsibleModule,
-    )
-
-    AnsibleModule.collection_name = "vmware.vmware_rest"
-except ImportError:
+        AnsibleModule.collection_name = "vmware.vmware_rest"
+    except ImportError:
+        from ansible.module_utils.basic import AnsibleModule
+else:
     from ansible.module_utils.basic import AnsibleModule
+
 from ansible_collections.vmware.vmware_rest.plugins.module_utils.vmware_rest import (
     gen_args,
     open_session,

--- a/plugins/modules/content_configuration.py
+++ b/plugins/modules/content_configuration.py
@@ -163,7 +163,7 @@ from ansible.module_utils.basic import env_fallback
 import os
 
 try:
-    if not os.getenv('VMWARE_ENABLE_TURBO', False):
+    if not os.getenv("VMWARE_ENABLE_TURBO", False):
         raise ImportError()
 
     from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (

--- a/plugins/modules/content_configuration.py
+++ b/plugins/modules/content_configuration.py
@@ -162,20 +162,21 @@ PAYLOAD_FORMAT = {
 from ansible.module_utils.basic import env_fallback
 import os
 
-try:
-    if not os.getenv("VMWARE_ENABLE_TURBO", False):
-        raise ImportError()
+if os.getenv("VMWARE_ENABLE_TURBO", False):
+    try:
+        from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
+            EmbeddedModuleFailure,
+        )
+        from ansible_collections.cloud.common.plugins.module_utils.turbo.module import (
+            AnsibleTurboModule as AnsibleModule,
+        )
 
-    from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
-        EmbeddedModuleFailure,
-    )
-    from ansible_collections.cloud.common.plugins.module_utils.turbo.module import (
-        AnsibleTurboModule as AnsibleModule,
-    )
-
-    AnsibleModule.collection_name = "vmware.vmware_rest"
-except ImportError:
+        AnsibleModule.collection_name = "vmware.vmware_rest"
+    except ImportError:
+        from ansible.module_utils.basic import AnsibleModule
+else:
     from ansible.module_utils.basic import AnsibleModule
+
 from ansible_collections.vmware.vmware_rest.plugins.module_utils.vmware_rest import (
     open_session,
     prepare_payload,

--- a/plugins/modules/content_configuration.py
+++ b/plugins/modules/content_configuration.py
@@ -160,8 +160,12 @@ PAYLOAD_FORMAT = {
 }  # pylint: disable=line-too-long
 
 from ansible.module_utils.basic import env_fallback
+import os
 
 try:
+    if not os.getenv('VMWARE_ENABLE_TURBO', False):
+        raise ImportError()
+
     from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
         EmbeddedModuleFailure,
     )

--- a/plugins/modules/content_configuration_info.py
+++ b/plugins/modules/content_configuration_info.py
@@ -96,7 +96,7 @@ from ansible.module_utils.basic import env_fallback
 import os
 
 try:
-    if not os.getenv('VMWARE_ENABLE_TURBO', False):
+    if not os.getenv("VMWARE_ENABLE_TURBO", False):
         raise ImportError()
 
     from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (

--- a/plugins/modules/content_configuration_info.py
+++ b/plugins/modules/content_configuration_info.py
@@ -93,8 +93,12 @@ PAYLOAD_FORMAT = {
 }  # pylint: disable=line-too-long
 
 from ansible.module_utils.basic import env_fallback
+import os
 
 try:
+    if not os.getenv('VMWARE_ENABLE_TURBO', False):
+        raise ImportError()
+
     from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
         EmbeddedModuleFailure,
     )

--- a/plugins/modules/content_configuration_info.py
+++ b/plugins/modules/content_configuration_info.py
@@ -95,20 +95,21 @@ PAYLOAD_FORMAT = {
 from ansible.module_utils.basic import env_fallback
 import os
 
-try:
-    if not os.getenv("VMWARE_ENABLE_TURBO", False):
-        raise ImportError()
+if os.getenv("VMWARE_ENABLE_TURBO", False):
+    try:
+        from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
+            EmbeddedModuleFailure,
+        )
+        from ansible_collections.cloud.common.plugins.module_utils.turbo.module import (
+            AnsibleTurboModule as AnsibleModule,
+        )
 
-    from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
-        EmbeddedModuleFailure,
-    )
-    from ansible_collections.cloud.common.plugins.module_utils.turbo.module import (
-        AnsibleTurboModule as AnsibleModule,
-    )
-
-    AnsibleModule.collection_name = "vmware.vmware_rest"
-except ImportError:
+        AnsibleModule.collection_name = "vmware.vmware_rest"
+    except ImportError:
+        from ansible.module_utils.basic import AnsibleModule
+else:
     from ansible.module_utils.basic import AnsibleModule
+
 from ansible_collections.vmware.vmware_rest.plugins.module_utils.vmware_rest import (
     gen_args,
     open_session,

--- a/plugins/modules/content_library_info.py
+++ b/plugins/modules/content_library_info.py
@@ -90,7 +90,7 @@ from ansible.module_utils.basic import env_fallback
 import os
 
 try:
-    if not os.getenv('VMWARE_ENABLE_TURBO', False):
+    if not os.getenv("VMWARE_ENABLE_TURBO", False):
         raise ImportError()
 
     from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (

--- a/plugins/modules/content_library_info.py
+++ b/plugins/modules/content_library_info.py
@@ -89,20 +89,21 @@ PAYLOAD_FORMAT = {
 from ansible.module_utils.basic import env_fallback
 import os
 
-try:
-    if not os.getenv("VMWARE_ENABLE_TURBO", False):
-        raise ImportError()
+if os.getenv("VMWARE_ENABLE_TURBO", False):
+    try:
+        from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
+            EmbeddedModuleFailure,
+        )
+        from ansible_collections.cloud.common.plugins.module_utils.turbo.module import (
+            AnsibleTurboModule as AnsibleModule,
+        )
 
-    from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
-        EmbeddedModuleFailure,
-    )
-    from ansible_collections.cloud.common.plugins.module_utils.turbo.module import (
-        AnsibleTurboModule as AnsibleModule,
-    )
-
-    AnsibleModule.collection_name = "vmware.vmware_rest"
-except ImportError:
+        AnsibleModule.collection_name = "vmware.vmware_rest"
+    except ImportError:
+        from ansible.module_utils.basic import AnsibleModule
+else:
     from ansible.module_utils.basic import AnsibleModule
+
 from ansible_collections.vmware.vmware_rest.plugins.module_utils.vmware_rest import (
     build_full_device_list,
     exists,

--- a/plugins/modules/content_library_info.py
+++ b/plugins/modules/content_library_info.py
@@ -87,8 +87,12 @@ PAYLOAD_FORMAT = {
 }  # pylint: disable=line-too-long
 
 from ansible.module_utils.basic import env_fallback
+import os
 
 try:
+    if not os.getenv('VMWARE_ENABLE_TURBO', False):
+        raise ImportError()
+
     from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
         EmbeddedModuleFailure,
     )

--- a/plugins/modules/content_library_item_info.py
+++ b/plugins/modules/content_library_item_info.py
@@ -191,20 +191,21 @@ PAYLOAD_FORMAT = {
 from ansible.module_utils.basic import env_fallback
 import os
 
-try:
-    if not os.getenv("VMWARE_ENABLE_TURBO", False):
-        raise ImportError()
+if os.getenv("VMWARE_ENABLE_TURBO", False):
+    try:
+        from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
+            EmbeddedModuleFailure,
+        )
+        from ansible_collections.cloud.common.plugins.module_utils.turbo.module import (
+            AnsibleTurboModule as AnsibleModule,
+        )
 
-    from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
-        EmbeddedModuleFailure,
-    )
-    from ansible_collections.cloud.common.plugins.module_utils.turbo.module import (
-        AnsibleTurboModule as AnsibleModule,
-    )
-
-    AnsibleModule.collection_name = "vmware.vmware_rest"
-except ImportError:
+        AnsibleModule.collection_name = "vmware.vmware_rest"
+    except ImportError:
+        from ansible.module_utils.basic import AnsibleModule
+else:
     from ansible.module_utils.basic import AnsibleModule
+
 from ansible_collections.vmware.vmware_rest.plugins.module_utils.vmware_rest import (
     build_full_device_list,
     exists,

--- a/plugins/modules/content_library_item_info.py
+++ b/plugins/modules/content_library_item_info.py
@@ -189,8 +189,12 @@ PAYLOAD_FORMAT = {
 }  # pylint: disable=line-too-long
 
 from ansible.module_utils.basic import env_fallback
+import os
 
 try:
+    if not os.getenv('VMWARE_ENABLE_TURBO', False):
+        raise ImportError()
+
     from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
         EmbeddedModuleFailure,
     )

--- a/plugins/modules/content_library_item_info.py
+++ b/plugins/modules/content_library_item_info.py
@@ -192,7 +192,7 @@ from ansible.module_utils.basic import env_fallback
 import os
 
 try:
-    if not os.getenv('VMWARE_ENABLE_TURBO', False):
+    if not os.getenv("VMWARE_ENABLE_TURBO", False):
         raise ImportError()
 
     from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (

--- a/plugins/modules/content_library_subscriptions_info.py
+++ b/plugins/modules/content_library_subscriptions_info.py
@@ -100,8 +100,12 @@ PAYLOAD_FORMAT = {
 }  # pylint: disable=line-too-long
 
 from ansible.module_utils.basic import env_fallback
+import os
 
 try:
+    if not os.getenv('VMWARE_ENABLE_TURBO', False):
+        raise ImportError()
+
     from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
         EmbeddedModuleFailure,
     )

--- a/plugins/modules/content_library_subscriptions_info.py
+++ b/plugins/modules/content_library_subscriptions_info.py
@@ -103,7 +103,7 @@ from ansible.module_utils.basic import env_fallback
 import os
 
 try:
-    if not os.getenv('VMWARE_ENABLE_TURBO', False):
+    if not os.getenv("VMWARE_ENABLE_TURBO", False):
         raise ImportError()
 
     from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (

--- a/plugins/modules/content_library_subscriptions_info.py
+++ b/plugins/modules/content_library_subscriptions_info.py
@@ -102,20 +102,21 @@ PAYLOAD_FORMAT = {
 from ansible.module_utils.basic import env_fallback
 import os
 
-try:
-    if not os.getenv("VMWARE_ENABLE_TURBO", False):
-        raise ImportError()
+if os.getenv("VMWARE_ENABLE_TURBO", False):
+    try:
+        from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
+            EmbeddedModuleFailure,
+        )
+        from ansible_collections.cloud.common.plugins.module_utils.turbo.module import (
+            AnsibleTurboModule as AnsibleModule,
+        )
 
-    from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
-        EmbeddedModuleFailure,
-    )
-    from ansible_collections.cloud.common.plugins.module_utils.turbo.module import (
-        AnsibleTurboModule as AnsibleModule,
-    )
-
-    AnsibleModule.collection_name = "vmware.vmware_rest"
-except ImportError:
+        AnsibleModule.collection_name = "vmware.vmware_rest"
+    except ImportError:
+        from ansible.module_utils.basic import AnsibleModule
+else:
     from ansible.module_utils.basic import AnsibleModule
+
 from ansible_collections.vmware.vmware_rest.plugins.module_utils.vmware_rest import (
     build_full_device_list,
     exists,

--- a/plugins/modules/content_locallibrary.py
+++ b/plugins/modules/content_locallibrary.py
@@ -1492,7 +1492,7 @@ from ansible.module_utils.basic import env_fallback
 import os
 
 try:
-    if not os.getenv('VMWARE_ENABLE_TURBO', False):
+    if not os.getenv("VMWARE_ENABLE_TURBO", False):
         raise ImportError()
 
     from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (

--- a/plugins/modules/content_locallibrary.py
+++ b/plugins/modules/content_locallibrary.py
@@ -1491,20 +1491,21 @@ PAYLOAD_FORMAT = {
 from ansible.module_utils.basic import env_fallback
 import os
 
-try:
-    if not os.getenv("VMWARE_ENABLE_TURBO", False):
-        raise ImportError()
+if os.getenv("VMWARE_ENABLE_TURBO", False):
+    try:
+        from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
+            EmbeddedModuleFailure,
+        )
+        from ansible_collections.cloud.common.plugins.module_utils.turbo.module import (
+            AnsibleTurboModule as AnsibleModule,
+        )
 
-    from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
-        EmbeddedModuleFailure,
-    )
-    from ansible_collections.cloud.common.plugins.module_utils.turbo.module import (
-        AnsibleTurboModule as AnsibleModule,
-    )
-
-    AnsibleModule.collection_name = "vmware.vmware_rest"
-except ImportError:
+        AnsibleModule.collection_name = "vmware.vmware_rest"
+    except ImportError:
+        from ansible.module_utils.basic import AnsibleModule
+else:
     from ansible.module_utils.basic import AnsibleModule
+
 from ansible_collections.vmware.vmware_rest.plugins.module_utils.vmware_rest import (
     exists,
     gen_args,

--- a/plugins/modules/content_locallibrary.py
+++ b/plugins/modules/content_locallibrary.py
@@ -1489,8 +1489,12 @@ PAYLOAD_FORMAT = {
 }  # pylint: disable=line-too-long
 
 from ansible.module_utils.basic import env_fallback
+import os
 
 try:
+    if not os.getenv('VMWARE_ENABLE_TURBO', False):
+        raise ImportError()
+
     from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
         EmbeddedModuleFailure,
     )

--- a/plugins/modules/content_locallibrary_info.py
+++ b/plugins/modules/content_locallibrary_info.py
@@ -323,8 +323,12 @@ PAYLOAD_FORMAT = {
 }  # pylint: disable=line-too-long
 
 from ansible.module_utils.basic import env_fallback
+import os
 
 try:
+    if not os.getenv('VMWARE_ENABLE_TURBO', False):
+        raise ImportError()
+
     from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
         EmbeddedModuleFailure,
     )

--- a/plugins/modules/content_locallibrary_info.py
+++ b/plugins/modules/content_locallibrary_info.py
@@ -326,7 +326,7 @@ from ansible.module_utils.basic import env_fallback
 import os
 
 try:
-    if not os.getenv('VMWARE_ENABLE_TURBO', False):
+    if not os.getenv("VMWARE_ENABLE_TURBO", False):
         raise ImportError()
 
     from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (

--- a/plugins/modules/content_locallibrary_info.py
+++ b/plugins/modules/content_locallibrary_info.py
@@ -325,20 +325,21 @@ PAYLOAD_FORMAT = {
 from ansible.module_utils.basic import env_fallback
 import os
 
-try:
-    if not os.getenv("VMWARE_ENABLE_TURBO", False):
-        raise ImportError()
+if os.getenv("VMWARE_ENABLE_TURBO", False):
+    try:
+        from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
+            EmbeddedModuleFailure,
+        )
+        from ansible_collections.cloud.common.plugins.module_utils.turbo.module import (
+            AnsibleTurboModule as AnsibleModule,
+        )
 
-    from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
-        EmbeddedModuleFailure,
-    )
-    from ansible_collections.cloud.common.plugins.module_utils.turbo.module import (
-        AnsibleTurboModule as AnsibleModule,
-    )
-
-    AnsibleModule.collection_name = "vmware.vmware_rest"
-except ImportError:
+        AnsibleModule.collection_name = "vmware.vmware_rest"
+    except ImportError:
+        from ansible.module_utils.basic import AnsibleModule
+else:
     from ansible.module_utils.basic import AnsibleModule
+
 from ansible_collections.vmware.vmware_rest.plugins.module_utils.vmware_rest import (
     build_full_device_list,
     exists,

--- a/plugins/modules/content_subscribedlibrary.py
+++ b/plugins/modules/content_subscribedlibrary.py
@@ -690,20 +690,21 @@ PAYLOAD_FORMAT = {
 from ansible.module_utils.basic import env_fallback
 import os
 
-try:
-    if not os.getenv("VMWARE_ENABLE_TURBO", False):
-        raise ImportError()
+if os.getenv("VMWARE_ENABLE_TURBO", False):
+    try:
+        from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
+            EmbeddedModuleFailure,
+        )
+        from ansible_collections.cloud.common.plugins.module_utils.turbo.module import (
+            AnsibleTurboModule as AnsibleModule,
+        )
 
-    from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
-        EmbeddedModuleFailure,
-    )
-    from ansible_collections.cloud.common.plugins.module_utils.turbo.module import (
-        AnsibleTurboModule as AnsibleModule,
-    )
-
-    AnsibleModule.collection_name = "vmware.vmware_rest"
-except ImportError:
+        AnsibleModule.collection_name = "vmware.vmware_rest"
+    except ImportError:
+        from ansible.module_utils.basic import AnsibleModule
+else:
     from ansible.module_utils.basic import AnsibleModule
+
 from ansible_collections.vmware.vmware_rest.plugins.module_utils.vmware_rest import (
     exists,
     gen_args,

--- a/plugins/modules/content_subscribedlibrary.py
+++ b/plugins/modules/content_subscribedlibrary.py
@@ -688,8 +688,12 @@ PAYLOAD_FORMAT = {
 }  # pylint: disable=line-too-long
 
 from ansible.module_utils.basic import env_fallback
+import os
 
 try:
+    if not os.getenv('VMWARE_ENABLE_TURBO', False):
+        raise ImportError()
+
     from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
         EmbeddedModuleFailure,
     )

--- a/plugins/modules/content_subscribedlibrary.py
+++ b/plugins/modules/content_subscribedlibrary.py
@@ -691,7 +691,7 @@ from ansible.module_utils.basic import env_fallback
 import os
 
 try:
-    if not os.getenv('VMWARE_ENABLE_TURBO', False):
+    if not os.getenv("VMWARE_ENABLE_TURBO", False):
         raise ImportError()
 
     from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (

--- a/plugins/modules/content_subscribedlibrary_info.py
+++ b/plugins/modules/content_subscribedlibrary_info.py
@@ -115,20 +115,21 @@ PAYLOAD_FORMAT = {
 from ansible.module_utils.basic import env_fallback
 import os
 
-try:
-    if not os.getenv("VMWARE_ENABLE_TURBO", False):
-        raise ImportError()
+if os.getenv("VMWARE_ENABLE_TURBO", False):
+    try:
+        from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
+            EmbeddedModuleFailure,
+        )
+        from ansible_collections.cloud.common.plugins.module_utils.turbo.module import (
+            AnsibleTurboModule as AnsibleModule,
+        )
 
-    from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
-        EmbeddedModuleFailure,
-    )
-    from ansible_collections.cloud.common.plugins.module_utils.turbo.module import (
-        AnsibleTurboModule as AnsibleModule,
-    )
-
-    AnsibleModule.collection_name = "vmware.vmware_rest"
-except ImportError:
+        AnsibleModule.collection_name = "vmware.vmware_rest"
+    except ImportError:
+        from ansible.module_utils.basic import AnsibleModule
+else:
     from ansible.module_utils.basic import AnsibleModule
+
 from ansible_collections.vmware.vmware_rest.plugins.module_utils.vmware_rest import (
     build_full_device_list,
     exists,

--- a/plugins/modules/content_subscribedlibrary_info.py
+++ b/plugins/modules/content_subscribedlibrary_info.py
@@ -116,7 +116,7 @@ from ansible.module_utils.basic import env_fallback
 import os
 
 try:
-    if not os.getenv('VMWARE_ENABLE_TURBO', False):
+    if not os.getenv("VMWARE_ENABLE_TURBO", False):
         raise ImportError()
 
     from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (

--- a/plugins/modules/content_subscribedlibrary_info.py
+++ b/plugins/modules/content_subscribedlibrary_info.py
@@ -113,8 +113,12 @@ PAYLOAD_FORMAT = {
 }  # pylint: disable=line-too-long
 
 from ansible.module_utils.basic import env_fallback
+import os
 
 try:
+    if not os.getenv('VMWARE_ENABLE_TURBO', False):
+        raise ImportError()
+
     from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
         EmbeddedModuleFailure,
     )

--- a/plugins/modules/vcenter_cluster_info.py
+++ b/plugins/modules/vcenter_cluster_info.py
@@ -160,7 +160,7 @@ from ansible.module_utils.basic import env_fallback
 import os
 
 try:
-    if not os.getenv('VMWARE_ENABLE_TURBO', False):
+    if not os.getenv("VMWARE_ENABLE_TURBO", False):
         raise ImportError()
 
     from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (

--- a/plugins/modules/vcenter_cluster_info.py
+++ b/plugins/modules/vcenter_cluster_info.py
@@ -159,20 +159,21 @@ PAYLOAD_FORMAT = {
 from ansible.module_utils.basic import env_fallback
 import os
 
-try:
-    if not os.getenv("VMWARE_ENABLE_TURBO", False):
-        raise ImportError()
+if os.getenv("VMWARE_ENABLE_TURBO", False):
+    try:
+        from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
+            EmbeddedModuleFailure,
+        )
+        from ansible_collections.cloud.common.plugins.module_utils.turbo.module import (
+            AnsibleTurboModule as AnsibleModule,
+        )
 
-    from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
-        EmbeddedModuleFailure,
-    )
-    from ansible_collections.cloud.common.plugins.module_utils.turbo.module import (
-        AnsibleTurboModule as AnsibleModule,
-    )
-
-    AnsibleModule.collection_name = "vmware.vmware_rest"
-except ImportError:
+        AnsibleModule.collection_name = "vmware.vmware_rest"
+    except ImportError:
+        from ansible.module_utils.basic import AnsibleModule
+else:
     from ansible.module_utils.basic import AnsibleModule
+
 from ansible_collections.vmware.vmware_rest.plugins.module_utils.vmware_rest import (
     build_full_device_list,
     exists,

--- a/plugins/modules/vcenter_cluster_info.py
+++ b/plugins/modules/vcenter_cluster_info.py
@@ -157,8 +157,12 @@ PAYLOAD_FORMAT = {
 }  # pylint: disable=line-too-long
 
 from ansible.module_utils.basic import env_fallback
+import os
 
 try:
+    if not os.getenv('VMWARE_ENABLE_TURBO', False):
+        raise ImportError()
+
     from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
         EmbeddedModuleFailure,
     )

--- a/plugins/modules/vcenter_datacenter.py
+++ b/plugins/modules/vcenter_datacenter.py
@@ -169,8 +169,12 @@ PAYLOAD_FORMAT = {
 }  # pylint: disable=line-too-long
 
 from ansible.module_utils.basic import env_fallback
+import os
 
 try:
+    if not os.getenv('VMWARE_ENABLE_TURBO', False):
+        raise ImportError()
+
     from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
         EmbeddedModuleFailure,
     )

--- a/plugins/modules/vcenter_datacenter.py
+++ b/plugins/modules/vcenter_datacenter.py
@@ -172,7 +172,7 @@ from ansible.module_utils.basic import env_fallback
 import os
 
 try:
-    if not os.getenv('VMWARE_ENABLE_TURBO', False):
+    if not os.getenv("VMWARE_ENABLE_TURBO", False):
         raise ImportError()
 
     from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (

--- a/plugins/modules/vcenter_datacenter.py
+++ b/plugins/modules/vcenter_datacenter.py
@@ -171,20 +171,21 @@ PAYLOAD_FORMAT = {
 from ansible.module_utils.basic import env_fallback
 import os
 
-try:
-    if not os.getenv("VMWARE_ENABLE_TURBO", False):
-        raise ImportError()
+if os.getenv("VMWARE_ENABLE_TURBO", False):
+    try:
+        from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
+            EmbeddedModuleFailure,
+        )
+        from ansible_collections.cloud.common.plugins.module_utils.turbo.module import (
+            AnsibleTurboModule as AnsibleModule,
+        )
 
-    from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
-        EmbeddedModuleFailure,
-    )
-    from ansible_collections.cloud.common.plugins.module_utils.turbo.module import (
-        AnsibleTurboModule as AnsibleModule,
-    )
-
-    AnsibleModule.collection_name = "vmware.vmware_rest"
-except ImportError:
+        AnsibleModule.collection_name = "vmware.vmware_rest"
+    except ImportError:
+        from ansible.module_utils.basic import AnsibleModule
+else:
     from ansible.module_utils.basic import AnsibleModule
+
 from ansible_collections.vmware.vmware_rest.plugins.module_utils.vmware_rest import (
     exists,
     gen_args,

--- a/plugins/modules/vcenter_datacenter_info.py
+++ b/plugins/modules/vcenter_datacenter_info.py
@@ -138,7 +138,7 @@ from ansible.module_utils.basic import env_fallback
 import os
 
 try:
-    if not os.getenv('VMWARE_ENABLE_TURBO', False):
+    if not os.getenv("VMWARE_ENABLE_TURBO", False):
         raise ImportError()
 
     from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (

--- a/plugins/modules/vcenter_datacenter_info.py
+++ b/plugins/modules/vcenter_datacenter_info.py
@@ -135,8 +135,12 @@ PAYLOAD_FORMAT = {
 }  # pylint: disable=line-too-long
 
 from ansible.module_utils.basic import env_fallback
+import os
 
 try:
+    if not os.getenv('VMWARE_ENABLE_TURBO', False):
+        raise ImportError()
+
     from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
         EmbeddedModuleFailure,
     )

--- a/plugins/modules/vcenter_datacenter_info.py
+++ b/plugins/modules/vcenter_datacenter_info.py
@@ -137,20 +137,21 @@ PAYLOAD_FORMAT = {
 from ansible.module_utils.basic import env_fallback
 import os
 
-try:
-    if not os.getenv("VMWARE_ENABLE_TURBO", False):
-        raise ImportError()
+if os.getenv("VMWARE_ENABLE_TURBO", False):
+    try:
+        from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
+            EmbeddedModuleFailure,
+        )
+        from ansible_collections.cloud.common.plugins.module_utils.turbo.module import (
+            AnsibleTurboModule as AnsibleModule,
+        )
 
-    from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
-        EmbeddedModuleFailure,
-    )
-    from ansible_collections.cloud.common.plugins.module_utils.turbo.module import (
-        AnsibleTurboModule as AnsibleModule,
-    )
-
-    AnsibleModule.collection_name = "vmware.vmware_rest"
-except ImportError:
+        AnsibleModule.collection_name = "vmware.vmware_rest"
+    except ImportError:
+        from ansible.module_utils.basic import AnsibleModule
+else:
     from ansible.module_utils.basic import AnsibleModule
+
 from ansible_collections.vmware.vmware_rest.plugins.module_utils.vmware_rest import (
     build_full_device_list,
     exists,

--- a/plugins/modules/vcenter_datastore_info.py
+++ b/plugins/modules/vcenter_datastore_info.py
@@ -169,7 +169,7 @@ from ansible.module_utils.basic import env_fallback
 import os
 
 try:
-    if not os.getenv('VMWARE_ENABLE_TURBO', False):
+    if not os.getenv("VMWARE_ENABLE_TURBO", False):
         raise ImportError()
 
     from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (

--- a/plugins/modules/vcenter_datastore_info.py
+++ b/plugins/modules/vcenter_datastore_info.py
@@ -168,20 +168,21 @@ PAYLOAD_FORMAT = {
 from ansible.module_utils.basic import env_fallback
 import os
 
-try:
-    if not os.getenv("VMWARE_ENABLE_TURBO", False):
-        raise ImportError()
+if os.getenv("VMWARE_ENABLE_TURBO", False):
+    try:
+        from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
+            EmbeddedModuleFailure,
+        )
+        from ansible_collections.cloud.common.plugins.module_utils.turbo.module import (
+            AnsibleTurboModule as AnsibleModule,
+        )
 
-    from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
-        EmbeddedModuleFailure,
-    )
-    from ansible_collections.cloud.common.plugins.module_utils.turbo.module import (
-        AnsibleTurboModule as AnsibleModule,
-    )
-
-    AnsibleModule.collection_name = "vmware.vmware_rest"
-except ImportError:
+        AnsibleModule.collection_name = "vmware.vmware_rest"
+    except ImportError:
+        from ansible.module_utils.basic import AnsibleModule
+else:
     from ansible.module_utils.basic import AnsibleModule
+
 from ansible_collections.vmware.vmware_rest.plugins.module_utils.vmware_rest import (
     build_full_device_list,
     exists,

--- a/plugins/modules/vcenter_datastore_info.py
+++ b/plugins/modules/vcenter_datastore_info.py
@@ -166,8 +166,12 @@ PAYLOAD_FORMAT = {
 }  # pylint: disable=line-too-long
 
 from ansible.module_utils.basic import env_fallback
+import os
 
 try:
+    if not os.getenv('VMWARE_ENABLE_TURBO', False):
+        raise ImportError()
+
     from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
         EmbeddedModuleFailure,
     )

--- a/plugins/modules/vcenter_folder_info.py
+++ b/plugins/modules/vcenter_folder_info.py
@@ -165,7 +165,7 @@ from ansible.module_utils.basic import env_fallback
 import os
 
 try:
-    if not os.getenv('VMWARE_ENABLE_TURBO', False):
+    if not os.getenv("VMWARE_ENABLE_TURBO", False):
         raise ImportError()
 
     from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (

--- a/plugins/modules/vcenter_folder_info.py
+++ b/plugins/modules/vcenter_folder_info.py
@@ -162,8 +162,12 @@ PAYLOAD_FORMAT = {
 }  # pylint: disable=line-too-long
 
 from ansible.module_utils.basic import env_fallback
+import os
 
 try:
+    if not os.getenv('VMWARE_ENABLE_TURBO', False):
+        raise ImportError()
+
     from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
         EmbeddedModuleFailure,
     )

--- a/plugins/modules/vcenter_folder_info.py
+++ b/plugins/modules/vcenter_folder_info.py
@@ -164,20 +164,21 @@ PAYLOAD_FORMAT = {
 from ansible.module_utils.basic import env_fallback
 import os
 
-try:
-    if not os.getenv("VMWARE_ENABLE_TURBO", False):
-        raise ImportError()
+if os.getenv("VMWARE_ENABLE_TURBO", False):
+    try:
+        from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
+            EmbeddedModuleFailure,
+        )
+        from ansible_collections.cloud.common.plugins.module_utils.turbo.module import (
+            AnsibleTurboModule as AnsibleModule,
+        )
 
-    from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
-        EmbeddedModuleFailure,
-    )
-    from ansible_collections.cloud.common.plugins.module_utils.turbo.module import (
-        AnsibleTurboModule as AnsibleModule,
-    )
-
-    AnsibleModule.collection_name = "vmware.vmware_rest"
-except ImportError:
+        AnsibleModule.collection_name = "vmware.vmware_rest"
+    except ImportError:
+        from ansible.module_utils.basic import AnsibleModule
+else:
     from ansible.module_utils.basic import AnsibleModule
+
 from ansible_collections.vmware.vmware_rest.plugins.module_utils.vmware_rest import (
     gen_args,
     open_session,

--- a/plugins/modules/vcenter_host.py
+++ b/plugins/modules/vcenter_host.py
@@ -183,8 +183,12 @@ PAYLOAD_FORMAT = {
 }  # pylint: disable=line-too-long
 
 from ansible.module_utils.basic import env_fallback
+import os
 
 try:
+    if not os.getenv('VMWARE_ENABLE_TURBO', False):
+        raise ImportError()
+
     from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
         EmbeddedModuleFailure,
     )

--- a/plugins/modules/vcenter_host.py
+++ b/plugins/modules/vcenter_host.py
@@ -186,7 +186,7 @@ from ansible.module_utils.basic import env_fallback
 import os
 
 try:
-    if not os.getenv('VMWARE_ENABLE_TURBO', False):
+    if not os.getenv("VMWARE_ENABLE_TURBO", False):
         raise ImportError()
 
     from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (

--- a/plugins/modules/vcenter_host.py
+++ b/plugins/modules/vcenter_host.py
@@ -185,20 +185,21 @@ PAYLOAD_FORMAT = {
 from ansible.module_utils.basic import env_fallback
 import os
 
-try:
-    if not os.getenv("VMWARE_ENABLE_TURBO", False):
-        raise ImportError()
+if os.getenv("VMWARE_ENABLE_TURBO", False):
+    try:
+        from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
+            EmbeddedModuleFailure,
+        )
+        from ansible_collections.cloud.common.plugins.module_utils.turbo.module import (
+            AnsibleTurboModule as AnsibleModule,
+        )
 
-    from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
-        EmbeddedModuleFailure,
-    )
-    from ansible_collections.cloud.common.plugins.module_utils.turbo.module import (
-        AnsibleTurboModule as AnsibleModule,
-    )
-
-    AnsibleModule.collection_name = "vmware.vmware_rest"
-except ImportError:
+        AnsibleModule.collection_name = "vmware.vmware_rest"
+    except ImportError:
+        from ansible.module_utils.basic import AnsibleModule
+else:
     from ansible.module_utils.basic import AnsibleModule
+
 from ansible_collections.vmware.vmware_rest.plugins.module_utils.vmware_rest import (
     exists,
     gen_args,

--- a/plugins/modules/vcenter_host_info.py
+++ b/plugins/modules/vcenter_host_info.py
@@ -168,8 +168,12 @@ PAYLOAD_FORMAT = {
 }  # pylint: disable=line-too-long
 
 from ansible.module_utils.basic import env_fallback
+import os
 
 try:
+    if not os.getenv('VMWARE_ENABLE_TURBO', False):
+        raise ImportError()
+
     from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
         EmbeddedModuleFailure,
     )

--- a/plugins/modules/vcenter_host_info.py
+++ b/plugins/modules/vcenter_host_info.py
@@ -171,7 +171,7 @@ from ansible.module_utils.basic import env_fallback
 import os
 
 try:
-    if not os.getenv('VMWARE_ENABLE_TURBO', False):
+    if not os.getenv("VMWARE_ENABLE_TURBO", False):
         raise ImportError()
 
     from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (

--- a/plugins/modules/vcenter_host_info.py
+++ b/plugins/modules/vcenter_host_info.py
@@ -170,20 +170,21 @@ PAYLOAD_FORMAT = {
 from ansible.module_utils.basic import env_fallback
 import os
 
-try:
-    if not os.getenv("VMWARE_ENABLE_TURBO", False):
-        raise ImportError()
+if os.getenv("VMWARE_ENABLE_TURBO", False):
+    try:
+        from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
+            EmbeddedModuleFailure,
+        )
+        from ansible_collections.cloud.common.plugins.module_utils.turbo.module import (
+            AnsibleTurboModule as AnsibleModule,
+        )
 
-    from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
-        EmbeddedModuleFailure,
-    )
-    from ansible_collections.cloud.common.plugins.module_utils.turbo.module import (
-        AnsibleTurboModule as AnsibleModule,
-    )
-
-    AnsibleModule.collection_name = "vmware.vmware_rest"
-except ImportError:
+        AnsibleModule.collection_name = "vmware.vmware_rest"
+    except ImportError:
+        from ansible.module_utils.basic import AnsibleModule
+else:
     from ansible.module_utils.basic import AnsibleModule
+
 from ansible_collections.vmware.vmware_rest.plugins.module_utils.vmware_rest import (
     build_full_device_list,
     exists,

--- a/plugins/modules/vcenter_network_info.py
+++ b/plugins/modules/vcenter_network_info.py
@@ -159,8 +159,12 @@ PAYLOAD_FORMAT = {
 }  # pylint: disable=line-too-long
 
 from ansible.module_utils.basic import env_fallback
+import os
 
 try:
+    if not os.getenv('VMWARE_ENABLE_TURBO', False):
+        raise ImportError()
+
     from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
         EmbeddedModuleFailure,
     )

--- a/plugins/modules/vcenter_network_info.py
+++ b/plugins/modules/vcenter_network_info.py
@@ -162,7 +162,7 @@ from ansible.module_utils.basic import env_fallback
 import os
 
 try:
-    if not os.getenv('VMWARE_ENABLE_TURBO', False):
+    if not os.getenv("VMWARE_ENABLE_TURBO", False):
         raise ImportError()
 
     from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (

--- a/plugins/modules/vcenter_network_info.py
+++ b/plugins/modules/vcenter_network_info.py
@@ -161,20 +161,21 @@ PAYLOAD_FORMAT = {
 from ansible.module_utils.basic import env_fallback
 import os
 
-try:
-    if not os.getenv("VMWARE_ENABLE_TURBO", False):
-        raise ImportError()
+if os.getenv("VMWARE_ENABLE_TURBO", False):
+    try:
+        from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
+            EmbeddedModuleFailure,
+        )
+        from ansible_collections.cloud.common.plugins.module_utils.turbo.module import (
+            AnsibleTurboModule as AnsibleModule,
+        )
 
-    from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
-        EmbeddedModuleFailure,
-    )
-    from ansible_collections.cloud.common.plugins.module_utils.turbo.module import (
-        AnsibleTurboModule as AnsibleModule,
-    )
-
-    AnsibleModule.collection_name = "vmware.vmware_rest"
-except ImportError:
+        AnsibleModule.collection_name = "vmware.vmware_rest"
+    except ImportError:
+        from ansible.module_utils.basic import AnsibleModule
+else:
     from ansible.module_utils.basic import AnsibleModule
+
 from ansible_collections.vmware.vmware_rest.plugins.module_utils.vmware_rest import (
     gen_args,
     open_session,

--- a/plugins/modules/vcenter_ovf_libraryitem.py
+++ b/plugins/modules/vcenter_ovf_libraryitem.py
@@ -379,7 +379,7 @@ from ansible.module_utils.basic import env_fallback
 import os
 
 try:
-    if not os.getenv('VMWARE_ENABLE_TURBO', False):
+    if not os.getenv("VMWARE_ENABLE_TURBO", False):
         raise ImportError()
 
     from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (

--- a/plugins/modules/vcenter_ovf_libraryitem.py
+++ b/plugins/modules/vcenter_ovf_libraryitem.py
@@ -378,20 +378,21 @@ PAYLOAD_FORMAT = {
 from ansible.module_utils.basic import env_fallback
 import os
 
-try:
-    if not os.getenv("VMWARE_ENABLE_TURBO", False):
-        raise ImportError()
+if os.getenv("VMWARE_ENABLE_TURBO", False):
+    try:
+        from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
+            EmbeddedModuleFailure,
+        )
+        from ansible_collections.cloud.common.plugins.module_utils.turbo.module import (
+            AnsibleTurboModule as AnsibleModule,
+        )
 
-    from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
-        EmbeddedModuleFailure,
-    )
-    from ansible_collections.cloud.common.plugins.module_utils.turbo.module import (
-        AnsibleTurboModule as AnsibleModule,
-    )
-
-    AnsibleModule.collection_name = "vmware.vmware_rest"
-except ImportError:
+        AnsibleModule.collection_name = "vmware.vmware_rest"
+    except ImportError:
+        from ansible.module_utils.basic import AnsibleModule
+else:
     from ansible.module_utils.basic import AnsibleModule
+
 from ansible_collections.vmware.vmware_rest.plugins.module_utils.vmware_rest import (
     exists,
     gen_args,

--- a/plugins/modules/vcenter_ovf_libraryitem.py
+++ b/plugins/modules/vcenter_ovf_libraryitem.py
@@ -376,8 +376,12 @@ PAYLOAD_FORMAT = {
 }  # pylint: disable=line-too-long
 
 from ansible.module_utils.basic import env_fallback
+import os
 
 try:
+    if not os.getenv('VMWARE_ENABLE_TURBO', False):
+        raise ImportError()
+
     from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
         EmbeddedModuleFailure,
     )

--- a/plugins/modules/vcenter_resourcepool.py
+++ b/plugins/modules/vcenter_resourcepool.py
@@ -274,8 +274,12 @@ PAYLOAD_FORMAT = {
 }  # pylint: disable=line-too-long
 
 from ansible.module_utils.basic import env_fallback
+import os
 
 try:
+    if not os.getenv('VMWARE_ENABLE_TURBO', False):
+        raise ImportError()
+
     from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
         EmbeddedModuleFailure,
     )

--- a/plugins/modules/vcenter_resourcepool.py
+++ b/plugins/modules/vcenter_resourcepool.py
@@ -277,7 +277,7 @@ from ansible.module_utils.basic import env_fallback
 import os
 
 try:
-    if not os.getenv('VMWARE_ENABLE_TURBO', False):
+    if not os.getenv("VMWARE_ENABLE_TURBO", False):
         raise ImportError()
 
     from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (

--- a/plugins/modules/vcenter_resourcepool.py
+++ b/plugins/modules/vcenter_resourcepool.py
@@ -276,20 +276,21 @@ PAYLOAD_FORMAT = {
 from ansible.module_utils.basic import env_fallback
 import os
 
-try:
-    if not os.getenv("VMWARE_ENABLE_TURBO", False):
-        raise ImportError()
+if os.getenv("VMWARE_ENABLE_TURBO", False):
+    try:
+        from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
+            EmbeddedModuleFailure,
+        )
+        from ansible_collections.cloud.common.plugins.module_utils.turbo.module import (
+            AnsibleTurboModule as AnsibleModule,
+        )
 
-    from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
-        EmbeddedModuleFailure,
-    )
-    from ansible_collections.cloud.common.plugins.module_utils.turbo.module import (
-        AnsibleTurboModule as AnsibleModule,
-    )
-
-    AnsibleModule.collection_name = "vmware.vmware_rest"
-except ImportError:
+        AnsibleModule.collection_name = "vmware.vmware_rest"
+    except ImportError:
+        from ansible.module_utils.basic import AnsibleModule
+else:
     from ansible.module_utils.basic import AnsibleModule
+
 from ansible_collections.vmware.vmware_rest.plugins.module_utils.vmware_rest import (
     exists,
     gen_args,

--- a/plugins/modules/vcenter_resourcepool_info.py
+++ b/plugins/modules/vcenter_resourcepool_info.py
@@ -196,7 +196,7 @@ from ansible.module_utils.basic import env_fallback
 import os
 
 try:
-    if not os.getenv('VMWARE_ENABLE_TURBO', False):
+    if not os.getenv("VMWARE_ENABLE_TURBO", False):
         raise ImportError()
 
     from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (

--- a/plugins/modules/vcenter_resourcepool_info.py
+++ b/plugins/modules/vcenter_resourcepool_info.py
@@ -193,8 +193,12 @@ PAYLOAD_FORMAT = {
 }  # pylint: disable=line-too-long
 
 from ansible.module_utils.basic import env_fallback
+import os
 
 try:
+    if not os.getenv('VMWARE_ENABLE_TURBO', False):
+        raise ImportError()
+
     from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
         EmbeddedModuleFailure,
     )

--- a/plugins/modules/vcenter_resourcepool_info.py
+++ b/plugins/modules/vcenter_resourcepool_info.py
@@ -195,20 +195,21 @@ PAYLOAD_FORMAT = {
 from ansible.module_utils.basic import env_fallback
 import os
 
-try:
-    if not os.getenv("VMWARE_ENABLE_TURBO", False):
-        raise ImportError()
+if os.getenv("VMWARE_ENABLE_TURBO", False):
+    try:
+        from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
+            EmbeddedModuleFailure,
+        )
+        from ansible_collections.cloud.common.plugins.module_utils.turbo.module import (
+            AnsibleTurboModule as AnsibleModule,
+        )
 
-    from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
-        EmbeddedModuleFailure,
-    )
-    from ansible_collections.cloud.common.plugins.module_utils.turbo.module import (
-        AnsibleTurboModule as AnsibleModule,
-    )
-
-    AnsibleModule.collection_name = "vmware.vmware_rest"
-except ImportError:
+        AnsibleModule.collection_name = "vmware.vmware_rest"
+    except ImportError:
+        from ansible.module_utils.basic import AnsibleModule
+else:
     from ansible.module_utils.basic import AnsibleModule
+
 from ansible_collections.vmware.vmware_rest.plugins.module_utils.vmware_rest import (
     build_full_device_list,
     exists,

--- a/plugins/modules/vcenter_storage_policies_info.py
+++ b/plugins/modules/vcenter_storage_policies_info.py
@@ -138,20 +138,21 @@ PAYLOAD_FORMAT = {
 from ansible.module_utils.basic import env_fallback
 import os
 
-try:
-    if not os.getenv("VMWARE_ENABLE_TURBO", False):
-        raise ImportError()
+if os.getenv("VMWARE_ENABLE_TURBO", False):
+    try:
+        from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
+            EmbeddedModuleFailure,
+        )
+        from ansible_collections.cloud.common.plugins.module_utils.turbo.module import (
+            AnsibleTurboModule as AnsibleModule,
+        )
 
-    from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
-        EmbeddedModuleFailure,
-    )
-    from ansible_collections.cloud.common.plugins.module_utils.turbo.module import (
-        AnsibleTurboModule as AnsibleModule,
-    )
-
-    AnsibleModule.collection_name = "vmware.vmware_rest"
-except ImportError:
+        AnsibleModule.collection_name = "vmware.vmware_rest"
+    except ImportError:
+        from ansible.module_utils.basic import AnsibleModule
+else:
     from ansible.module_utils.basic import AnsibleModule
+
 from ansible_collections.vmware.vmware_rest.plugins.module_utils.vmware_rest import (
     gen_args,
     open_session,

--- a/plugins/modules/vcenter_storage_policies_info.py
+++ b/plugins/modules/vcenter_storage_policies_info.py
@@ -136,8 +136,12 @@ PAYLOAD_FORMAT = {
 }  # pylint: disable=line-too-long
 
 from ansible.module_utils.basic import env_fallback
+import os
 
 try:
+    if not os.getenv('VMWARE_ENABLE_TURBO', False):
+        raise ImportError()
+
     from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
         EmbeddedModuleFailure,
     )

--- a/plugins/modules/vcenter_storage_policies_info.py
+++ b/plugins/modules/vcenter_storage_policies_info.py
@@ -139,7 +139,7 @@ from ansible.module_utils.basic import env_fallback
 import os
 
 try:
-    if not os.getenv('VMWARE_ENABLE_TURBO', False):
+    if not os.getenv("VMWARE_ENABLE_TURBO", False):
         raise ImportError()
 
     from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (

--- a/plugins/modules/vcenter_vm.py
+++ b/plugins/modules/vcenter_vm.py
@@ -1339,8 +1339,12 @@ PAYLOAD_FORMAT = {
 }  # pylint: disable=line-too-long
 
 from ansible.module_utils.basic import env_fallback
+import os
 
 try:
+    if not os.getenv('VMWARE_ENABLE_TURBO', False):
+        raise ImportError()
+
     from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
         EmbeddedModuleFailure,
     )

--- a/plugins/modules/vcenter_vm.py
+++ b/plugins/modules/vcenter_vm.py
@@ -1341,20 +1341,21 @@ PAYLOAD_FORMAT = {
 from ansible.module_utils.basic import env_fallback
 import os
 
-try:
-    if not os.getenv("VMWARE_ENABLE_TURBO", False):
-        raise ImportError()
+if os.getenv("VMWARE_ENABLE_TURBO", False):
+    try:
+        from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
+            EmbeddedModuleFailure,
+        )
+        from ansible_collections.cloud.common.plugins.module_utils.turbo.module import (
+            AnsibleTurboModule as AnsibleModule,
+        )
 
-    from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
-        EmbeddedModuleFailure,
-    )
-    from ansible_collections.cloud.common.plugins.module_utils.turbo.module import (
-        AnsibleTurboModule as AnsibleModule,
-    )
-
-    AnsibleModule.collection_name = "vmware.vmware_rest"
-except ImportError:
+        AnsibleModule.collection_name = "vmware.vmware_rest"
+    except ImportError:
+        from ansible.module_utils.basic import AnsibleModule
+else:
     from ansible.module_utils.basic import AnsibleModule
+
 from ansible_collections.vmware.vmware_rest.plugins.module_utils.vmware_rest import (
     exists,
     gen_args,

--- a/plugins/modules/vcenter_vm.py
+++ b/plugins/modules/vcenter_vm.py
@@ -1342,7 +1342,7 @@ from ansible.module_utils.basic import env_fallback
 import os
 
 try:
-    if not os.getenv('VMWARE_ENABLE_TURBO', False):
+    if not os.getenv("VMWARE_ENABLE_TURBO", False):
         raise ImportError()
 
     from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (

--- a/plugins/modules/vcenter_vm_guest_customization.py
+++ b/plugins/modules/vcenter_vm_guest_customization.py
@@ -461,20 +461,21 @@ PAYLOAD_FORMAT = {
 from ansible.module_utils.basic import env_fallback
 import os
 
-try:
-    if not os.getenv("VMWARE_ENABLE_TURBO", False):
-        raise ImportError()
+if os.getenv("VMWARE_ENABLE_TURBO", False):
+    try:
+        from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
+            EmbeddedModuleFailure,
+        )
+        from ansible_collections.cloud.common.plugins.module_utils.turbo.module import (
+            AnsibleTurboModule as AnsibleModule,
+        )
 
-    from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
-        EmbeddedModuleFailure,
-    )
-    from ansible_collections.cloud.common.plugins.module_utils.turbo.module import (
-        AnsibleTurboModule as AnsibleModule,
-    )
-
-    AnsibleModule.collection_name = "vmware.vmware_rest"
-except ImportError:
+        AnsibleModule.collection_name = "vmware.vmware_rest"
+    except ImportError:
+        from ansible.module_utils.basic import AnsibleModule
+else:
     from ansible.module_utils.basic import AnsibleModule
+
 from ansible_collections.vmware.vmware_rest.plugins.module_utils.vmware_rest import (
     exists,
     gen_args,

--- a/plugins/modules/vcenter_vm_guest_customization.py
+++ b/plugins/modules/vcenter_vm_guest_customization.py
@@ -459,8 +459,12 @@ PAYLOAD_FORMAT = {
 }  # pylint: disable=line-too-long
 
 from ansible.module_utils.basic import env_fallback
+import os
 
 try:
+    if not os.getenv('VMWARE_ENABLE_TURBO', False):
+        raise ImportError()
+
     from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
         EmbeddedModuleFailure,
     )

--- a/plugins/modules/vcenter_vm_guest_customization.py
+++ b/plugins/modules/vcenter_vm_guest_customization.py
@@ -462,7 +462,7 @@ from ansible.module_utils.basic import env_fallback
 import os
 
 try:
-    if not os.getenv('VMWARE_ENABLE_TURBO', False):
+    if not os.getenv("VMWARE_ENABLE_TURBO", False):
         raise ImportError()
 
     from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (

--- a/plugins/modules/vcenter_vm_guest_filesystem_directories.py
+++ b/plugins/modules/vcenter_vm_guest_filesystem_directories.py
@@ -241,20 +241,21 @@ PAYLOAD_FORMAT = {
 from ansible.module_utils.basic import env_fallback
 import os
 
-try:
-    if not os.getenv("VMWARE_ENABLE_TURBO", False):
-        raise ImportError()
+if os.getenv("VMWARE_ENABLE_TURBO", False):
+    try:
+        from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
+            EmbeddedModuleFailure,
+        )
+        from ansible_collections.cloud.common.plugins.module_utils.turbo.module import (
+            AnsibleTurboModule as AnsibleModule,
+        )
 
-    from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
-        EmbeddedModuleFailure,
-    )
-    from ansible_collections.cloud.common.plugins.module_utils.turbo.module import (
-        AnsibleTurboModule as AnsibleModule,
-    )
-
-    AnsibleModule.collection_name = "vmware.vmware_rest"
-except ImportError:
+        AnsibleModule.collection_name = "vmware.vmware_rest"
+    except ImportError:
+        from ansible.module_utils.basic import AnsibleModule
+else:
     from ansible.module_utils.basic import AnsibleModule
+
 from ansible_collections.vmware.vmware_rest.plugins.module_utils.vmware_rest import (
     exists,
     gen_args,

--- a/plugins/modules/vcenter_vm_guest_filesystem_directories.py
+++ b/plugins/modules/vcenter_vm_guest_filesystem_directories.py
@@ -239,8 +239,12 @@ PAYLOAD_FORMAT = {
 }  # pylint: disable=line-too-long
 
 from ansible.module_utils.basic import env_fallback
+import os
 
 try:
+    if not os.getenv('VMWARE_ENABLE_TURBO', False):
+        raise ImportError()
+
     from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
         EmbeddedModuleFailure,
     )

--- a/plugins/modules/vcenter_vm_guest_filesystem_directories.py
+++ b/plugins/modules/vcenter_vm_guest_filesystem_directories.py
@@ -242,7 +242,7 @@ from ansible.module_utils.basic import env_fallback
 import os
 
 try:
-    if not os.getenv('VMWARE_ENABLE_TURBO', False):
+    if not os.getenv("VMWARE_ENABLE_TURBO", False):
         raise ImportError()
 
     from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (

--- a/plugins/modules/vcenter_vm_guest_identity_info.py
+++ b/plugins/modules/vcenter_vm_guest_identity_info.py
@@ -117,7 +117,7 @@ from ansible.module_utils.basic import env_fallback
 import os
 
 try:
-    if not os.getenv('VMWARE_ENABLE_TURBO', False):
+    if not os.getenv("VMWARE_ENABLE_TURBO", False):
         raise ImportError()
 
     from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (

--- a/plugins/modules/vcenter_vm_guest_identity_info.py
+++ b/plugins/modules/vcenter_vm_guest_identity_info.py
@@ -116,20 +116,21 @@ PAYLOAD_FORMAT = {
 from ansible.module_utils.basic import env_fallback
 import os
 
-try:
-    if not os.getenv("VMWARE_ENABLE_TURBO", False):
-        raise ImportError()
+if os.getenv("VMWARE_ENABLE_TURBO", False):
+    try:
+        from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
+            EmbeddedModuleFailure,
+        )
+        from ansible_collections.cloud.common.plugins.module_utils.turbo.module import (
+            AnsibleTurboModule as AnsibleModule,
+        )
 
-    from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
-        EmbeddedModuleFailure,
-    )
-    from ansible_collections.cloud.common.plugins.module_utils.turbo.module import (
-        AnsibleTurboModule as AnsibleModule,
-    )
-
-    AnsibleModule.collection_name = "vmware.vmware_rest"
-except ImportError:
+        AnsibleModule.collection_name = "vmware.vmware_rest"
+    except ImportError:
+        from ansible.module_utils.basic import AnsibleModule
+else:
     from ansible.module_utils.basic import AnsibleModule
+
 from ansible_collections.vmware.vmware_rest.plugins.module_utils.vmware_rest import (
     gen_args,
     open_session,

--- a/plugins/modules/vcenter_vm_guest_identity_info.py
+++ b/plugins/modules/vcenter_vm_guest_identity_info.py
@@ -114,8 +114,12 @@ PAYLOAD_FORMAT = {
 }  # pylint: disable=line-too-long
 
 from ansible.module_utils.basic import env_fallback
+import os
 
 try:
+    if not os.getenv('VMWARE_ENABLE_TURBO', False):
+        raise ImportError()
+
     from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
         EmbeddedModuleFailure,
     )

--- a/plugins/modules/vcenter_vm_guest_localfilesystem_info.py
+++ b/plugins/modules/vcenter_vm_guest_localfilesystem_info.py
@@ -119,7 +119,7 @@ from ansible.module_utils.basic import env_fallback
 import os
 
 try:
-    if not os.getenv('VMWARE_ENABLE_TURBO', False):
+    if not os.getenv("VMWARE_ENABLE_TURBO", False):
         raise ImportError()
 
     from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (

--- a/plugins/modules/vcenter_vm_guest_localfilesystem_info.py
+++ b/plugins/modules/vcenter_vm_guest_localfilesystem_info.py
@@ -118,20 +118,21 @@ PAYLOAD_FORMAT = {
 from ansible.module_utils.basic import env_fallback
 import os
 
-try:
-    if not os.getenv("VMWARE_ENABLE_TURBO", False):
-        raise ImportError()
+if os.getenv("VMWARE_ENABLE_TURBO", False):
+    try:
+        from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
+            EmbeddedModuleFailure,
+        )
+        from ansible_collections.cloud.common.plugins.module_utils.turbo.module import (
+            AnsibleTurboModule as AnsibleModule,
+        )
 
-    from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
-        EmbeddedModuleFailure,
-    )
-    from ansible_collections.cloud.common.plugins.module_utils.turbo.module import (
-        AnsibleTurboModule as AnsibleModule,
-    )
-
-    AnsibleModule.collection_name = "vmware.vmware_rest"
-except ImportError:
+        AnsibleModule.collection_name = "vmware.vmware_rest"
+    except ImportError:
+        from ansible.module_utils.basic import AnsibleModule
+else:
     from ansible.module_utils.basic import AnsibleModule
+
 from ansible_collections.vmware.vmware_rest.plugins.module_utils.vmware_rest import (
     gen_args,
     open_session,

--- a/plugins/modules/vcenter_vm_guest_localfilesystem_info.py
+++ b/plugins/modules/vcenter_vm_guest_localfilesystem_info.py
@@ -116,8 +116,12 @@ PAYLOAD_FORMAT = {
 }  # pylint: disable=line-too-long
 
 from ansible.module_utils.basic import env_fallback
+import os
 
 try:
+    if not os.getenv('VMWARE_ENABLE_TURBO', False):
+        raise ImportError()
+
     from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
         EmbeddedModuleFailure,
     )

--- a/plugins/modules/vcenter_vm_guest_networking_info.py
+++ b/plugins/modules/vcenter_vm_guest_networking_info.py
@@ -117,8 +117,12 @@ PAYLOAD_FORMAT = {
 }  # pylint: disable=line-too-long
 
 from ansible.module_utils.basic import env_fallback
+import os
 
 try:
+    if not os.getenv('VMWARE_ENABLE_TURBO', False):
+        raise ImportError()
+
     from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
         EmbeddedModuleFailure,
     )

--- a/plugins/modules/vcenter_vm_guest_networking_info.py
+++ b/plugins/modules/vcenter_vm_guest_networking_info.py
@@ -119,20 +119,21 @@ PAYLOAD_FORMAT = {
 from ansible.module_utils.basic import env_fallback
 import os
 
-try:
-    if not os.getenv("VMWARE_ENABLE_TURBO", False):
-        raise ImportError()
+if os.getenv("VMWARE_ENABLE_TURBO", False):
+    try:
+        from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
+            EmbeddedModuleFailure,
+        )
+        from ansible_collections.cloud.common.plugins.module_utils.turbo.module import (
+            AnsibleTurboModule as AnsibleModule,
+        )
 
-    from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
-        EmbeddedModuleFailure,
-    )
-    from ansible_collections.cloud.common.plugins.module_utils.turbo.module import (
-        AnsibleTurboModule as AnsibleModule,
-    )
-
-    AnsibleModule.collection_name = "vmware.vmware_rest"
-except ImportError:
+        AnsibleModule.collection_name = "vmware.vmware_rest"
+    except ImportError:
+        from ansible.module_utils.basic import AnsibleModule
+else:
     from ansible.module_utils.basic import AnsibleModule
+
 from ansible_collections.vmware.vmware_rest.plugins.module_utils.vmware_rest import (
     gen_args,
     open_session,

--- a/plugins/modules/vcenter_vm_guest_networking_info.py
+++ b/plugins/modules/vcenter_vm_guest_networking_info.py
@@ -120,7 +120,7 @@ from ansible.module_utils.basic import env_fallback
 import os
 
 try:
-    if not os.getenv('VMWARE_ENABLE_TURBO', False):
+    if not os.getenv("VMWARE_ENABLE_TURBO", False):
         raise ImportError()
 
     from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (

--- a/plugins/modules/vcenter_vm_guest_networking_interfaces_info.py
+++ b/plugins/modules/vcenter_vm_guest_networking_interfaces_info.py
@@ -117,8 +117,12 @@ PAYLOAD_FORMAT = {
 }  # pylint: disable=line-too-long
 
 from ansible.module_utils.basic import env_fallback
+import os
 
 try:
+    if not os.getenv('VMWARE_ENABLE_TURBO', False):
+        raise ImportError()
+
     from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
         EmbeddedModuleFailure,
     )

--- a/plugins/modules/vcenter_vm_guest_networking_interfaces_info.py
+++ b/plugins/modules/vcenter_vm_guest_networking_interfaces_info.py
@@ -119,20 +119,21 @@ PAYLOAD_FORMAT = {
 from ansible.module_utils.basic import env_fallback
 import os
 
-try:
-    if not os.getenv("VMWARE_ENABLE_TURBO", False):
-        raise ImportError()
+if os.getenv("VMWARE_ENABLE_TURBO", False):
+    try:
+        from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
+            EmbeddedModuleFailure,
+        )
+        from ansible_collections.cloud.common.plugins.module_utils.turbo.module import (
+            AnsibleTurboModule as AnsibleModule,
+        )
 
-    from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
-        EmbeddedModuleFailure,
-    )
-    from ansible_collections.cloud.common.plugins.module_utils.turbo.module import (
-        AnsibleTurboModule as AnsibleModule,
-    )
-
-    AnsibleModule.collection_name = "vmware.vmware_rest"
-except ImportError:
+        AnsibleModule.collection_name = "vmware.vmware_rest"
+    except ImportError:
+        from ansible.module_utils.basic import AnsibleModule
+else:
     from ansible.module_utils.basic import AnsibleModule
+
 from ansible_collections.vmware.vmware_rest.plugins.module_utils.vmware_rest import (
     gen_args,
     open_session,

--- a/plugins/modules/vcenter_vm_guest_networking_interfaces_info.py
+++ b/plugins/modules/vcenter_vm_guest_networking_interfaces_info.py
@@ -120,7 +120,7 @@ from ansible.module_utils.basic import env_fallback
 import os
 
 try:
-    if not os.getenv('VMWARE_ENABLE_TURBO', False):
+    if not os.getenv("VMWARE_ENABLE_TURBO", False):
         raise ImportError()
 
     from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (

--- a/plugins/modules/vcenter_vm_guest_networking_routes_info.py
+++ b/plugins/modules/vcenter_vm_guest_networking_routes_info.py
@@ -108,8 +108,12 @@ PAYLOAD_FORMAT = {
 }  # pylint: disable=line-too-long
 
 from ansible.module_utils.basic import env_fallback
+import os
 
 try:
+    if not os.getenv('VMWARE_ENABLE_TURBO', False):
+        raise ImportError()
+
     from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
         EmbeddedModuleFailure,
     )

--- a/plugins/modules/vcenter_vm_guest_networking_routes_info.py
+++ b/plugins/modules/vcenter_vm_guest_networking_routes_info.py
@@ -111,7 +111,7 @@ from ansible.module_utils.basic import env_fallback
 import os
 
 try:
-    if not os.getenv('VMWARE_ENABLE_TURBO', False):
+    if not os.getenv("VMWARE_ENABLE_TURBO", False):
         raise ImportError()
 
     from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (

--- a/plugins/modules/vcenter_vm_guest_networking_routes_info.py
+++ b/plugins/modules/vcenter_vm_guest_networking_routes_info.py
@@ -110,20 +110,21 @@ PAYLOAD_FORMAT = {
 from ansible.module_utils.basic import env_fallback
 import os
 
-try:
-    if not os.getenv("VMWARE_ENABLE_TURBO", False):
-        raise ImportError()
+if os.getenv("VMWARE_ENABLE_TURBO", False):
+    try:
+        from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
+            EmbeddedModuleFailure,
+        )
+        from ansible_collections.cloud.common.plugins.module_utils.turbo.module import (
+            AnsibleTurboModule as AnsibleModule,
+        )
 
-    from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
-        EmbeddedModuleFailure,
-    )
-    from ansible_collections.cloud.common.plugins.module_utils.turbo.module import (
-        AnsibleTurboModule as AnsibleModule,
-    )
-
-    AnsibleModule.collection_name = "vmware.vmware_rest"
-except ImportError:
+        AnsibleModule.collection_name = "vmware.vmware_rest"
+    except ImportError:
+        from ansible.module_utils.basic import AnsibleModule
+else:
     from ansible.module_utils.basic import AnsibleModule
+
 from ansible_collections.vmware.vmware_rest.plugins.module_utils.vmware_rest import (
     gen_args,
     open_session,

--- a/plugins/modules/vcenter_vm_guest_operations_info.py
+++ b/plugins/modules/vcenter_vm_guest_operations_info.py
@@ -88,20 +88,21 @@ PAYLOAD_FORMAT = {
 from ansible.module_utils.basic import env_fallback
 import os
 
-try:
-    if not os.getenv("VMWARE_ENABLE_TURBO", False):
-        raise ImportError()
+if os.getenv("VMWARE_ENABLE_TURBO", False):
+    try:
+        from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
+            EmbeddedModuleFailure,
+        )
+        from ansible_collections.cloud.common.plugins.module_utils.turbo.module import (
+            AnsibleTurboModule as AnsibleModule,
+        )
 
-    from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
-        EmbeddedModuleFailure,
-    )
-    from ansible_collections.cloud.common.plugins.module_utils.turbo.module import (
-        AnsibleTurboModule as AnsibleModule,
-    )
-
-    AnsibleModule.collection_name = "vmware.vmware_rest"
-except ImportError:
+        AnsibleModule.collection_name = "vmware.vmware_rest"
+    except ImportError:
+        from ansible.module_utils.basic import AnsibleModule
+else:
     from ansible.module_utils.basic import AnsibleModule
+
 from ansible_collections.vmware.vmware_rest.plugins.module_utils.vmware_rest import (
     gen_args,
     open_session,

--- a/plugins/modules/vcenter_vm_guest_operations_info.py
+++ b/plugins/modules/vcenter_vm_guest_operations_info.py
@@ -86,8 +86,12 @@ PAYLOAD_FORMAT = {
 }  # pylint: disable=line-too-long
 
 from ansible.module_utils.basic import env_fallback
+import os
 
 try:
+    if not os.getenv('VMWARE_ENABLE_TURBO', False):
+        raise ImportError()
+
     from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
         EmbeddedModuleFailure,
     )

--- a/plugins/modules/vcenter_vm_guest_operations_info.py
+++ b/plugins/modules/vcenter_vm_guest_operations_info.py
@@ -89,7 +89,7 @@ from ansible.module_utils.basic import env_fallback
 import os
 
 try:
-    if not os.getenv('VMWARE_ENABLE_TURBO', False):
+    if not os.getenv("VMWARE_ENABLE_TURBO", False):
         raise ImportError()
 
     from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (

--- a/plugins/modules/vcenter_vm_guest_power.py
+++ b/plugins/modules/vcenter_vm_guest_power.py
@@ -152,20 +152,21 @@ PAYLOAD_FORMAT = {
 from ansible.module_utils.basic import env_fallback
 import os
 
-try:
-    if not os.getenv("VMWARE_ENABLE_TURBO", False):
-        raise ImportError()
+if os.getenv("VMWARE_ENABLE_TURBO", False):
+    try:
+        from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
+            EmbeddedModuleFailure,
+        )
+        from ansible_collections.cloud.common.plugins.module_utils.turbo.module import (
+            AnsibleTurboModule as AnsibleModule,
+        )
 
-    from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
-        EmbeddedModuleFailure,
-    )
-    from ansible_collections.cloud.common.plugins.module_utils.turbo.module import (
-        AnsibleTurboModule as AnsibleModule,
-    )
-
-    AnsibleModule.collection_name = "vmware.vmware_rest"
-except ImportError:
+        AnsibleModule.collection_name = "vmware.vmware_rest"
+    except ImportError:
+        from ansible.module_utils.basic import AnsibleModule
+else:
     from ansible.module_utils.basic import AnsibleModule
+
 from ansible_collections.vmware.vmware_rest.plugins.module_utils.vmware_rest import (
     exists,
     gen_args,

--- a/plugins/modules/vcenter_vm_guest_power.py
+++ b/plugins/modules/vcenter_vm_guest_power.py
@@ -150,8 +150,12 @@ PAYLOAD_FORMAT = {
 }  # pylint: disable=line-too-long
 
 from ansible.module_utils.basic import env_fallback
+import os
 
 try:
+    if not os.getenv('VMWARE_ENABLE_TURBO', False):
+        raise ImportError()
+
     from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
         EmbeddedModuleFailure,
     )

--- a/plugins/modules/vcenter_vm_guest_power.py
+++ b/plugins/modules/vcenter_vm_guest_power.py
@@ -153,7 +153,7 @@ from ansible.module_utils.basic import env_fallback
 import os
 
 try:
-    if not os.getenv('VMWARE_ENABLE_TURBO', False):
+    if not os.getenv("VMWARE_ENABLE_TURBO", False):
         raise ImportError()
 
     from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (

--- a/plugins/modules/vcenter_vm_guest_power_info.py
+++ b/plugins/modules/vcenter_vm_guest_power_info.py
@@ -132,20 +132,21 @@ PAYLOAD_FORMAT = {
 from ansible.module_utils.basic import env_fallback
 import os
 
-try:
-    if not os.getenv("VMWARE_ENABLE_TURBO", False):
-        raise ImportError()
+if os.getenv("VMWARE_ENABLE_TURBO", False):
+    try:
+        from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
+            EmbeddedModuleFailure,
+        )
+        from ansible_collections.cloud.common.plugins.module_utils.turbo.module import (
+            AnsibleTurboModule as AnsibleModule,
+        )
 
-    from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
-        EmbeddedModuleFailure,
-    )
-    from ansible_collections.cloud.common.plugins.module_utils.turbo.module import (
-        AnsibleTurboModule as AnsibleModule,
-    )
-
-    AnsibleModule.collection_name = "vmware.vmware_rest"
-except ImportError:
+        AnsibleModule.collection_name = "vmware.vmware_rest"
+    except ImportError:
+        from ansible.module_utils.basic import AnsibleModule
+else:
     from ansible.module_utils.basic import AnsibleModule
+
 from ansible_collections.vmware.vmware_rest.plugins.module_utils.vmware_rest import (
     gen_args,
     open_session,

--- a/plugins/modules/vcenter_vm_guest_power_info.py
+++ b/plugins/modules/vcenter_vm_guest_power_info.py
@@ -133,7 +133,7 @@ from ansible.module_utils.basic import env_fallback
 import os
 
 try:
-    if not os.getenv('VMWARE_ENABLE_TURBO', False):
+    if not os.getenv("VMWARE_ENABLE_TURBO", False):
         raise ImportError()
 
     from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (

--- a/plugins/modules/vcenter_vm_guest_power_info.py
+++ b/plugins/modules/vcenter_vm_guest_power_info.py
@@ -130,8 +130,12 @@ PAYLOAD_FORMAT = {
 }  # pylint: disable=line-too-long
 
 from ansible.module_utils.basic import env_fallback
+import os
 
 try:
+    if not os.getenv('VMWARE_ENABLE_TURBO', False):
+        raise ImportError()
+
     from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
         EmbeddedModuleFailure,
     )

--- a/plugins/modules/vcenter_vm_hardware.py
+++ b/plugins/modules/vcenter_vm_hardware.py
@@ -178,8 +178,12 @@ PAYLOAD_FORMAT = {
 }  # pylint: disable=line-too-long
 
 from ansible.module_utils.basic import env_fallback
+import os
 
 try:
+    if not os.getenv('VMWARE_ENABLE_TURBO', False):
+        raise ImportError()
+
     from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
         EmbeddedModuleFailure,
     )

--- a/plugins/modules/vcenter_vm_hardware.py
+++ b/plugins/modules/vcenter_vm_hardware.py
@@ -180,20 +180,21 @@ PAYLOAD_FORMAT = {
 from ansible.module_utils.basic import env_fallback
 import os
 
-try:
-    if not os.getenv("VMWARE_ENABLE_TURBO", False):
-        raise ImportError()
+if os.getenv("VMWARE_ENABLE_TURBO", False):
+    try:
+        from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
+            EmbeddedModuleFailure,
+        )
+        from ansible_collections.cloud.common.plugins.module_utils.turbo.module import (
+            AnsibleTurboModule as AnsibleModule,
+        )
 
-    from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
-        EmbeddedModuleFailure,
-    )
-    from ansible_collections.cloud.common.plugins.module_utils.turbo.module import (
-        AnsibleTurboModule as AnsibleModule,
-    )
-
-    AnsibleModule.collection_name = "vmware.vmware_rest"
-except ImportError:
+        AnsibleModule.collection_name = "vmware.vmware_rest"
+    except ImportError:
+        from ansible.module_utils.basic import AnsibleModule
+else:
     from ansible.module_utils.basic import AnsibleModule
+
 from ansible_collections.vmware.vmware_rest.plugins.module_utils.vmware_rest import (
     exists,
     gen_args,

--- a/plugins/modules/vcenter_vm_hardware.py
+++ b/plugins/modules/vcenter_vm_hardware.py
@@ -181,7 +181,7 @@ from ansible.module_utils.basic import env_fallback
 import os
 
 try:
-    if not os.getenv('VMWARE_ENABLE_TURBO', False):
+    if not os.getenv("VMWARE_ENABLE_TURBO", False):
         raise ImportError()
 
     from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (

--- a/plugins/modules/vcenter_vm_hardware_adapter_sata.py
+++ b/plugins/modules/vcenter_vm_hardware_adapter_sata.py
@@ -169,7 +169,7 @@ from ansible.module_utils.basic import env_fallback
 import os
 
 try:
-    if not os.getenv('VMWARE_ENABLE_TURBO', False):
+    if not os.getenv("VMWARE_ENABLE_TURBO", False):
         raise ImportError()
 
     from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (

--- a/plugins/modules/vcenter_vm_hardware_adapter_sata.py
+++ b/plugins/modules/vcenter_vm_hardware_adapter_sata.py
@@ -166,8 +166,12 @@ PAYLOAD_FORMAT = {
 }  # pylint: disable=line-too-long
 
 from ansible.module_utils.basic import env_fallback
+import os
 
 try:
+    if not os.getenv('VMWARE_ENABLE_TURBO', False):
+        raise ImportError()
+
     from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
         EmbeddedModuleFailure,
     )

--- a/plugins/modules/vcenter_vm_hardware_adapter_sata.py
+++ b/plugins/modules/vcenter_vm_hardware_adapter_sata.py
@@ -168,20 +168,21 @@ PAYLOAD_FORMAT = {
 from ansible.module_utils.basic import env_fallback
 import os
 
-try:
-    if not os.getenv("VMWARE_ENABLE_TURBO", False):
-        raise ImportError()
+if os.getenv("VMWARE_ENABLE_TURBO", False):
+    try:
+        from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
+            EmbeddedModuleFailure,
+        )
+        from ansible_collections.cloud.common.plugins.module_utils.turbo.module import (
+            AnsibleTurboModule as AnsibleModule,
+        )
 
-    from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
-        EmbeddedModuleFailure,
-    )
-    from ansible_collections.cloud.common.plugins.module_utils.turbo.module import (
-        AnsibleTurboModule as AnsibleModule,
-    )
-
-    AnsibleModule.collection_name = "vmware.vmware_rest"
-except ImportError:
+        AnsibleModule.collection_name = "vmware.vmware_rest"
+    except ImportError:
+        from ansible.module_utils.basic import AnsibleModule
+else:
     from ansible.module_utils.basic import AnsibleModule
+
 from ansible_collections.vmware.vmware_rest.plugins.module_utils.vmware_rest import (
     exists,
     gen_args,

--- a/plugins/modules/vcenter_vm_hardware_adapter_sata_info.py
+++ b/plugins/modules/vcenter_vm_hardware_adapter_sata_info.py
@@ -134,20 +134,21 @@ PAYLOAD_FORMAT = {
 from ansible.module_utils.basic import env_fallback
 import os
 
-try:
-    if not os.getenv("VMWARE_ENABLE_TURBO", False):
-        raise ImportError()
+if os.getenv("VMWARE_ENABLE_TURBO", False):
+    try:
+        from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
+            EmbeddedModuleFailure,
+        )
+        from ansible_collections.cloud.common.plugins.module_utils.turbo.module import (
+            AnsibleTurboModule as AnsibleModule,
+        )
 
-    from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
-        EmbeddedModuleFailure,
-    )
-    from ansible_collections.cloud.common.plugins.module_utils.turbo.module import (
-        AnsibleTurboModule as AnsibleModule,
-    )
-
-    AnsibleModule.collection_name = "vmware.vmware_rest"
-except ImportError:
+        AnsibleModule.collection_name = "vmware.vmware_rest"
+    except ImportError:
+        from ansible.module_utils.basic import AnsibleModule
+else:
     from ansible.module_utils.basic import AnsibleModule
+
 from ansible_collections.vmware.vmware_rest.plugins.module_utils.vmware_rest import (
     build_full_device_list,
     exists,

--- a/plugins/modules/vcenter_vm_hardware_adapter_sata_info.py
+++ b/plugins/modules/vcenter_vm_hardware_adapter_sata_info.py
@@ -135,7 +135,7 @@ from ansible.module_utils.basic import env_fallback
 import os
 
 try:
-    if not os.getenv('VMWARE_ENABLE_TURBO', False):
+    if not os.getenv("VMWARE_ENABLE_TURBO", False):
         raise ImportError()
 
     from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (

--- a/plugins/modules/vcenter_vm_hardware_adapter_sata_info.py
+++ b/plugins/modules/vcenter_vm_hardware_adapter_sata_info.py
@@ -132,8 +132,12 @@ PAYLOAD_FORMAT = {
 }  # pylint: disable=line-too-long
 
 from ansible.module_utils.basic import env_fallback
+import os
 
 try:
+    if not os.getenv('VMWARE_ENABLE_TURBO', False):
+        raise ImportError()
+
     from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
         EmbeddedModuleFailure,
     )

--- a/plugins/modules/vcenter_vm_hardware_adapter_scsi.py
+++ b/plugins/modules/vcenter_vm_hardware_adapter_scsi.py
@@ -196,20 +196,21 @@ PAYLOAD_FORMAT = {
 from ansible.module_utils.basic import env_fallback
 import os
 
-try:
-    if not os.getenv("VMWARE_ENABLE_TURBO", False):
-        raise ImportError()
+if os.getenv("VMWARE_ENABLE_TURBO", False):
+    try:
+        from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
+            EmbeddedModuleFailure,
+        )
+        from ansible_collections.cloud.common.plugins.module_utils.turbo.module import (
+            AnsibleTurboModule as AnsibleModule,
+        )
 
-    from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
-        EmbeddedModuleFailure,
-    )
-    from ansible_collections.cloud.common.plugins.module_utils.turbo.module import (
-        AnsibleTurboModule as AnsibleModule,
-    )
-
-    AnsibleModule.collection_name = "vmware.vmware_rest"
-except ImportError:
+        AnsibleModule.collection_name = "vmware.vmware_rest"
+    except ImportError:
+        from ansible.module_utils.basic import AnsibleModule
+else:
     from ansible.module_utils.basic import AnsibleModule
+
 from ansible_collections.vmware.vmware_rest.plugins.module_utils.vmware_rest import (
     exists,
     gen_args,

--- a/plugins/modules/vcenter_vm_hardware_adapter_scsi.py
+++ b/plugins/modules/vcenter_vm_hardware_adapter_scsi.py
@@ -194,8 +194,12 @@ PAYLOAD_FORMAT = {
 }  # pylint: disable=line-too-long
 
 from ansible.module_utils.basic import env_fallback
+import os
 
 try:
+    if not os.getenv('VMWARE_ENABLE_TURBO', False):
+        raise ImportError()
+
     from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
         EmbeddedModuleFailure,
     )

--- a/plugins/modules/vcenter_vm_hardware_adapter_scsi.py
+++ b/plugins/modules/vcenter_vm_hardware_adapter_scsi.py
@@ -197,7 +197,7 @@ from ansible.module_utils.basic import env_fallback
 import os
 
 try:
-    if not os.getenv('VMWARE_ENABLE_TURBO', False):
+    if not os.getenv("VMWARE_ENABLE_TURBO", False):
         raise ImportError()
 
     from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (

--- a/plugins/modules/vcenter_vm_hardware_adapter_scsi_info.py
+++ b/plugins/modules/vcenter_vm_hardware_adapter_scsi_info.py
@@ -122,20 +122,21 @@ PAYLOAD_FORMAT = {
 from ansible.module_utils.basic import env_fallback
 import os
 
-try:
-    if not os.getenv("VMWARE_ENABLE_TURBO", False):
-        raise ImportError()
+if os.getenv("VMWARE_ENABLE_TURBO", False):
+    try:
+        from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
+            EmbeddedModuleFailure,
+        )
+        from ansible_collections.cloud.common.plugins.module_utils.turbo.module import (
+            AnsibleTurboModule as AnsibleModule,
+        )
 
-    from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
-        EmbeddedModuleFailure,
-    )
-    from ansible_collections.cloud.common.plugins.module_utils.turbo.module import (
-        AnsibleTurboModule as AnsibleModule,
-    )
-
-    AnsibleModule.collection_name = "vmware.vmware_rest"
-except ImportError:
+        AnsibleModule.collection_name = "vmware.vmware_rest"
+    except ImportError:
+        from ansible.module_utils.basic import AnsibleModule
+else:
     from ansible.module_utils.basic import AnsibleModule
+
 from ansible_collections.vmware.vmware_rest.plugins.module_utils.vmware_rest import (
     build_full_device_list,
     exists,

--- a/plugins/modules/vcenter_vm_hardware_adapter_scsi_info.py
+++ b/plugins/modules/vcenter_vm_hardware_adapter_scsi_info.py
@@ -123,7 +123,7 @@ from ansible.module_utils.basic import env_fallback
 import os
 
 try:
-    if not os.getenv('VMWARE_ENABLE_TURBO', False):
+    if not os.getenv("VMWARE_ENABLE_TURBO", False):
         raise ImportError()
 
     from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (

--- a/plugins/modules/vcenter_vm_hardware_adapter_scsi_info.py
+++ b/plugins/modules/vcenter_vm_hardware_adapter_scsi_info.py
@@ -120,8 +120,12 @@ PAYLOAD_FORMAT = {
 }  # pylint: disable=line-too-long
 
 from ansible.module_utils.basic import env_fallback
+import os
 
 try:
+    if not os.getenv('VMWARE_ENABLE_TURBO', False):
+        raise ImportError()
+
     from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
         EmbeddedModuleFailure,
     )

--- a/plugins/modules/vcenter_vm_hardware_boot.py
+++ b/plugins/modules/vcenter_vm_hardware_boot.py
@@ -182,8 +182,12 @@ PAYLOAD_FORMAT = {
 }  # pylint: disable=line-too-long
 
 from ansible.module_utils.basic import env_fallback
+import os
 
 try:
+    if not os.getenv('VMWARE_ENABLE_TURBO', False):
+        raise ImportError()
+
     from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
         EmbeddedModuleFailure,
     )

--- a/plugins/modules/vcenter_vm_hardware_boot.py
+++ b/plugins/modules/vcenter_vm_hardware_boot.py
@@ -184,20 +184,21 @@ PAYLOAD_FORMAT = {
 from ansible.module_utils.basic import env_fallback
 import os
 
-try:
-    if not os.getenv("VMWARE_ENABLE_TURBO", False):
-        raise ImportError()
+if os.getenv("VMWARE_ENABLE_TURBO", False):
+    try:
+        from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
+            EmbeddedModuleFailure,
+        )
+        from ansible_collections.cloud.common.plugins.module_utils.turbo.module import (
+            AnsibleTurboModule as AnsibleModule,
+        )
 
-    from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
-        EmbeddedModuleFailure,
-    )
-    from ansible_collections.cloud.common.plugins.module_utils.turbo.module import (
-        AnsibleTurboModule as AnsibleModule,
-    )
-
-    AnsibleModule.collection_name = "vmware.vmware_rest"
-except ImportError:
+        AnsibleModule.collection_name = "vmware.vmware_rest"
+    except ImportError:
+        from ansible.module_utils.basic import AnsibleModule
+else:
     from ansible.module_utils.basic import AnsibleModule
+
 from ansible_collections.vmware.vmware_rest.plugins.module_utils.vmware_rest import (
     open_session,
     prepare_payload,

--- a/plugins/modules/vcenter_vm_hardware_boot.py
+++ b/plugins/modules/vcenter_vm_hardware_boot.py
@@ -185,7 +185,7 @@ from ansible.module_utils.basic import env_fallback
 import os
 
 try:
-    if not os.getenv('VMWARE_ENABLE_TURBO', False):
+    if not os.getenv("VMWARE_ENABLE_TURBO", False):
         raise ImportError()
 
     from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (

--- a/plugins/modules/vcenter_vm_hardware_boot_device.py
+++ b/plugins/modules/vcenter_vm_hardware_boot_device.py
@@ -152,20 +152,21 @@ PAYLOAD_FORMAT = {
 from ansible.module_utils.basic import env_fallback
 import os
 
-try:
-    if not os.getenv("VMWARE_ENABLE_TURBO", False):
-        raise ImportError()
+if os.getenv("VMWARE_ENABLE_TURBO", False):
+    try:
+        from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
+            EmbeddedModuleFailure,
+        )
+        from ansible_collections.cloud.common.plugins.module_utils.turbo.module import (
+            AnsibleTurboModule as AnsibleModule,
+        )
 
-    from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
-        EmbeddedModuleFailure,
-    )
-    from ansible_collections.cloud.common.plugins.module_utils.turbo.module import (
-        AnsibleTurboModule as AnsibleModule,
-    )
-
-    AnsibleModule.collection_name = "vmware.vmware_rest"
-except ImportError:
+        AnsibleModule.collection_name = "vmware.vmware_rest"
+    except ImportError:
+        from ansible.module_utils.basic import AnsibleModule
+else:
     from ansible.module_utils.basic import AnsibleModule
+
 from ansible_collections.vmware.vmware_rest.plugins.module_utils.vmware_rest import (
     exists,
     gen_args,

--- a/plugins/modules/vcenter_vm_hardware_boot_device.py
+++ b/plugins/modules/vcenter_vm_hardware_boot_device.py
@@ -150,8 +150,12 @@ PAYLOAD_FORMAT = {
 }  # pylint: disable=line-too-long
 
 from ansible.module_utils.basic import env_fallback
+import os
 
 try:
+    if not os.getenv('VMWARE_ENABLE_TURBO', False):
+        raise ImportError()
+
     from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
         EmbeddedModuleFailure,
     )

--- a/plugins/modules/vcenter_vm_hardware_boot_device.py
+++ b/plugins/modules/vcenter_vm_hardware_boot_device.py
@@ -153,7 +153,7 @@ from ansible.module_utils.basic import env_fallback
 import os
 
 try:
-    if not os.getenv('VMWARE_ENABLE_TURBO', False):
+    if not os.getenv("VMWARE_ENABLE_TURBO", False):
         raise ImportError()
 
     from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (

--- a/plugins/modules/vcenter_vm_hardware_boot_device_info.py
+++ b/plugins/modules/vcenter_vm_hardware_boot_device_info.py
@@ -117,7 +117,7 @@ from ansible.module_utils.basic import env_fallback
 import os
 
 try:
-    if not os.getenv('VMWARE_ENABLE_TURBO', False):
+    if not os.getenv("VMWARE_ENABLE_TURBO", False):
         raise ImportError()
 
     from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (

--- a/plugins/modules/vcenter_vm_hardware_boot_device_info.py
+++ b/plugins/modules/vcenter_vm_hardware_boot_device_info.py
@@ -116,20 +116,21 @@ PAYLOAD_FORMAT = {
 from ansible.module_utils.basic import env_fallback
 import os
 
-try:
-    if not os.getenv("VMWARE_ENABLE_TURBO", False):
-        raise ImportError()
+if os.getenv("VMWARE_ENABLE_TURBO", False):
+    try:
+        from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
+            EmbeddedModuleFailure,
+        )
+        from ansible_collections.cloud.common.plugins.module_utils.turbo.module import (
+            AnsibleTurboModule as AnsibleModule,
+        )
 
-    from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
-        EmbeddedModuleFailure,
-    )
-    from ansible_collections.cloud.common.plugins.module_utils.turbo.module import (
-        AnsibleTurboModule as AnsibleModule,
-    )
-
-    AnsibleModule.collection_name = "vmware.vmware_rest"
-except ImportError:
+        AnsibleModule.collection_name = "vmware.vmware_rest"
+    except ImportError:
+        from ansible.module_utils.basic import AnsibleModule
+else:
     from ansible.module_utils.basic import AnsibleModule
+
 from ansible_collections.vmware.vmware_rest.plugins.module_utils.vmware_rest import (
     gen_args,
     open_session,

--- a/plugins/modules/vcenter_vm_hardware_boot_device_info.py
+++ b/plugins/modules/vcenter_vm_hardware_boot_device_info.py
@@ -114,8 +114,12 @@ PAYLOAD_FORMAT = {
 }  # pylint: disable=line-too-long
 
 from ansible.module_utils.basic import env_fallback
+import os
 
 try:
+    if not os.getenv('VMWARE_ENABLE_TURBO', False):
+        raise ImportError()
+
     from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
         EmbeddedModuleFailure,
     )

--- a/plugins/modules/vcenter_vm_hardware_boot_info.py
+++ b/plugins/modules/vcenter_vm_hardware_boot_info.py
@@ -113,20 +113,21 @@ PAYLOAD_FORMAT = {
 from ansible.module_utils.basic import env_fallback
 import os
 
-try:
-    if not os.getenv("VMWARE_ENABLE_TURBO", False):
-        raise ImportError()
+if os.getenv("VMWARE_ENABLE_TURBO", False):
+    try:
+        from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
+            EmbeddedModuleFailure,
+        )
+        from ansible_collections.cloud.common.plugins.module_utils.turbo.module import (
+            AnsibleTurboModule as AnsibleModule,
+        )
 
-    from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
-        EmbeddedModuleFailure,
-    )
-    from ansible_collections.cloud.common.plugins.module_utils.turbo.module import (
-        AnsibleTurboModule as AnsibleModule,
-    )
-
-    AnsibleModule.collection_name = "vmware.vmware_rest"
-except ImportError:
+        AnsibleModule.collection_name = "vmware.vmware_rest"
+    except ImportError:
+        from ansible.module_utils.basic import AnsibleModule
+else:
     from ansible.module_utils.basic import AnsibleModule
+
 from ansible_collections.vmware.vmware_rest.plugins.module_utils.vmware_rest import (
     gen_args,
     open_session,

--- a/plugins/modules/vcenter_vm_hardware_boot_info.py
+++ b/plugins/modules/vcenter_vm_hardware_boot_info.py
@@ -114,7 +114,7 @@ from ansible.module_utils.basic import env_fallback
 import os
 
 try:
-    if not os.getenv('VMWARE_ENABLE_TURBO', False):
+    if not os.getenv("VMWARE_ENABLE_TURBO", False):
         raise ImportError()
 
     from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (

--- a/plugins/modules/vcenter_vm_hardware_boot_info.py
+++ b/plugins/modules/vcenter_vm_hardware_boot_info.py
@@ -111,8 +111,12 @@ PAYLOAD_FORMAT = {
 }  # pylint: disable=line-too-long
 
 from ansible.module_utils.basic import env_fallback
+import os
 
 try:
+    if not os.getenv('VMWARE_ENABLE_TURBO', False):
+        raise ImportError()
+
     from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
         EmbeddedModuleFailure,
     )

--- a/plugins/modules/vcenter_vm_hardware_cdrom.py
+++ b/plugins/modules/vcenter_vm_hardware_cdrom.py
@@ -251,8 +251,12 @@ PAYLOAD_FORMAT = {
 }  # pylint: disable=line-too-long
 
 from ansible.module_utils.basic import env_fallback
+import os
 
 try:
+    if not os.getenv('VMWARE_ENABLE_TURBO', False):
+        raise ImportError()
+
     from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
         EmbeddedModuleFailure,
     )

--- a/plugins/modules/vcenter_vm_hardware_cdrom.py
+++ b/plugins/modules/vcenter_vm_hardware_cdrom.py
@@ -254,7 +254,7 @@ from ansible.module_utils.basic import env_fallback
 import os
 
 try:
-    if not os.getenv('VMWARE_ENABLE_TURBO', False):
+    if not os.getenv("VMWARE_ENABLE_TURBO", False):
         raise ImportError()
 
     from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (

--- a/plugins/modules/vcenter_vm_hardware_cdrom.py
+++ b/plugins/modules/vcenter_vm_hardware_cdrom.py
@@ -253,20 +253,21 @@ PAYLOAD_FORMAT = {
 from ansible.module_utils.basic import env_fallback
 import os
 
-try:
-    if not os.getenv("VMWARE_ENABLE_TURBO", False):
-        raise ImportError()
+if os.getenv("VMWARE_ENABLE_TURBO", False):
+    try:
+        from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
+            EmbeddedModuleFailure,
+        )
+        from ansible_collections.cloud.common.plugins.module_utils.turbo.module import (
+            AnsibleTurboModule as AnsibleModule,
+        )
 
-    from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
-        EmbeddedModuleFailure,
-    )
-    from ansible_collections.cloud.common.plugins.module_utils.turbo.module import (
-        AnsibleTurboModule as AnsibleModule,
-    )
-
-    AnsibleModule.collection_name = "vmware.vmware_rest"
-except ImportError:
+        AnsibleModule.collection_name = "vmware.vmware_rest"
+    except ImportError:
+        from ansible.module_utils.basic import AnsibleModule
+else:
     from ansible.module_utils.basic import AnsibleModule
+
 from ansible_collections.vmware.vmware_rest.plugins.module_utils.vmware_rest import (
     exists,
     gen_args,

--- a/plugins/modules/vcenter_vm_hardware_cdrom_info.py
+++ b/plugins/modules/vcenter_vm_hardware_cdrom_info.py
@@ -121,20 +121,21 @@ PAYLOAD_FORMAT = {
 from ansible.module_utils.basic import env_fallback
 import os
 
-try:
-    if not os.getenv("VMWARE_ENABLE_TURBO", False):
-        raise ImportError()
+if os.getenv("VMWARE_ENABLE_TURBO", False):
+    try:
+        from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
+            EmbeddedModuleFailure,
+        )
+        from ansible_collections.cloud.common.plugins.module_utils.turbo.module import (
+            AnsibleTurboModule as AnsibleModule,
+        )
 
-    from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
-        EmbeddedModuleFailure,
-    )
-    from ansible_collections.cloud.common.plugins.module_utils.turbo.module import (
-        AnsibleTurboModule as AnsibleModule,
-    )
-
-    AnsibleModule.collection_name = "vmware.vmware_rest"
-except ImportError:
+        AnsibleModule.collection_name = "vmware.vmware_rest"
+    except ImportError:
+        from ansible.module_utils.basic import AnsibleModule
+else:
     from ansible.module_utils.basic import AnsibleModule
+
 from ansible_collections.vmware.vmware_rest.plugins.module_utils.vmware_rest import (
     build_full_device_list,
     exists,

--- a/plugins/modules/vcenter_vm_hardware_cdrom_info.py
+++ b/plugins/modules/vcenter_vm_hardware_cdrom_info.py
@@ -122,7 +122,7 @@ from ansible.module_utils.basic import env_fallback
 import os
 
 try:
-    if not os.getenv('VMWARE_ENABLE_TURBO', False):
+    if not os.getenv("VMWARE_ENABLE_TURBO", False):
         raise ImportError()
 
     from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (

--- a/plugins/modules/vcenter_vm_hardware_cdrom_info.py
+++ b/plugins/modules/vcenter_vm_hardware_cdrom_info.py
@@ -119,8 +119,12 @@ PAYLOAD_FORMAT = {
 }  # pylint: disable=line-too-long
 
 from ansible.module_utils.basic import env_fallback
+import os
 
 try:
+    if not os.getenv('VMWARE_ENABLE_TURBO', False):
+        raise ImportError()
+
     from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
         EmbeddedModuleFailure,
     )

--- a/plugins/modules/vcenter_vm_hardware_cpu.py
+++ b/plugins/modules/vcenter_vm_hardware_cpu.py
@@ -170,20 +170,21 @@ PAYLOAD_FORMAT = {
 from ansible.module_utils.basic import env_fallback
 import os
 
-try:
-    if not os.getenv("VMWARE_ENABLE_TURBO", False):
-        raise ImportError()
+if os.getenv("VMWARE_ENABLE_TURBO", False):
+    try:
+        from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
+            EmbeddedModuleFailure,
+        )
+        from ansible_collections.cloud.common.plugins.module_utils.turbo.module import (
+            AnsibleTurboModule as AnsibleModule,
+        )
 
-    from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
-        EmbeddedModuleFailure,
-    )
-    from ansible_collections.cloud.common.plugins.module_utils.turbo.module import (
-        AnsibleTurboModule as AnsibleModule,
-    )
-
-    AnsibleModule.collection_name = "vmware.vmware_rest"
-except ImportError:
+        AnsibleModule.collection_name = "vmware.vmware_rest"
+    except ImportError:
+        from ansible.module_utils.basic import AnsibleModule
+else:
     from ansible.module_utils.basic import AnsibleModule
+
 from ansible_collections.vmware.vmware_rest.plugins.module_utils.vmware_rest import (
     open_session,
     prepare_payload,

--- a/plugins/modules/vcenter_vm_hardware_cpu.py
+++ b/plugins/modules/vcenter_vm_hardware_cpu.py
@@ -168,8 +168,12 @@ PAYLOAD_FORMAT = {
 }  # pylint: disable=line-too-long
 
 from ansible.module_utils.basic import env_fallback
+import os
 
 try:
+    if not os.getenv('VMWARE_ENABLE_TURBO', False):
+        raise ImportError()
+
     from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
         EmbeddedModuleFailure,
     )

--- a/plugins/modules/vcenter_vm_hardware_cpu.py
+++ b/plugins/modules/vcenter_vm_hardware_cpu.py
@@ -171,7 +171,7 @@ from ansible.module_utils.basic import env_fallback
 import os
 
 try:
-    if not os.getenv('VMWARE_ENABLE_TURBO', False):
+    if not os.getenv("VMWARE_ENABLE_TURBO", False):
         raise ImportError()
 
     from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (

--- a/plugins/modules/vcenter_vm_hardware_cpu_info.py
+++ b/plugins/modules/vcenter_vm_hardware_cpu_info.py
@@ -117,20 +117,21 @@ PAYLOAD_FORMAT = {
 from ansible.module_utils.basic import env_fallback
 import os
 
-try:
-    if not os.getenv("VMWARE_ENABLE_TURBO", False):
-        raise ImportError()
+if os.getenv("VMWARE_ENABLE_TURBO", False):
+    try:
+        from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
+            EmbeddedModuleFailure,
+        )
+        from ansible_collections.cloud.common.plugins.module_utils.turbo.module import (
+            AnsibleTurboModule as AnsibleModule,
+        )
 
-    from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
-        EmbeddedModuleFailure,
-    )
-    from ansible_collections.cloud.common.plugins.module_utils.turbo.module import (
-        AnsibleTurboModule as AnsibleModule,
-    )
-
-    AnsibleModule.collection_name = "vmware.vmware_rest"
-except ImportError:
+        AnsibleModule.collection_name = "vmware.vmware_rest"
+    except ImportError:
+        from ansible.module_utils.basic import AnsibleModule
+else:
     from ansible.module_utils.basic import AnsibleModule
+
 from ansible_collections.vmware.vmware_rest.plugins.module_utils.vmware_rest import (
     gen_args,
     open_session,

--- a/plugins/modules/vcenter_vm_hardware_cpu_info.py
+++ b/plugins/modules/vcenter_vm_hardware_cpu_info.py
@@ -118,7 +118,7 @@ from ansible.module_utils.basic import env_fallback
 import os
 
 try:
-    if not os.getenv('VMWARE_ENABLE_TURBO', False):
+    if not os.getenv("VMWARE_ENABLE_TURBO", False):
         raise ImportError()
 
     from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (

--- a/plugins/modules/vcenter_vm_hardware_cpu_info.py
+++ b/plugins/modules/vcenter_vm_hardware_cpu_info.py
@@ -115,8 +115,12 @@ PAYLOAD_FORMAT = {
 }  # pylint: disable=line-too-long
 
 from ansible.module_utils.basic import env_fallback
+import os
 
 try:
+    if not os.getenv('VMWARE_ENABLE_TURBO', False):
+        raise ImportError()
+
     from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
         EmbeddedModuleFailure,
     )

--- a/plugins/modules/vcenter_vm_hardware_disk.py
+++ b/plugins/modules/vcenter_vm_hardware_disk.py
@@ -280,20 +280,21 @@ PAYLOAD_FORMAT = {
 from ansible.module_utils.basic import env_fallback
 import os
 
-try:
-    if not os.getenv("VMWARE_ENABLE_TURBO", False):
-        raise ImportError()
+if os.getenv("VMWARE_ENABLE_TURBO", False):
+    try:
+        from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
+            EmbeddedModuleFailure,
+        )
+        from ansible_collections.cloud.common.plugins.module_utils.turbo.module import (
+            AnsibleTurboModule as AnsibleModule,
+        )
 
-    from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
-        EmbeddedModuleFailure,
-    )
-    from ansible_collections.cloud.common.plugins.module_utils.turbo.module import (
-        AnsibleTurboModule as AnsibleModule,
-    )
-
-    AnsibleModule.collection_name = "vmware.vmware_rest"
-except ImportError:
+        AnsibleModule.collection_name = "vmware.vmware_rest"
+    except ImportError:
+        from ansible.module_utils.basic import AnsibleModule
+else:
     from ansible.module_utils.basic import AnsibleModule
+
 from ansible_collections.vmware.vmware_rest.plugins.module_utils.vmware_rest import (
     exists,
     gen_args,

--- a/plugins/modules/vcenter_vm_hardware_disk.py
+++ b/plugins/modules/vcenter_vm_hardware_disk.py
@@ -281,7 +281,7 @@ from ansible.module_utils.basic import env_fallback
 import os
 
 try:
-    if not os.getenv('VMWARE_ENABLE_TURBO', False):
+    if not os.getenv("VMWARE_ENABLE_TURBO", False):
         raise ImportError()
 
     from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (

--- a/plugins/modules/vcenter_vm_hardware_disk.py
+++ b/plugins/modules/vcenter_vm_hardware_disk.py
@@ -278,8 +278,12 @@ PAYLOAD_FORMAT = {
 }  # pylint: disable=line-too-long
 
 from ansible.module_utils.basic import env_fallback
+import os
 
 try:
+    if not os.getenv('VMWARE_ENABLE_TURBO', False):
+        raise ImportError()
+
     from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
         EmbeddedModuleFailure,
     )

--- a/plugins/modules/vcenter_vm_hardware_disk_info.py
+++ b/plugins/modules/vcenter_vm_hardware_disk_info.py
@@ -139,8 +139,12 @@ PAYLOAD_FORMAT = {
 }  # pylint: disable=line-too-long
 
 from ansible.module_utils.basic import env_fallback
+import os
 
 try:
+    if not os.getenv('VMWARE_ENABLE_TURBO', False):
+        raise ImportError()
+
     from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
         EmbeddedModuleFailure,
     )

--- a/plugins/modules/vcenter_vm_hardware_disk_info.py
+++ b/plugins/modules/vcenter_vm_hardware_disk_info.py
@@ -141,20 +141,21 @@ PAYLOAD_FORMAT = {
 from ansible.module_utils.basic import env_fallback
 import os
 
-try:
-    if not os.getenv("VMWARE_ENABLE_TURBO", False):
-        raise ImportError()
+if os.getenv("VMWARE_ENABLE_TURBO", False):
+    try:
+        from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
+            EmbeddedModuleFailure,
+        )
+        from ansible_collections.cloud.common.plugins.module_utils.turbo.module import (
+            AnsibleTurboModule as AnsibleModule,
+        )
 
-    from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
-        EmbeddedModuleFailure,
-    )
-    from ansible_collections.cloud.common.plugins.module_utils.turbo.module import (
-        AnsibleTurboModule as AnsibleModule,
-    )
-
-    AnsibleModule.collection_name = "vmware.vmware_rest"
-except ImportError:
+        AnsibleModule.collection_name = "vmware.vmware_rest"
+    except ImportError:
+        from ansible.module_utils.basic import AnsibleModule
+else:
     from ansible.module_utils.basic import AnsibleModule
+
 from ansible_collections.vmware.vmware_rest.plugins.module_utils.vmware_rest import (
     build_full_device_list,
     exists,

--- a/plugins/modules/vcenter_vm_hardware_disk_info.py
+++ b/plugins/modules/vcenter_vm_hardware_disk_info.py
@@ -142,7 +142,7 @@ from ansible.module_utils.basic import env_fallback
 import os
 
 try:
-    if not os.getenv('VMWARE_ENABLE_TURBO', False):
+    if not os.getenv("VMWARE_ENABLE_TURBO", False):
         raise ImportError()
 
     from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (

--- a/plugins/modules/vcenter_vm_hardware_ethernet.py
+++ b/plugins/modules/vcenter_vm_hardware_ethernet.py
@@ -342,7 +342,7 @@ from ansible.module_utils.basic import env_fallback
 import os
 
 try:
-    if not os.getenv('VMWARE_ENABLE_TURBO', False):
+    if not os.getenv("VMWARE_ENABLE_TURBO", False):
         raise ImportError()
 
     from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (

--- a/plugins/modules/vcenter_vm_hardware_ethernet.py
+++ b/plugins/modules/vcenter_vm_hardware_ethernet.py
@@ -341,20 +341,21 @@ PAYLOAD_FORMAT = {
 from ansible.module_utils.basic import env_fallback
 import os
 
-try:
-    if not os.getenv("VMWARE_ENABLE_TURBO", False):
-        raise ImportError()
+if os.getenv("VMWARE_ENABLE_TURBO", False):
+    try:
+        from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
+            EmbeddedModuleFailure,
+        )
+        from ansible_collections.cloud.common.plugins.module_utils.turbo.module import (
+            AnsibleTurboModule as AnsibleModule,
+        )
 
-    from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
-        EmbeddedModuleFailure,
-    )
-    from ansible_collections.cloud.common.plugins.module_utils.turbo.module import (
-        AnsibleTurboModule as AnsibleModule,
-    )
-
-    AnsibleModule.collection_name = "vmware.vmware_rest"
-except ImportError:
+        AnsibleModule.collection_name = "vmware.vmware_rest"
+    except ImportError:
+        from ansible.module_utils.basic import AnsibleModule
+else:
     from ansible.module_utils.basic import AnsibleModule
+
 from ansible_collections.vmware.vmware_rest.plugins.module_utils.vmware_rest import (
     exists,
     gen_args,

--- a/plugins/modules/vcenter_vm_hardware_ethernet.py
+++ b/plugins/modules/vcenter_vm_hardware_ethernet.py
@@ -339,8 +339,12 @@ PAYLOAD_FORMAT = {
 }  # pylint: disable=line-too-long
 
 from ansible.module_utils.basic import env_fallback
+import os
 
 try:
+    if not os.getenv('VMWARE_ENABLE_TURBO', False):
+        raise ImportError()
+
     from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
         EmbeddedModuleFailure,
     )

--- a/plugins/modules/vcenter_vm_hardware_ethernet_info.py
+++ b/plugins/modules/vcenter_vm_hardware_ethernet_info.py
@@ -127,7 +127,7 @@ from ansible.module_utils.basic import env_fallback
 import os
 
 try:
-    if not os.getenv('VMWARE_ENABLE_TURBO', False):
+    if not os.getenv("VMWARE_ENABLE_TURBO", False):
         raise ImportError()
 
     from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (

--- a/plugins/modules/vcenter_vm_hardware_ethernet_info.py
+++ b/plugins/modules/vcenter_vm_hardware_ethernet_info.py
@@ -124,8 +124,12 @@ PAYLOAD_FORMAT = {
 }  # pylint: disable=line-too-long
 
 from ansible.module_utils.basic import env_fallback
+import os
 
 try:
+    if not os.getenv('VMWARE_ENABLE_TURBO', False):
+        raise ImportError()
+
     from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
         EmbeddedModuleFailure,
     )

--- a/plugins/modules/vcenter_vm_hardware_ethernet_info.py
+++ b/plugins/modules/vcenter_vm_hardware_ethernet_info.py
@@ -126,20 +126,21 @@ PAYLOAD_FORMAT = {
 from ansible.module_utils.basic import env_fallback
 import os
 
-try:
-    if not os.getenv("VMWARE_ENABLE_TURBO", False):
-        raise ImportError()
+if os.getenv("VMWARE_ENABLE_TURBO", False):
+    try:
+        from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
+            EmbeddedModuleFailure,
+        )
+        from ansible_collections.cloud.common.plugins.module_utils.turbo.module import (
+            AnsibleTurboModule as AnsibleModule,
+        )
 
-    from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
-        EmbeddedModuleFailure,
-    )
-    from ansible_collections.cloud.common.plugins.module_utils.turbo.module import (
-        AnsibleTurboModule as AnsibleModule,
-    )
-
-    AnsibleModule.collection_name = "vmware.vmware_rest"
-except ImportError:
+        AnsibleModule.collection_name = "vmware.vmware_rest"
+    except ImportError:
+        from ansible.module_utils.basic import AnsibleModule
+else:
     from ansible.module_utils.basic import AnsibleModule
+
 from ansible_collections.vmware.vmware_rest.plugins.module_utils.vmware_rest import (
     build_full_device_list,
     exists,

--- a/plugins/modules/vcenter_vm_hardware_floppy.py
+++ b/plugins/modules/vcenter_vm_hardware_floppy.py
@@ -203,20 +203,21 @@ PAYLOAD_FORMAT = {
 from ansible.module_utils.basic import env_fallback
 import os
 
-try:
-    if not os.getenv("VMWARE_ENABLE_TURBO", False):
-        raise ImportError()
+if os.getenv("VMWARE_ENABLE_TURBO", False):
+    try:
+        from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
+            EmbeddedModuleFailure,
+        )
+        from ansible_collections.cloud.common.plugins.module_utils.turbo.module import (
+            AnsibleTurboModule as AnsibleModule,
+        )
 
-    from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
-        EmbeddedModuleFailure,
-    )
-    from ansible_collections.cloud.common.plugins.module_utils.turbo.module import (
-        AnsibleTurboModule as AnsibleModule,
-    )
-
-    AnsibleModule.collection_name = "vmware.vmware_rest"
-except ImportError:
+        AnsibleModule.collection_name = "vmware.vmware_rest"
+    except ImportError:
+        from ansible.module_utils.basic import AnsibleModule
+else:
     from ansible.module_utils.basic import AnsibleModule
+
 from ansible_collections.vmware.vmware_rest.plugins.module_utils.vmware_rest import (
     exists,
     gen_args,

--- a/plugins/modules/vcenter_vm_hardware_floppy.py
+++ b/plugins/modules/vcenter_vm_hardware_floppy.py
@@ -201,8 +201,12 @@ PAYLOAD_FORMAT = {
 }  # pylint: disable=line-too-long
 
 from ansible.module_utils.basic import env_fallback
+import os
 
 try:
+    if not os.getenv('VMWARE_ENABLE_TURBO', False):
+        raise ImportError()
+
     from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
         EmbeddedModuleFailure,
     )

--- a/plugins/modules/vcenter_vm_hardware_floppy.py
+++ b/plugins/modules/vcenter_vm_hardware_floppy.py
@@ -204,7 +204,7 @@ from ansible.module_utils.basic import env_fallback
 import os
 
 try:
-    if not os.getenv('VMWARE_ENABLE_TURBO', False):
+    if not os.getenv("VMWARE_ENABLE_TURBO", False):
         raise ImportError()
 
     from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (

--- a/plugins/modules/vcenter_vm_hardware_floppy_info.py
+++ b/plugins/modules/vcenter_vm_hardware_floppy_info.py
@@ -121,20 +121,21 @@ PAYLOAD_FORMAT = {
 from ansible.module_utils.basic import env_fallback
 import os
 
-try:
-    if not os.getenv("VMWARE_ENABLE_TURBO", False):
-        raise ImportError()
+if os.getenv("VMWARE_ENABLE_TURBO", False):
+    try:
+        from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
+            EmbeddedModuleFailure,
+        )
+        from ansible_collections.cloud.common.plugins.module_utils.turbo.module import (
+            AnsibleTurboModule as AnsibleModule,
+        )
 
-    from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
-        EmbeddedModuleFailure,
-    )
-    from ansible_collections.cloud.common.plugins.module_utils.turbo.module import (
-        AnsibleTurboModule as AnsibleModule,
-    )
-
-    AnsibleModule.collection_name = "vmware.vmware_rest"
-except ImportError:
+        AnsibleModule.collection_name = "vmware.vmware_rest"
+    except ImportError:
+        from ansible.module_utils.basic import AnsibleModule
+else:
     from ansible.module_utils.basic import AnsibleModule
+
 from ansible_collections.vmware.vmware_rest.plugins.module_utils.vmware_rest import (
     build_full_device_list,
     exists,

--- a/plugins/modules/vcenter_vm_hardware_floppy_info.py
+++ b/plugins/modules/vcenter_vm_hardware_floppy_info.py
@@ -122,7 +122,7 @@ from ansible.module_utils.basic import env_fallback
 import os
 
 try:
-    if not os.getenv('VMWARE_ENABLE_TURBO', False):
+    if not os.getenv("VMWARE_ENABLE_TURBO", False):
         raise ImportError()
 
     from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (

--- a/plugins/modules/vcenter_vm_hardware_floppy_info.py
+++ b/plugins/modules/vcenter_vm_hardware_floppy_info.py
@@ -119,8 +119,12 @@ PAYLOAD_FORMAT = {
 }  # pylint: disable=line-too-long
 
 from ansible.module_utils.basic import env_fallback
+import os
 
 try:
+    if not os.getenv('VMWARE_ENABLE_TURBO', False):
+        raise ImportError()
+
     from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
         EmbeddedModuleFailure,
     )

--- a/plugins/modules/vcenter_vm_hardware_info.py
+++ b/plugins/modules/vcenter_vm_hardware_info.py
@@ -108,7 +108,7 @@ from ansible.module_utils.basic import env_fallback
 import os
 
 try:
-    if not os.getenv('VMWARE_ENABLE_TURBO', False):
+    if not os.getenv("VMWARE_ENABLE_TURBO", False):
         raise ImportError()
 
     from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (

--- a/plugins/modules/vcenter_vm_hardware_info.py
+++ b/plugins/modules/vcenter_vm_hardware_info.py
@@ -107,20 +107,21 @@ PAYLOAD_FORMAT = {
 from ansible.module_utils.basic import env_fallback
 import os
 
-try:
-    if not os.getenv("VMWARE_ENABLE_TURBO", False):
-        raise ImportError()
+if os.getenv("VMWARE_ENABLE_TURBO", False):
+    try:
+        from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
+            EmbeddedModuleFailure,
+        )
+        from ansible_collections.cloud.common.plugins.module_utils.turbo.module import (
+            AnsibleTurboModule as AnsibleModule,
+        )
 
-    from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
-        EmbeddedModuleFailure,
-    )
-    from ansible_collections.cloud.common.plugins.module_utils.turbo.module import (
-        AnsibleTurboModule as AnsibleModule,
-    )
-
-    AnsibleModule.collection_name = "vmware.vmware_rest"
-except ImportError:
+        AnsibleModule.collection_name = "vmware.vmware_rest"
+    except ImportError:
+        from ansible.module_utils.basic import AnsibleModule
+else:
     from ansible.module_utils.basic import AnsibleModule
+
 from ansible_collections.vmware.vmware_rest.plugins.module_utils.vmware_rest import (
     gen_args,
     open_session,

--- a/plugins/modules/vcenter_vm_hardware_info.py
+++ b/plugins/modules/vcenter_vm_hardware_info.py
@@ -105,8 +105,12 @@ PAYLOAD_FORMAT = {
 }  # pylint: disable=line-too-long
 
 from ansible.module_utils.basic import env_fallback
+import os
 
 try:
+    if not os.getenv('VMWARE_ENABLE_TURBO', False):
+        raise ImportError()
+
     from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
         EmbeddedModuleFailure,
     )

--- a/plugins/modules/vcenter_vm_hardware_memory.py
+++ b/plugins/modules/vcenter_vm_hardware_memory.py
@@ -152,7 +152,7 @@ from ansible.module_utils.basic import env_fallback
 import os
 
 try:
-    if not os.getenv('VMWARE_ENABLE_TURBO', False):
+    if not os.getenv("VMWARE_ENABLE_TURBO", False):
         raise ImportError()
 
     from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (

--- a/plugins/modules/vcenter_vm_hardware_memory.py
+++ b/plugins/modules/vcenter_vm_hardware_memory.py
@@ -149,8 +149,12 @@ PAYLOAD_FORMAT = {
 }  # pylint: disable=line-too-long
 
 from ansible.module_utils.basic import env_fallback
+import os
 
 try:
+    if not os.getenv('VMWARE_ENABLE_TURBO', False):
+        raise ImportError()
+
     from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
         EmbeddedModuleFailure,
     )

--- a/plugins/modules/vcenter_vm_hardware_memory.py
+++ b/plugins/modules/vcenter_vm_hardware_memory.py
@@ -151,20 +151,21 @@ PAYLOAD_FORMAT = {
 from ansible.module_utils.basic import env_fallback
 import os
 
-try:
-    if not os.getenv("VMWARE_ENABLE_TURBO", False):
-        raise ImportError()
+if os.getenv("VMWARE_ENABLE_TURBO", False):
+    try:
+        from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
+            EmbeddedModuleFailure,
+        )
+        from ansible_collections.cloud.common.plugins.module_utils.turbo.module import (
+            AnsibleTurboModule as AnsibleModule,
+        )
 
-    from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
-        EmbeddedModuleFailure,
-    )
-    from ansible_collections.cloud.common.plugins.module_utils.turbo.module import (
-        AnsibleTurboModule as AnsibleModule,
-    )
-
-    AnsibleModule.collection_name = "vmware.vmware_rest"
-except ImportError:
+        AnsibleModule.collection_name = "vmware.vmware_rest"
+    except ImportError:
+        from ansible.module_utils.basic import AnsibleModule
+else:
     from ansible.module_utils.basic import AnsibleModule
+
 from ansible_collections.vmware.vmware_rest.plugins.module_utils.vmware_rest import (
     open_session,
     prepare_payload,

--- a/plugins/modules/vcenter_vm_hardware_memory_info.py
+++ b/plugins/modules/vcenter_vm_hardware_memory_info.py
@@ -116,7 +116,7 @@ from ansible.module_utils.basic import env_fallback
 import os
 
 try:
-    if not os.getenv('VMWARE_ENABLE_TURBO', False):
+    if not os.getenv("VMWARE_ENABLE_TURBO", False):
         raise ImportError()
 
     from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (

--- a/plugins/modules/vcenter_vm_hardware_memory_info.py
+++ b/plugins/modules/vcenter_vm_hardware_memory_info.py
@@ -115,20 +115,21 @@ PAYLOAD_FORMAT = {
 from ansible.module_utils.basic import env_fallback
 import os
 
-try:
-    if not os.getenv("VMWARE_ENABLE_TURBO", False):
-        raise ImportError()
+if os.getenv("VMWARE_ENABLE_TURBO", False):
+    try:
+        from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
+            EmbeddedModuleFailure,
+        )
+        from ansible_collections.cloud.common.plugins.module_utils.turbo.module import (
+            AnsibleTurboModule as AnsibleModule,
+        )
 
-    from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
-        EmbeddedModuleFailure,
-    )
-    from ansible_collections.cloud.common.plugins.module_utils.turbo.module import (
-        AnsibleTurboModule as AnsibleModule,
-    )
-
-    AnsibleModule.collection_name = "vmware.vmware_rest"
-except ImportError:
+        AnsibleModule.collection_name = "vmware.vmware_rest"
+    except ImportError:
+        from ansible.module_utils.basic import AnsibleModule
+else:
     from ansible.module_utils.basic import AnsibleModule
+
 from ansible_collections.vmware.vmware_rest.plugins.module_utils.vmware_rest import (
     gen_args,
     open_session,

--- a/plugins/modules/vcenter_vm_hardware_memory_info.py
+++ b/plugins/modules/vcenter_vm_hardware_memory_info.py
@@ -113,8 +113,12 @@ PAYLOAD_FORMAT = {
 }  # pylint: disable=line-too-long
 
 from ansible.module_utils.basic import env_fallback
+import os
 
 try:
+    if not os.getenv('VMWARE_ENABLE_TURBO', False):
+        raise ImportError()
+
     from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
         EmbeddedModuleFailure,
     )

--- a/plugins/modules/vcenter_vm_hardware_parallel.py
+++ b/plugins/modules/vcenter_vm_hardware_parallel.py
@@ -196,7 +196,7 @@ from ansible.module_utils.basic import env_fallback
 import os
 
 try:
-    if not os.getenv('VMWARE_ENABLE_TURBO', False):
+    if not os.getenv("VMWARE_ENABLE_TURBO", False):
         raise ImportError()
 
     from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (

--- a/plugins/modules/vcenter_vm_hardware_parallel.py
+++ b/plugins/modules/vcenter_vm_hardware_parallel.py
@@ -193,8 +193,12 @@ PAYLOAD_FORMAT = {
 }  # pylint: disable=line-too-long
 
 from ansible.module_utils.basic import env_fallback
+import os
 
 try:
+    if not os.getenv('VMWARE_ENABLE_TURBO', False):
+        raise ImportError()
+
     from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
         EmbeddedModuleFailure,
     )

--- a/plugins/modules/vcenter_vm_hardware_parallel.py
+++ b/plugins/modules/vcenter_vm_hardware_parallel.py
@@ -195,20 +195,21 @@ PAYLOAD_FORMAT = {
 from ansible.module_utils.basic import env_fallback
 import os
 
-try:
-    if not os.getenv("VMWARE_ENABLE_TURBO", False):
-        raise ImportError()
+if os.getenv("VMWARE_ENABLE_TURBO", False):
+    try:
+        from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
+            EmbeddedModuleFailure,
+        )
+        from ansible_collections.cloud.common.plugins.module_utils.turbo.module import (
+            AnsibleTurboModule as AnsibleModule,
+        )
 
-    from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
-        EmbeddedModuleFailure,
-    )
-    from ansible_collections.cloud.common.plugins.module_utils.turbo.module import (
-        AnsibleTurboModule as AnsibleModule,
-    )
-
-    AnsibleModule.collection_name = "vmware.vmware_rest"
-except ImportError:
+        AnsibleModule.collection_name = "vmware.vmware_rest"
+    except ImportError:
+        from ansible.module_utils.basic import AnsibleModule
+else:
     from ansible.module_utils.basic import AnsibleModule
+
 from ansible_collections.vmware.vmware_rest.plugins.module_utils.vmware_rest import (
     exists,
     gen_args,

--- a/plugins/modules/vcenter_vm_hardware_parallel_info.py
+++ b/plugins/modules/vcenter_vm_hardware_parallel_info.py
@@ -121,20 +121,21 @@ PAYLOAD_FORMAT = {
 from ansible.module_utils.basic import env_fallback
 import os
 
-try:
-    if not os.getenv("VMWARE_ENABLE_TURBO", False):
-        raise ImportError()
+if os.getenv("VMWARE_ENABLE_TURBO", False):
+    try:
+        from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
+            EmbeddedModuleFailure,
+        )
+        from ansible_collections.cloud.common.plugins.module_utils.turbo.module import (
+            AnsibleTurboModule as AnsibleModule,
+        )
 
-    from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
-        EmbeddedModuleFailure,
-    )
-    from ansible_collections.cloud.common.plugins.module_utils.turbo.module import (
-        AnsibleTurboModule as AnsibleModule,
-    )
-
-    AnsibleModule.collection_name = "vmware.vmware_rest"
-except ImportError:
+        AnsibleModule.collection_name = "vmware.vmware_rest"
+    except ImportError:
+        from ansible.module_utils.basic import AnsibleModule
+else:
     from ansible.module_utils.basic import AnsibleModule
+
 from ansible_collections.vmware.vmware_rest.plugins.module_utils.vmware_rest import (
     build_full_device_list,
     exists,

--- a/plugins/modules/vcenter_vm_hardware_parallel_info.py
+++ b/plugins/modules/vcenter_vm_hardware_parallel_info.py
@@ -122,7 +122,7 @@ from ansible.module_utils.basic import env_fallback
 import os
 
 try:
-    if not os.getenv('VMWARE_ENABLE_TURBO', False):
+    if not os.getenv("VMWARE_ENABLE_TURBO", False):
         raise ImportError()
 
     from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (

--- a/plugins/modules/vcenter_vm_hardware_parallel_info.py
+++ b/plugins/modules/vcenter_vm_hardware_parallel_info.py
@@ -119,8 +119,12 @@ PAYLOAD_FORMAT = {
 }  # pylint: disable=line-too-long
 
 from ansible.module_utils.basic import env_fallback
+import os
 
 try:
+    if not os.getenv('VMWARE_ENABLE_TURBO', False):
+        raise ImportError()
+
     from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
         EmbeddedModuleFailure,
     )

--- a/plugins/modules/vcenter_vm_hardware_serial.py
+++ b/plugins/modules/vcenter_vm_hardware_serial.py
@@ -270,8 +270,12 @@ PAYLOAD_FORMAT = {
 }  # pylint: disable=line-too-long
 
 from ansible.module_utils.basic import env_fallback
+import os
 
 try:
+    if not os.getenv('VMWARE_ENABLE_TURBO', False):
+        raise ImportError()
+
     from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
         EmbeddedModuleFailure,
     )

--- a/plugins/modules/vcenter_vm_hardware_serial.py
+++ b/plugins/modules/vcenter_vm_hardware_serial.py
@@ -272,20 +272,21 @@ PAYLOAD_FORMAT = {
 from ansible.module_utils.basic import env_fallback
 import os
 
-try:
-    if not os.getenv("VMWARE_ENABLE_TURBO", False):
-        raise ImportError()
+if os.getenv("VMWARE_ENABLE_TURBO", False):
+    try:
+        from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
+            EmbeddedModuleFailure,
+        )
+        from ansible_collections.cloud.common.plugins.module_utils.turbo.module import (
+            AnsibleTurboModule as AnsibleModule,
+        )
 
-    from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
-        EmbeddedModuleFailure,
-    )
-    from ansible_collections.cloud.common.plugins.module_utils.turbo.module import (
-        AnsibleTurboModule as AnsibleModule,
-    )
-
-    AnsibleModule.collection_name = "vmware.vmware_rest"
-except ImportError:
+        AnsibleModule.collection_name = "vmware.vmware_rest"
+    except ImportError:
+        from ansible.module_utils.basic import AnsibleModule
+else:
     from ansible.module_utils.basic import AnsibleModule
+
 from ansible_collections.vmware.vmware_rest.plugins.module_utils.vmware_rest import (
     exists,
     gen_args,

--- a/plugins/modules/vcenter_vm_hardware_serial.py
+++ b/plugins/modules/vcenter_vm_hardware_serial.py
@@ -273,7 +273,7 @@ from ansible.module_utils.basic import env_fallback
 import os
 
 try:
-    if not os.getenv('VMWARE_ENABLE_TURBO', False):
+    if not os.getenv("VMWARE_ENABLE_TURBO", False):
         raise ImportError()
 
     from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (

--- a/plugins/modules/vcenter_vm_hardware_serial_info.py
+++ b/plugins/modules/vcenter_vm_hardware_serial_info.py
@@ -139,8 +139,12 @@ PAYLOAD_FORMAT = {
 }  # pylint: disable=line-too-long
 
 from ansible.module_utils.basic import env_fallback
+import os
 
 try:
+    if not os.getenv('VMWARE_ENABLE_TURBO', False):
+        raise ImportError()
+
     from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
         EmbeddedModuleFailure,
     )

--- a/plugins/modules/vcenter_vm_hardware_serial_info.py
+++ b/plugins/modules/vcenter_vm_hardware_serial_info.py
@@ -141,20 +141,21 @@ PAYLOAD_FORMAT = {
 from ansible.module_utils.basic import env_fallback
 import os
 
-try:
-    if not os.getenv("VMWARE_ENABLE_TURBO", False):
-        raise ImportError()
+if os.getenv("VMWARE_ENABLE_TURBO", False):
+    try:
+        from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
+            EmbeddedModuleFailure,
+        )
+        from ansible_collections.cloud.common.plugins.module_utils.turbo.module import (
+            AnsibleTurboModule as AnsibleModule,
+        )
 
-    from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
-        EmbeddedModuleFailure,
-    )
-    from ansible_collections.cloud.common.plugins.module_utils.turbo.module import (
-        AnsibleTurboModule as AnsibleModule,
-    )
-
-    AnsibleModule.collection_name = "vmware.vmware_rest"
-except ImportError:
+        AnsibleModule.collection_name = "vmware.vmware_rest"
+    except ImportError:
+        from ansible.module_utils.basic import AnsibleModule
+else:
     from ansible.module_utils.basic import AnsibleModule
+
 from ansible_collections.vmware.vmware_rest.plugins.module_utils.vmware_rest import (
     build_full_device_list,
     exists,

--- a/plugins/modules/vcenter_vm_hardware_serial_info.py
+++ b/plugins/modules/vcenter_vm_hardware_serial_info.py
@@ -142,7 +142,7 @@ from ansible.module_utils.basic import env_fallback
 import os
 
 try:
-    if not os.getenv('VMWARE_ENABLE_TURBO', False):
+    if not os.getenv("VMWARE_ENABLE_TURBO", False):
         raise ImportError()
 
     from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (

--- a/plugins/modules/vcenter_vm_info.py
+++ b/plugins/modules/vcenter_vm_info.py
@@ -330,8 +330,12 @@ PAYLOAD_FORMAT = {
 }  # pylint: disable=line-too-long
 
 from ansible.module_utils.basic import env_fallback
+import os
 
 try:
+    if not os.getenv('VMWARE_ENABLE_TURBO', False):
+        raise ImportError()
+
     from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
         EmbeddedModuleFailure,
     )

--- a/plugins/modules/vcenter_vm_info.py
+++ b/plugins/modules/vcenter_vm_info.py
@@ -332,20 +332,21 @@ PAYLOAD_FORMAT = {
 from ansible.module_utils.basic import env_fallback
 import os
 
-try:
-    if not os.getenv("VMWARE_ENABLE_TURBO", False):
-        raise ImportError()
+if os.getenv("VMWARE_ENABLE_TURBO", False):
+    try:
+        from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
+            EmbeddedModuleFailure,
+        )
+        from ansible_collections.cloud.common.plugins.module_utils.turbo.module import (
+            AnsibleTurboModule as AnsibleModule,
+        )
 
-    from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
-        EmbeddedModuleFailure,
-    )
-    from ansible_collections.cloud.common.plugins.module_utils.turbo.module import (
-        AnsibleTurboModule as AnsibleModule,
-    )
-
-    AnsibleModule.collection_name = "vmware.vmware_rest"
-except ImportError:
+        AnsibleModule.collection_name = "vmware.vmware_rest"
+    except ImportError:
+        from ansible.module_utils.basic import AnsibleModule
+else:
     from ansible.module_utils.basic import AnsibleModule
+
 from ansible_collections.vmware.vmware_rest.plugins.module_utils.vmware_rest import (
     build_full_device_list,
     exists,

--- a/plugins/modules/vcenter_vm_info.py
+++ b/plugins/modules/vcenter_vm_info.py
@@ -333,7 +333,7 @@ from ansible.module_utils.basic import env_fallback
 import os
 
 try:
-    if not os.getenv('VMWARE_ENABLE_TURBO', False):
+    if not os.getenv("VMWARE_ENABLE_TURBO", False):
         raise ImportError()
 
     from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (

--- a/plugins/modules/vcenter_vm_libraryitem_info.py
+++ b/plugins/modules/vcenter_vm_libraryitem_info.py
@@ -116,7 +116,7 @@ from ansible.module_utils.basic import env_fallback
 import os
 
 try:
-    if not os.getenv('VMWARE_ENABLE_TURBO', False):
+    if not os.getenv("VMWARE_ENABLE_TURBO", False):
         raise ImportError()
 
     from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (

--- a/plugins/modules/vcenter_vm_libraryitem_info.py
+++ b/plugins/modules/vcenter_vm_libraryitem_info.py
@@ -115,20 +115,21 @@ PAYLOAD_FORMAT = {
 from ansible.module_utils.basic import env_fallback
 import os
 
-try:
-    if not os.getenv("VMWARE_ENABLE_TURBO", False):
-        raise ImportError()
+if os.getenv("VMWARE_ENABLE_TURBO", False):
+    try:
+        from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
+            EmbeddedModuleFailure,
+        )
+        from ansible_collections.cloud.common.plugins.module_utils.turbo.module import (
+            AnsibleTurboModule as AnsibleModule,
+        )
 
-    from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
-        EmbeddedModuleFailure,
-    )
-    from ansible_collections.cloud.common.plugins.module_utils.turbo.module import (
-        AnsibleTurboModule as AnsibleModule,
-    )
-
-    AnsibleModule.collection_name = "vmware.vmware_rest"
-except ImportError:
+        AnsibleModule.collection_name = "vmware.vmware_rest"
+    except ImportError:
+        from ansible.module_utils.basic import AnsibleModule
+else:
     from ansible.module_utils.basic import AnsibleModule
+
 from ansible_collections.vmware.vmware_rest.plugins.module_utils.vmware_rest import (
     gen_args,
     open_session,

--- a/plugins/modules/vcenter_vm_libraryitem_info.py
+++ b/plugins/modules/vcenter_vm_libraryitem_info.py
@@ -113,8 +113,12 @@ PAYLOAD_FORMAT = {
 }  # pylint: disable=line-too-long
 
 from ansible.module_utils.basic import env_fallback
+import os
 
 try:
+    if not os.getenv('VMWARE_ENABLE_TURBO', False):
+        raise ImportError()
+
     from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
         EmbeddedModuleFailure,
     )

--- a/plugins/modules/vcenter_vm_power.py
+++ b/plugins/modules/vcenter_vm_power.py
@@ -243,7 +243,7 @@ from ansible.module_utils.basic import env_fallback
 import os
 
 try:
-    if not os.getenv('VMWARE_ENABLE_TURBO', False):
+    if not os.getenv("VMWARE_ENABLE_TURBO", False):
         raise ImportError()
 
     from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (

--- a/plugins/modules/vcenter_vm_power.py
+++ b/plugins/modules/vcenter_vm_power.py
@@ -242,20 +242,21 @@ PAYLOAD_FORMAT = {
 from ansible.module_utils.basic import env_fallback
 import os
 
-try:
-    if not os.getenv("VMWARE_ENABLE_TURBO", False):
-        raise ImportError()
+if os.getenv("VMWARE_ENABLE_TURBO", False):
+    try:
+        from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
+            EmbeddedModuleFailure,
+        )
+        from ansible_collections.cloud.common.plugins.module_utils.turbo.module import (
+            AnsibleTurboModule as AnsibleModule,
+        )
 
-    from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
-        EmbeddedModuleFailure,
-    )
-    from ansible_collections.cloud.common.plugins.module_utils.turbo.module import (
-        AnsibleTurboModule as AnsibleModule,
-    )
-
-    AnsibleModule.collection_name = "vmware.vmware_rest"
-except ImportError:
+        AnsibleModule.collection_name = "vmware.vmware_rest"
+    except ImportError:
+        from ansible.module_utils.basic import AnsibleModule
+else:
     from ansible.module_utils.basic import AnsibleModule
+
 from ansible_collections.vmware.vmware_rest.plugins.module_utils.vmware_rest import (
     exists,
     gen_args,

--- a/plugins/modules/vcenter_vm_power.py
+++ b/plugins/modules/vcenter_vm_power.py
@@ -240,8 +240,12 @@ PAYLOAD_FORMAT = {
 }  # pylint: disable=line-too-long
 
 from ansible.module_utils.basic import env_fallback
+import os
 
 try:
+    if not os.getenv('VMWARE_ENABLE_TURBO', False):
+        raise ImportError()
+
     from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
         EmbeddedModuleFailure,
     )

--- a/plugins/modules/vcenter_vm_power_info.py
+++ b/plugins/modules/vcenter_vm_power_info.py
@@ -108,8 +108,12 @@ PAYLOAD_FORMAT = {
 }  # pylint: disable=line-too-long
 
 from ansible.module_utils.basic import env_fallback
+import os
 
 try:
+    if not os.getenv('VMWARE_ENABLE_TURBO', False):
+        raise ImportError()
+
     from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
         EmbeddedModuleFailure,
     )

--- a/plugins/modules/vcenter_vm_power_info.py
+++ b/plugins/modules/vcenter_vm_power_info.py
@@ -111,7 +111,7 @@ from ansible.module_utils.basic import env_fallback
 import os
 
 try:
-    if not os.getenv('VMWARE_ENABLE_TURBO', False):
+    if not os.getenv("VMWARE_ENABLE_TURBO", False):
         raise ImportError()
 
     from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (

--- a/plugins/modules/vcenter_vm_power_info.py
+++ b/plugins/modules/vcenter_vm_power_info.py
@@ -110,20 +110,21 @@ PAYLOAD_FORMAT = {
 from ansible.module_utils.basic import env_fallback
 import os
 
-try:
-    if not os.getenv("VMWARE_ENABLE_TURBO", False):
-        raise ImportError()
+if os.getenv("VMWARE_ENABLE_TURBO", False):
+    try:
+        from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
+            EmbeddedModuleFailure,
+        )
+        from ansible_collections.cloud.common.plugins.module_utils.turbo.module import (
+            AnsibleTurboModule as AnsibleModule,
+        )
 
-    from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
-        EmbeddedModuleFailure,
-    )
-    from ansible_collections.cloud.common.plugins.module_utils.turbo.module import (
-        AnsibleTurboModule as AnsibleModule,
-    )
-
-    AnsibleModule.collection_name = "vmware.vmware_rest"
-except ImportError:
+        AnsibleModule.collection_name = "vmware.vmware_rest"
+    except ImportError:
+        from ansible.module_utils.basic import AnsibleModule
+else:
     from ansible.module_utils.basic import AnsibleModule
+
 from ansible_collections.vmware.vmware_rest.plugins.module_utils.vmware_rest import (
     gen_args,
     open_session,

--- a/plugins/modules/vcenter_vm_storage_policy.py
+++ b/plugins/modules/vcenter_vm_storage_policy.py
@@ -159,8 +159,12 @@ PAYLOAD_FORMAT = {
 }  # pylint: disable=line-too-long
 
 from ansible.module_utils.basic import env_fallback
+import os
 
 try:
+    if not os.getenv('VMWARE_ENABLE_TURBO', False):
+        raise ImportError()
+
     from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
         EmbeddedModuleFailure,
     )

--- a/plugins/modules/vcenter_vm_storage_policy.py
+++ b/plugins/modules/vcenter_vm_storage_policy.py
@@ -162,7 +162,7 @@ from ansible.module_utils.basic import env_fallback
 import os
 
 try:
-    if not os.getenv('VMWARE_ENABLE_TURBO', False):
+    if not os.getenv("VMWARE_ENABLE_TURBO", False):
         raise ImportError()
 
     from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (

--- a/plugins/modules/vcenter_vm_storage_policy.py
+++ b/plugins/modules/vcenter_vm_storage_policy.py
@@ -161,20 +161,21 @@ PAYLOAD_FORMAT = {
 from ansible.module_utils.basic import env_fallback
 import os
 
-try:
-    if not os.getenv("VMWARE_ENABLE_TURBO", False):
-        raise ImportError()
+if os.getenv("VMWARE_ENABLE_TURBO", False):
+    try:
+        from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
+            EmbeddedModuleFailure,
+        )
+        from ansible_collections.cloud.common.plugins.module_utils.turbo.module import (
+            AnsibleTurboModule as AnsibleModule,
+        )
 
-    from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
-        EmbeddedModuleFailure,
-    )
-    from ansible_collections.cloud.common.plugins.module_utils.turbo.module import (
-        AnsibleTurboModule as AnsibleModule,
-    )
-
-    AnsibleModule.collection_name = "vmware.vmware_rest"
-except ImportError:
+        AnsibleModule.collection_name = "vmware.vmware_rest"
+    except ImportError:
+        from ansible.module_utils.basic import AnsibleModule
+else:
     from ansible.module_utils.basic import AnsibleModule
+
 from ansible_collections.vmware.vmware_rest.plugins.module_utils.vmware_rest import (
     open_session,
     prepare_payload,

--- a/plugins/modules/vcenter_vm_storage_policy_compliance.py
+++ b/plugins/modules/vcenter_vm_storage_policy_compliance.py
@@ -116,20 +116,21 @@ PAYLOAD_FORMAT = {
 from ansible.module_utils.basic import env_fallback
 import os
 
-try:
-    if not os.getenv("VMWARE_ENABLE_TURBO", False):
-        raise ImportError()
+if os.getenv("VMWARE_ENABLE_TURBO", False):
+    try:
+        from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
+            EmbeddedModuleFailure,
+        )
+        from ansible_collections.cloud.common.plugins.module_utils.turbo.module import (
+            AnsibleTurboModule as AnsibleModule,
+        )
 
-    from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
-        EmbeddedModuleFailure,
-    )
-    from ansible_collections.cloud.common.plugins.module_utils.turbo.module import (
-        AnsibleTurboModule as AnsibleModule,
-    )
-
-    AnsibleModule.collection_name = "vmware.vmware_rest"
-except ImportError:
+        AnsibleModule.collection_name = "vmware.vmware_rest"
+    except ImportError:
+        from ansible.module_utils.basic import AnsibleModule
+else:
     from ansible.module_utils.basic import AnsibleModule
+
 from ansible_collections.vmware.vmware_rest.plugins.module_utils.vmware_rest import (
     exists,
     gen_args,

--- a/plugins/modules/vcenter_vm_storage_policy_compliance.py
+++ b/plugins/modules/vcenter_vm_storage_policy_compliance.py
@@ -117,7 +117,7 @@ from ansible.module_utils.basic import env_fallback
 import os
 
 try:
-    if not os.getenv('VMWARE_ENABLE_TURBO', False):
+    if not os.getenv("VMWARE_ENABLE_TURBO", False):
         raise ImportError()
 
     from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (

--- a/plugins/modules/vcenter_vm_storage_policy_compliance.py
+++ b/plugins/modules/vcenter_vm_storage_policy_compliance.py
@@ -114,8 +114,12 @@ PAYLOAD_FORMAT = {
 }  # pylint: disable=line-too-long
 
 from ansible.module_utils.basic import env_fallback
+import os
 
 try:
+    if not os.getenv('VMWARE_ENABLE_TURBO', False):
+        raise ImportError()
+
     from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
         EmbeddedModuleFailure,
     )

--- a/plugins/modules/vcenter_vm_storage_policy_compliance_info.py
+++ b/plugins/modules/vcenter_vm_storage_policy_compliance_info.py
@@ -119,7 +119,7 @@ from ansible.module_utils.basic import env_fallback
 import os
 
 try:
-    if not os.getenv('VMWARE_ENABLE_TURBO', False):
+    if not os.getenv("VMWARE_ENABLE_TURBO", False):
         raise ImportError()
 
     from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (

--- a/plugins/modules/vcenter_vm_storage_policy_compliance_info.py
+++ b/plugins/modules/vcenter_vm_storage_policy_compliance_info.py
@@ -118,20 +118,21 @@ PAYLOAD_FORMAT = {
 from ansible.module_utils.basic import env_fallback
 import os
 
-try:
-    if not os.getenv("VMWARE_ENABLE_TURBO", False):
-        raise ImportError()
+if os.getenv("VMWARE_ENABLE_TURBO", False):
+    try:
+        from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
+            EmbeddedModuleFailure,
+        )
+        from ansible_collections.cloud.common.plugins.module_utils.turbo.module import (
+            AnsibleTurboModule as AnsibleModule,
+        )
 
-    from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
-        EmbeddedModuleFailure,
-    )
-    from ansible_collections.cloud.common.plugins.module_utils.turbo.module import (
-        AnsibleTurboModule as AnsibleModule,
-    )
-
-    AnsibleModule.collection_name = "vmware.vmware_rest"
-except ImportError:
+        AnsibleModule.collection_name = "vmware.vmware_rest"
+    except ImportError:
+        from ansible.module_utils.basic import AnsibleModule
+else:
     from ansible.module_utils.basic import AnsibleModule
+
 from ansible_collections.vmware.vmware_rest.plugins.module_utils.vmware_rest import (
     gen_args,
     open_session,

--- a/plugins/modules/vcenter_vm_storage_policy_compliance_info.py
+++ b/plugins/modules/vcenter_vm_storage_policy_compliance_info.py
@@ -116,8 +116,12 @@ PAYLOAD_FORMAT = {
 }  # pylint: disable=line-too-long
 
 from ansible.module_utils.basic import env_fallback
+import os
 
 try:
+    if not os.getenv('VMWARE_ENABLE_TURBO', False):
+        raise ImportError()
+
     from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
         EmbeddedModuleFailure,
     )

--- a/plugins/modules/vcenter_vm_storage_policy_info.py
+++ b/plugins/modules/vcenter_vm_storage_policy_info.py
@@ -113,7 +113,7 @@ from ansible.module_utils.basic import env_fallback
 import os
 
 try:
-    if not os.getenv('VMWARE_ENABLE_TURBO', False):
+    if not os.getenv("VMWARE_ENABLE_TURBO", False):
         raise ImportError()
 
     from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (

--- a/plugins/modules/vcenter_vm_storage_policy_info.py
+++ b/plugins/modules/vcenter_vm_storage_policy_info.py
@@ -110,8 +110,12 @@ PAYLOAD_FORMAT = {
 }  # pylint: disable=line-too-long
 
 from ansible.module_utils.basic import env_fallback
+import os
 
 try:
+    if not os.getenv('VMWARE_ENABLE_TURBO', False):
+        raise ImportError()
+
     from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
         EmbeddedModuleFailure,
     )

--- a/plugins/modules/vcenter_vm_storage_policy_info.py
+++ b/plugins/modules/vcenter_vm_storage_policy_info.py
@@ -112,20 +112,21 @@ PAYLOAD_FORMAT = {
 from ansible.module_utils.basic import env_fallback
 import os
 
-try:
-    if not os.getenv("VMWARE_ENABLE_TURBO", False):
-        raise ImportError()
+if os.getenv("VMWARE_ENABLE_TURBO", False):
+    try:
+        from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
+            EmbeddedModuleFailure,
+        )
+        from ansible_collections.cloud.common.plugins.module_utils.turbo.module import (
+            AnsibleTurboModule as AnsibleModule,
+        )
 
-    from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
-        EmbeddedModuleFailure,
-    )
-    from ansible_collections.cloud.common.plugins.module_utils.turbo.module import (
-        AnsibleTurboModule as AnsibleModule,
-    )
-
-    AnsibleModule.collection_name = "vmware.vmware_rest"
-except ImportError:
+        AnsibleModule.collection_name = "vmware.vmware_rest"
+    except ImportError:
+        from ansible.module_utils.basic import AnsibleModule
+else:
     from ansible.module_utils.basic import AnsibleModule
+
 from ansible_collections.vmware.vmware_rest.plugins.module_utils.vmware_rest import (
     gen_args,
     open_session,

--- a/plugins/modules/vcenter_vm_tools.py
+++ b/plugins/modules/vcenter_vm_tools.py
@@ -163,8 +163,12 @@ PAYLOAD_FORMAT = {
 }  # pylint: disable=line-too-long
 
 from ansible.module_utils.basic import env_fallback
+import os
 
 try:
+    if not os.getenv('VMWARE_ENABLE_TURBO', False):
+        raise ImportError()
+
     from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
         EmbeddedModuleFailure,
     )

--- a/plugins/modules/vcenter_vm_tools.py
+++ b/plugins/modules/vcenter_vm_tools.py
@@ -166,7 +166,7 @@ from ansible.module_utils.basic import env_fallback
 import os
 
 try:
-    if not os.getenv('VMWARE_ENABLE_TURBO', False):
+    if not os.getenv("VMWARE_ENABLE_TURBO", False):
         raise ImportError()
 
     from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (

--- a/plugins/modules/vcenter_vm_tools.py
+++ b/plugins/modules/vcenter_vm_tools.py
@@ -165,20 +165,21 @@ PAYLOAD_FORMAT = {
 from ansible.module_utils.basic import env_fallback
 import os
 
-try:
-    if not os.getenv("VMWARE_ENABLE_TURBO", False):
-        raise ImportError()
+if os.getenv("VMWARE_ENABLE_TURBO", False):
+    try:
+        from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
+            EmbeddedModuleFailure,
+        )
+        from ansible_collections.cloud.common.plugins.module_utils.turbo.module import (
+            AnsibleTurboModule as AnsibleModule,
+        )
 
-    from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
-        EmbeddedModuleFailure,
-    )
-    from ansible_collections.cloud.common.plugins.module_utils.turbo.module import (
-        AnsibleTurboModule as AnsibleModule,
-    )
-
-    AnsibleModule.collection_name = "vmware.vmware_rest"
-except ImportError:
+        AnsibleModule.collection_name = "vmware.vmware_rest"
+    except ImportError:
+        from ansible.module_utils.basic import AnsibleModule
+else:
     from ansible.module_utils.basic import AnsibleModule
+
 from ansible_collections.vmware.vmware_rest.plugins.module_utils.vmware_rest import (
     exists,
     gen_args,

--- a/plugins/modules/vcenter_vm_tools_info.py
+++ b/plugins/modules/vcenter_vm_tools_info.py
@@ -175,20 +175,21 @@ PAYLOAD_FORMAT = {
 from ansible.module_utils.basic import env_fallback
 import os
 
-try:
-    if not os.getenv("VMWARE_ENABLE_TURBO", False):
-        raise ImportError()
+if os.getenv("VMWARE_ENABLE_TURBO", False):
+    try:
+        from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
+            EmbeddedModuleFailure,
+        )
+        from ansible_collections.cloud.common.plugins.module_utils.turbo.module import (
+            AnsibleTurboModule as AnsibleModule,
+        )
 
-    from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
-        EmbeddedModuleFailure,
-    )
-    from ansible_collections.cloud.common.plugins.module_utils.turbo.module import (
-        AnsibleTurboModule as AnsibleModule,
-    )
-
-    AnsibleModule.collection_name = "vmware.vmware_rest"
-except ImportError:
+        AnsibleModule.collection_name = "vmware.vmware_rest"
+    except ImportError:
+        from ansible.module_utils.basic import AnsibleModule
+else:
     from ansible.module_utils.basic import AnsibleModule
+
 from ansible_collections.vmware.vmware_rest.plugins.module_utils.vmware_rest import (
     gen_args,
     open_session,

--- a/plugins/modules/vcenter_vm_tools_info.py
+++ b/plugins/modules/vcenter_vm_tools_info.py
@@ -173,8 +173,12 @@ PAYLOAD_FORMAT = {
 }  # pylint: disable=line-too-long
 
 from ansible.module_utils.basic import env_fallback
+import os
 
 try:
+    if not os.getenv('VMWARE_ENABLE_TURBO', False):
+        raise ImportError()
+
     from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
         EmbeddedModuleFailure,
     )

--- a/plugins/modules/vcenter_vm_tools_info.py
+++ b/plugins/modules/vcenter_vm_tools_info.py
@@ -176,7 +176,7 @@ from ansible.module_utils.basic import env_fallback
 import os
 
 try:
-    if not os.getenv('VMWARE_ENABLE_TURBO', False):
+    if not os.getenv("VMWARE_ENABLE_TURBO", False):
         raise ImportError()
 
     from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (

--- a/plugins/modules/vcenter_vm_tools_installer.py
+++ b/plugins/modules/vcenter_vm_tools_installer.py
@@ -146,8 +146,12 @@ PAYLOAD_FORMAT = {
 }  # pylint: disable=line-too-long
 
 from ansible.module_utils.basic import env_fallback
+import os
 
 try:
+    if not os.getenv('VMWARE_ENABLE_TURBO', False):
+        raise ImportError()
+
     from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
         EmbeddedModuleFailure,
     )

--- a/plugins/modules/vcenter_vm_tools_installer.py
+++ b/plugins/modules/vcenter_vm_tools_installer.py
@@ -148,20 +148,21 @@ PAYLOAD_FORMAT = {
 from ansible.module_utils.basic import env_fallback
 import os
 
-try:
-    if not os.getenv("VMWARE_ENABLE_TURBO", False):
-        raise ImportError()
+if os.getenv("VMWARE_ENABLE_TURBO", False):
+    try:
+        from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
+            EmbeddedModuleFailure,
+        )
+        from ansible_collections.cloud.common.plugins.module_utils.turbo.module import (
+            AnsibleTurboModule as AnsibleModule,
+        )
 
-    from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
-        EmbeddedModuleFailure,
-    )
-    from ansible_collections.cloud.common.plugins.module_utils.turbo.module import (
-        AnsibleTurboModule as AnsibleModule,
-    )
-
-    AnsibleModule.collection_name = "vmware.vmware_rest"
-except ImportError:
+        AnsibleModule.collection_name = "vmware.vmware_rest"
+    except ImportError:
+        from ansible.module_utils.basic import AnsibleModule
+else:
     from ansible.module_utils.basic import AnsibleModule
+
 from ansible_collections.vmware.vmware_rest.plugins.module_utils.vmware_rest import (
     exists,
     gen_args,

--- a/plugins/modules/vcenter_vm_tools_installer.py
+++ b/plugins/modules/vcenter_vm_tools_installer.py
@@ -149,7 +149,7 @@ from ansible.module_utils.basic import env_fallback
 import os
 
 try:
-    if not os.getenv('VMWARE_ENABLE_TURBO', False):
+    if not os.getenv("VMWARE_ENABLE_TURBO", False):
         raise ImportError()
 
     from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (

--- a/plugins/modules/vcenter_vm_tools_installer_info.py
+++ b/plugins/modules/vcenter_vm_tools_installer_info.py
@@ -131,20 +131,21 @@ PAYLOAD_FORMAT = {
 from ansible.module_utils.basic import env_fallback
 import os
 
-try:
-    if not os.getenv("VMWARE_ENABLE_TURBO", False):
-        raise ImportError()
+if os.getenv("VMWARE_ENABLE_TURBO", False):
+    try:
+        from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
+            EmbeddedModuleFailure,
+        )
+        from ansible_collections.cloud.common.plugins.module_utils.turbo.module import (
+            AnsibleTurboModule as AnsibleModule,
+        )
 
-    from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
-        EmbeddedModuleFailure,
-    )
-    from ansible_collections.cloud.common.plugins.module_utils.turbo.module import (
-        AnsibleTurboModule as AnsibleModule,
-    )
-
-    AnsibleModule.collection_name = "vmware.vmware_rest"
-except ImportError:
+        AnsibleModule.collection_name = "vmware.vmware_rest"
+    except ImportError:
+        from ansible.module_utils.basic import AnsibleModule
+else:
     from ansible.module_utils.basic import AnsibleModule
+
 from ansible_collections.vmware.vmware_rest.plugins.module_utils.vmware_rest import (
     gen_args,
     open_session,

--- a/plugins/modules/vcenter_vm_tools_installer_info.py
+++ b/plugins/modules/vcenter_vm_tools_installer_info.py
@@ -132,7 +132,7 @@ from ansible.module_utils.basic import env_fallback
 import os
 
 try:
-    if not os.getenv('VMWARE_ENABLE_TURBO', False):
+    if not os.getenv("VMWARE_ENABLE_TURBO", False):
         raise ImportError()
 
     from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (

--- a/plugins/modules/vcenter_vm_tools_installer_info.py
+++ b/plugins/modules/vcenter_vm_tools_installer_info.py
@@ -129,8 +129,12 @@ PAYLOAD_FORMAT = {
 }  # pylint: disable=line-too-long
 
 from ansible.module_utils.basic import env_fallback
+import os
 
 try:
+    if not os.getenv('VMWARE_ENABLE_TURBO', False):
+        raise ImportError()
+
     from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
         EmbeddedModuleFailure,
     )

--- a/plugins/modules/vcenter_vmtemplate_libraryitems.py
+++ b/plugins/modules/vcenter_vmtemplate_libraryitems.py
@@ -450,8 +450,12 @@ PAYLOAD_FORMAT = {
 }  # pylint: disable=line-too-long
 
 from ansible.module_utils.basic import env_fallback
+import os
 
 try:
+    if not os.getenv('VMWARE_ENABLE_TURBO', False):
+        raise ImportError()
+
     from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
         EmbeddedModuleFailure,
     )

--- a/plugins/modules/vcenter_vmtemplate_libraryitems.py
+++ b/plugins/modules/vcenter_vmtemplate_libraryitems.py
@@ -452,20 +452,21 @@ PAYLOAD_FORMAT = {
 from ansible.module_utils.basic import env_fallback
 import os
 
-try:
-    if not os.getenv("VMWARE_ENABLE_TURBO", False):
-        raise ImportError()
+if os.getenv("VMWARE_ENABLE_TURBO", False):
+    try:
+        from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
+            EmbeddedModuleFailure,
+        )
+        from ansible_collections.cloud.common.plugins.module_utils.turbo.module import (
+            AnsibleTurboModule as AnsibleModule,
+        )
 
-    from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
-        EmbeddedModuleFailure,
-    )
-    from ansible_collections.cloud.common.plugins.module_utils.turbo.module import (
-        AnsibleTurboModule as AnsibleModule,
-    )
-
-    AnsibleModule.collection_name = "vmware.vmware_rest"
-except ImportError:
+        AnsibleModule.collection_name = "vmware.vmware_rest"
+    except ImportError:
+        from ansible.module_utils.basic import AnsibleModule
+else:
     from ansible.module_utils.basic import AnsibleModule
+
 from ansible_collections.vmware.vmware_rest.plugins.module_utils.vmware_rest import (
     exists,
     gen_args,

--- a/plugins/modules/vcenter_vmtemplate_libraryitems.py
+++ b/plugins/modules/vcenter_vmtemplate_libraryitems.py
@@ -453,7 +453,7 @@ from ansible.module_utils.basic import env_fallback
 import os
 
 try:
-    if not os.getenv('VMWARE_ENABLE_TURBO', False):
+    if not os.getenv("VMWARE_ENABLE_TURBO", False):
         raise ImportError()
 
     from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (

--- a/plugins/modules/vcenter_vmtemplate_libraryitems_info.py
+++ b/plugins/modules/vcenter_vmtemplate_libraryitems_info.py
@@ -98,20 +98,21 @@ PAYLOAD_FORMAT = {
 from ansible.module_utils.basic import env_fallback
 import os
 
-try:
-    if not os.getenv("VMWARE_ENABLE_TURBO", False):
-        raise ImportError()
+if os.getenv("VMWARE_ENABLE_TURBO", False):
+    try:
+        from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
+            EmbeddedModuleFailure,
+        )
+        from ansible_collections.cloud.common.plugins.module_utils.turbo.module import (
+            AnsibleTurboModule as AnsibleModule,
+        )
 
-    from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
-        EmbeddedModuleFailure,
-    )
-    from ansible_collections.cloud.common.plugins.module_utils.turbo.module import (
-        AnsibleTurboModule as AnsibleModule,
-    )
-
-    AnsibleModule.collection_name = "vmware.vmware_rest"
-except ImportError:
+        AnsibleModule.collection_name = "vmware.vmware_rest"
+    except ImportError:
+        from ansible.module_utils.basic import AnsibleModule
+else:
     from ansible.module_utils.basic import AnsibleModule
+
 from ansible_collections.vmware.vmware_rest.plugins.module_utils.vmware_rest import (
     gen_args,
     open_session,

--- a/plugins/modules/vcenter_vmtemplate_libraryitems_info.py
+++ b/plugins/modules/vcenter_vmtemplate_libraryitems_info.py
@@ -96,8 +96,12 @@ PAYLOAD_FORMAT = {
 }  # pylint: disable=line-too-long
 
 from ansible.module_utils.basic import env_fallback
+import os
 
 try:
+    if not os.getenv('VMWARE_ENABLE_TURBO', False):
+        raise ImportError()
+
     from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
         EmbeddedModuleFailure,
     )

--- a/plugins/modules/vcenter_vmtemplate_libraryitems_info.py
+++ b/plugins/modules/vcenter_vmtemplate_libraryitems_info.py
@@ -99,7 +99,7 @@ from ansible.module_utils.basic import env_fallback
 import os
 
 try:
-    if not os.getenv('VMWARE_ENABLE_TURBO', False):
+    if not os.getenv("VMWARE_ENABLE_TURBO", False):
         raise ImportError()
 
     from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (


### PR DESCRIPTION
##### SUMMARY
This change will make the turbo server optional and disable it by default. This will slow down module execution but otherwise will not change the module behavior.

This is a user requested feature. However, with the recent ansible-core 2.19 changes it seems like now is a good time to implement this. We can add a statement saying the collection does not support turbo mode in 2.19+ and remove the statement if the upstream cloud.common collection works out all the issues.

Related issues: 
https://github.com/ansible-collections/vmware.vmware_rest/issues/499
https://github.com/ansible-collections/vmware.vmware_rest/issues/364

##### ISSUE TYPE
- Feature Pull Request
