### PR TITLE
disable turbo mode for lookup plugins by default

### DIFF
--- a/changelogs/fragments/604-disable-turbo-for-lookups.yml
+++ b/changelogs/fragments/604-disable-turbo-for-lookups.yml
@@ -1,0 +1,6 @@
+---
+major_changes:
+  - >-
+    lookups - disable turbo mode for lookup execution by default. Make it optional
+    to enable it using an environment variable
+    (https://github.com/ansible-collections/vmware.vmware_rest/issues/499)

--- a/plugins/lookup/cluster_moid.py
+++ b/plugins/lookup/cluster_moid.py
@@ -128,18 +128,43 @@ _raw:
     sample: domain-c1007
 """
 
+import os
+import asyncio
 
-from ansible_collections.cloud.common.plugins.plugin_utils.turbo.lookup import (
-    TurboLookupBase as LookupBase,
-)
+if os.getenv("VMWARE_ENABLE_TURBO", False):
+    from ansible_collections.cloud.common.plugins.plugin_utils.turbo.lookup import (
+        TurboLookupBase as LookupBase,
+    )
+else:
+    from ansible.plugins.lookup import LookupBase
+
 from ansible_collections.vmware.vmware_rest.plugins.plugin_utils.lookup import Lookup
 
 
 class LookupModule(LookupBase):
+    # needed for turbo mode
     async def _run(self, terms, variables, **kwargs):
         self.set_options(var_options=variables, direct=kwargs)
         self.set_option("object_type", "cluster")
         result = await Lookup.entry_point(terms, self._options)
         return [result]
 
-    run = _run if not hasattr(LookupBase, "run_on_daemon") else LookupBase.run_on_daemon
+    def _run_no_turbo(self, terms, variables, **kwargs):
+        self.set_options(var_options=variables, direct=kwargs)
+        self.set_option("object_type", "cluster")
+        current_loop = asyncio.new_event_loop()
+        try:
+            asyncio.set_event_loop(current_loop)
+            result = current_loop.run_until_complete(
+                Lookup.entry_point(terms, self._options)
+            )
+        finally:
+            current_loop.close()
+
+        return [result]
+
+    run = (
+        _run_no_turbo
+        if not hasattr(LookupBase, "run_on_daemon")
+        else LookupBase.run_on_daemon
+    )

--- a/plugins/lookup/cluster_moid.py
+++ b/plugins/lookup/cluster_moid.py
@@ -132,9 +132,12 @@ import os
 import asyncio
 
 if os.getenv("VMWARE_ENABLE_TURBO", False):
-    from ansible_collections.cloud.common.plugins.plugin_utils.turbo.lookup import (
-        TurboLookupBase as LookupBase,
-    )
+    try:
+        from ansible_collections.cloud.common.plugins.plugin_utils.turbo.lookup import (
+            TurboLookupBase as LookupBase,
+        )
+    except ImportError:
+        from ansible.plugins.lookup import LookupBase
 else:
     from ansible.plugins.lookup import LookupBase
 

--- a/plugins/lookup/datacenter_moid.py
+++ b/plugins/lookup/datacenter_moid.py
@@ -132,9 +132,12 @@ import os
 import asyncio
 
 if os.getenv("VMWARE_ENABLE_TURBO", False):
-    from ansible_collections.cloud.common.plugins.plugin_utils.turbo.lookup import (
-        TurboLookupBase as LookupBase,
-    )
+    try:
+        from ansible_collections.cloud.common.plugins.plugin_utils.turbo.lookup import (
+            TurboLookupBase as LookupBase,
+        )
+    except ImportError:
+        from ansible.plugins.lookup import LookupBase
 else:
     from ansible.plugins.lookup import LookupBase
 

--- a/plugins/lookup/datacenter_moid.py
+++ b/plugins/lookup/datacenter_moid.py
@@ -128,17 +128,43 @@ _raw:
 """
 
 
-from ansible_collections.cloud.common.plugins.plugin_utils.turbo.lookup import (
-    TurboLookupBase as LookupBase,
-)
+import os
+import asyncio
+
+if os.getenv("VMWARE_ENABLE_TURBO", False):
+    from ansible_collections.cloud.common.plugins.plugin_utils.turbo.lookup import (
+        TurboLookupBase as LookupBase,
+    )
+else:
+    from ansible.plugins.lookup import LookupBase
+
 from ansible_collections.vmware.vmware_rest.plugins.plugin_utils.lookup import Lookup
 
 
 class LookupModule(LookupBase):
+    # needed for turbo mode
     async def _run(self, terms, variables, **kwargs):
         self.set_options(var_options=variables, direct=kwargs)
         self.set_option("object_type", "datacenter")
         result = await Lookup.entry_point(terms, self._options)
         return [result]
 
-    run = _run if not hasattr(LookupBase, "run_on_daemon") else LookupBase.run_on_daemon
+    def _run_no_turbo(self, terms, variables, **kwargs):
+        self.set_options(var_options=variables, direct=kwargs)
+        self.set_option("object_type", "datacenter")
+        current_loop = asyncio.new_event_loop()
+        try:
+            asyncio.set_event_loop(current_loop)
+            result = current_loop.run_until_complete(
+                Lookup.entry_point(terms, self._options)
+            )
+        finally:
+            current_loop.close()
+
+        return [result]
+
+    run = (
+        _run_no_turbo
+        if not hasattr(LookupBase, "run_on_daemon")
+        else LookupBase.run_on_daemon
+    )

--- a/plugins/lookup/datastore_moid.py
+++ b/plugins/lookup/datastore_moid.py
@@ -141,9 +141,12 @@ import os
 import asyncio
 
 if os.getenv("VMWARE_ENABLE_TURBO", False):
-    from ansible_collections.cloud.common.plugins.plugin_utils.turbo.lookup import (
-        TurboLookupBase as LookupBase,
-    )
+    try:
+        from ansible_collections.cloud.common.plugins.plugin_utils.turbo.lookup import (
+            TurboLookupBase as LookupBase,
+        )
+    except ImportError:
+        from ansible.plugins.lookup import LookupBase
 else:
     from ansible.plugins.lookup import LookupBase
 

--- a/plugins/lookup/datastore_moid.py
+++ b/plugins/lookup/datastore_moid.py
@@ -137,17 +137,43 @@ _raw:
 """
 
 
-from ansible_collections.cloud.common.plugins.plugin_utils.turbo.lookup import (
-    TurboLookupBase as LookupBase,
-)
+import os
+import asyncio
+
+if os.getenv("VMWARE_ENABLE_TURBO", False):
+    from ansible_collections.cloud.common.plugins.plugin_utils.turbo.lookup import (
+        TurboLookupBase as LookupBase,
+    )
+else:
+    from ansible.plugins.lookup import LookupBase
+
 from ansible_collections.vmware.vmware_rest.plugins.plugin_utils.lookup import Lookup
 
 
 class LookupModule(LookupBase):
+    # needed for turbo mode
     async def _run(self, terms, variables, **kwargs):
         self.set_options(var_options=variables, direct=kwargs)
         self.set_option("object_type", "datastore")
         result = await Lookup.entry_point(terms, self._options)
         return [result]
 
-    run = _run if not hasattr(LookupBase, "run_on_daemon") else LookupBase.run_on_daemon
+    def _run_no_turbo(self, terms, variables, **kwargs):
+        self.set_options(var_options=variables, direct=kwargs)
+        self.set_option("object_type", "datastore")
+        current_loop = asyncio.new_event_loop()
+        try:
+            asyncio.set_event_loop(current_loop)
+            result = current_loop.run_until_complete(
+                Lookup.entry_point(terms, self._options)
+            )
+        finally:
+            current_loop.close()
+
+        return [result]
+
+    run = (
+        _run_no_turbo
+        if not hasattr(LookupBase, "run_on_daemon")
+        else LookupBase.run_on_daemon
+    )

--- a/plugins/lookup/folder_moid.py
+++ b/plugins/lookup/folder_moid.py
@@ -136,9 +136,12 @@ import os
 import asyncio
 
 if os.getenv("VMWARE_ENABLE_TURBO", False):
-    from ansible_collections.cloud.common.plugins.plugin_utils.turbo.lookup import (
-        TurboLookupBase as LookupBase,
-    )
+    try:
+        from ansible_collections.cloud.common.plugins.plugin_utils.turbo.lookup import (
+            TurboLookupBase as LookupBase,
+        )
+    except ImportError:
+        from ansible.plugins.lookup import LookupBase
 else:
     from ansible.plugins.lookup import LookupBase
 

--- a/plugins/lookup/folder_moid.py
+++ b/plugins/lookup/folder_moid.py
@@ -132,17 +132,43 @@ _raw:
 """
 
 
-from ansible_collections.cloud.common.plugins.plugin_utils.turbo.lookup import (
-    TurboLookupBase as LookupBase,
-)
+import os
+import asyncio
+
+if os.getenv("VMWARE_ENABLE_TURBO", False):
+    from ansible_collections.cloud.common.plugins.plugin_utils.turbo.lookup import (
+        TurboLookupBase as LookupBase,
+    )
+else:
+    from ansible.plugins.lookup import LookupBase
+
 from ansible_collections.vmware.vmware_rest.plugins.plugin_utils.lookup import Lookup
 
 
 class LookupModule(LookupBase):
+    # needed for turbo mode
     async def _run(self, terms, variables, **kwargs):
         self.set_options(var_options=variables, direct=kwargs)
         self.set_option("object_type", "folder")
         result = await Lookup.entry_point(terms, self._options)
         return [result]
 
-    run = _run if not hasattr(LookupBase, "run_on_daemon") else LookupBase.run_on_daemon
+    def _run_no_turbo(self, terms, variables, **kwargs):
+        self.set_options(var_options=variables, direct=kwargs)
+        self.set_option("object_type", "folder")
+        current_loop = asyncio.new_event_loop()
+        try:
+            asyncio.set_event_loop(current_loop)
+            result = current_loop.run_until_complete(
+                Lookup.entry_point(terms, self._options)
+            )
+        finally:
+            current_loop.close()
+
+        return [result]
+
+    run = (
+        _run_no_turbo
+        if not hasattr(LookupBase, "run_on_daemon")
+        else LookupBase.run_on_daemon
+    )

--- a/plugins/lookup/host_moid.py
+++ b/plugins/lookup/host_moid.py
@@ -141,17 +141,43 @@ _raw:
 """
 
 
-from ansible_collections.cloud.common.plugins.plugin_utils.turbo.lookup import (
-    TurboLookupBase as LookupBase,
-)
+import os
+import asyncio
+
+if os.getenv("VMWARE_ENABLE_TURBO", False):
+    from ansible_collections.cloud.common.plugins.plugin_utils.turbo.lookup import (
+        TurboLookupBase as LookupBase,
+    )
+else:
+    from ansible.plugins.lookup import LookupBase
+
 from ansible_collections.vmware.vmware_rest.plugins.plugin_utils.lookup import Lookup
 
 
 class LookupModule(LookupBase):
+    # needed for turbo mode
     async def _run(self, terms, variables, **kwargs):
         self.set_options(var_options=variables, direct=kwargs)
         self.set_option("object_type", "host")
         result = await Lookup.entry_point(terms, self._options)
         return [result]
 
-    run = _run if not hasattr(LookupBase, "run_on_daemon") else LookupBase.run_on_daemon
+    def _run_no_turbo(self, terms, variables, **kwargs):
+        self.set_options(var_options=variables, direct=kwargs)
+        self.set_option("object_type", "host")
+        current_loop = asyncio.new_event_loop()
+        try:
+            asyncio.set_event_loop(current_loop)
+            result = current_loop.run_until_complete(
+                Lookup.entry_point(terms, self._options)
+            )
+        finally:
+            current_loop.close()
+
+        return [result]
+
+    run = (
+        _run_no_turbo
+        if not hasattr(LookupBase, "run_on_daemon")
+        else LookupBase.run_on_daemon
+    )

--- a/plugins/lookup/host_moid.py
+++ b/plugins/lookup/host_moid.py
@@ -145,9 +145,12 @@ import os
 import asyncio
 
 if os.getenv("VMWARE_ENABLE_TURBO", False):
-    from ansible_collections.cloud.common.plugins.plugin_utils.turbo.lookup import (
-        TurboLookupBase as LookupBase,
-    )
+    try:
+        from ansible_collections.cloud.common.plugins.plugin_utils.turbo.lookup import (
+            TurboLookupBase as LookupBase,
+        )
+    except ImportError:
+        from ansible.plugins.lookup import LookupBase
 else:
     from ansible.plugins.lookup import LookupBase
 

--- a/plugins/lookup/network_moid.py
+++ b/plugins/lookup/network_moid.py
@@ -143,17 +143,43 @@ _raw:
 """
 
 
-from ansible_collections.cloud.common.plugins.plugin_utils.turbo.lookup import (
-    TurboLookupBase as LookupBase,
-)
+import os
+import asyncio
+
+if os.getenv("VMWARE_ENABLE_TURBO", False):
+    from ansible_collections.cloud.common.plugins.plugin_utils.turbo.lookup import (
+        TurboLookupBase as LookupBase,
+    )
+else:
+    from ansible.plugins.lookup import LookupBase
+
 from ansible_collections.vmware.vmware_rest.plugins.plugin_utils.lookup import Lookup
 
 
 class LookupModule(LookupBase):
+    # needed for turbo mode
     async def _run(self, terms, variables, **kwargs):
         self.set_options(var_options=variables, direct=kwargs)
         self.set_option("object_type", "network")
         result = await Lookup.entry_point(terms, self._options)
         return [result]
 
-    run = _run if not hasattr(LookupBase, "run_on_daemon") else LookupBase.run_on_daemon
+    def _run_no_turbo(self, terms, variables, **kwargs):
+        self.set_options(var_options=variables, direct=kwargs)
+        self.set_option("object_type", "network")
+        current_loop = asyncio.new_event_loop()
+        try:
+            asyncio.set_event_loop(current_loop)
+            result = current_loop.run_until_complete(
+                Lookup.entry_point(terms, self._options)
+            )
+        finally:
+            current_loop.close()
+
+        return [result]
+
+    run = (
+        _run_no_turbo
+        if not hasattr(LookupBase, "run_on_daemon")
+        else LookupBase.run_on_daemon
+    )

--- a/plugins/lookup/network_moid.py
+++ b/plugins/lookup/network_moid.py
@@ -147,9 +147,12 @@ import os
 import asyncio
 
 if os.getenv("VMWARE_ENABLE_TURBO", False):
-    from ansible_collections.cloud.common.plugins.plugin_utils.turbo.lookup import (
-        TurboLookupBase as LookupBase,
-    )
+    try:
+        from ansible_collections.cloud.common.plugins.plugin_utils.turbo.lookup import (
+            TurboLookupBase as LookupBase,
+        )
+    except ImportError:
+        from ansible.plugins.lookup import LookupBase
 else:
     from ansible.plugins.lookup import LookupBase
 

--- a/plugins/lookup/resource_pool_moid.py
+++ b/plugins/lookup/resource_pool_moid.py
@@ -140,9 +140,12 @@ import os
 import asyncio
 
 if os.getenv("VMWARE_ENABLE_TURBO", False):
-    from ansible_collections.cloud.common.plugins.plugin_utils.turbo.lookup import (
-        TurboLookupBase as LookupBase,
-    )
+    try:
+        from ansible_collections.cloud.common.plugins.plugin_utils.turbo.lookup import (
+            TurboLookupBase as LookupBase,
+        )
+    except ImportError:
+        from ansible.plugins.lookup import LookupBase
 else:
     from ansible.plugins.lookup import LookupBase
 

--- a/plugins/lookup/vm_moid.py
+++ b/plugins/lookup/vm_moid.py
@@ -119,9 +119,12 @@ import os
 import asyncio
 
 if os.getenv("VMWARE_ENABLE_TURBO", False):
-    from ansible_collections.cloud.common.plugins.plugin_utils.turbo.lookup import (
-        TurboLookupBase as LookupBase,
-    )
+    try:
+        from ansible_collections.cloud.common.plugins.plugin_utils.turbo.lookup import (
+            TurboLookupBase as LookupBase,
+        )
+    except ImportError:
+        from ansible.plugins.lookup import LookupBase
 else:
     from ansible.plugins.lookup import LookupBase
 

--- a/plugins/lookup/vm_moid.py
+++ b/plugins/lookup/vm_moid.py
@@ -115,17 +115,43 @@ _raw:
 """
 
 
-from ansible_collections.cloud.common.plugins.plugin_utils.turbo.lookup import (
-    TurboLookupBase as LookupBase,
-)
+import os
+import asyncio
+
+if os.getenv("VMWARE_ENABLE_TURBO", False):
+    from ansible_collections.cloud.common.plugins.plugin_utils.turbo.lookup import (
+        TurboLookupBase as LookupBase,
+    )
+else:
+    from ansible.plugins.lookup import LookupBase
+
 from ansible_collections.vmware.vmware_rest.plugins.plugin_utils.lookup import Lookup
 
 
 class LookupModule(LookupBase):
+    # needed for turbo mode
     async def _run(self, terms, variables, **kwargs):
         self.set_options(var_options=variables, direct=kwargs)
         self.set_option("object_type", "vm")
         result = await Lookup.entry_point(terms, self._options)
         return [result]
 
-    run = _run if not hasattr(LookupBase, "run_on_daemon") else LookupBase.run_on_daemon
+    def _run_no_turbo(self, terms, variables, **kwargs):
+        self.set_options(var_options=variables, direct=kwargs)
+        self.set_option("object_type", "vm")
+        current_loop = asyncio.new_event_loop()
+        try:
+            asyncio.set_event_loop(current_loop)
+            result = current_loop.run_until_complete(
+                Lookup.entry_point(terms, self._options)
+            )
+        finally:
+            current_loop.close()
+
+        return [result]
+
+    run = (
+        _run_no_turbo
+        if not hasattr(LookupBase, "run_on_daemon")
+        else LookupBase.run_on_daemon
+    )


### PR DESCRIPTION
##### SUMMARY
This change will make the turbo server optional and disable it by default. This will slow down lookup execution but otherwise will not change the lookup behavior.

This is a user requested feature. However, with the recent ansible-core 2.19 changes it seems like now is a good time to implement this. We can add a statement saying the collection does not support turbo mode in 2.19+ and remove the statement if the upstream cloud.common collection works out all the issues.

Related issues: 
https://github.com/ansible-collections/vmware.vmware_rest/issues/499
https://github.com/ansible-collections/vmware.vmware_rest/issues/364

##### ISSUE TYPE
- Feature Pull Request
