### PR TITLE
restrict cloud.common version

### DIFF
--- a/changelogs/fragments/598-bump-cloud-common-dep.yml
+++ b/changelogs/fragments/598-bump-cloud-common-dep.yml
@@ -1,3 +1,0 @@
----
-minor_changes:
-  - change cloud.common dependency to 4.1 to support anisble 2.19

--- a/changelogs/fragments/604-pin-cloud-common-dep.yml
+++ b/changelogs/fragments/604-pin-cloud-common-dep.yml
@@ -1,3 +1,3 @@
 ---
 minor_changes:
-  - restrict highest cloud.common version to 4.0.0. Higher versions do not support anisble 2.19 and cause instability in the lookup plugins
+  - restrict highest cloud.common version to 4.0.0. Higher versions cause instability in the lookup plugins

--- a/changelogs/fragments/604-pin-cloud-common-dep.yml
+++ b/changelogs/fragments/604-pin-cloud-common-dep.yml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - restrict highest cloud.common version to 4.0.0. Higher versions do not support anisble 2.19 and cause instability in the lookup plugins

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -12,7 +12,8 @@ tags:
   - vmware
   - virtualization
 dependencies:
-  cloud.common: ">=4.1.0,<5.0.0"
+  # pinned at 4.0.0 because higher versions break the lookup plugins, and do not support ansible-core 2.19
+  cloud.common: ">=3.0.0,<=4.0.0"
 repository: https://github.com/ansible-collections/vmware.vmware_rest
 homepage: https://github.com/ansible-collections/vmware.vmware_rest
 issues: https://github.com/ansible-collections/vmware.vmware_rest/issues?q=is%3Aissue+is%3Aopen+sort%3Aupdated-desc

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -12,7 +12,7 @@ tags:
   - vmware
   - virtualization
 dependencies:
-  # pinned at 4.0.0 because higher versions break the lookup plugins, and do not support ansible-core 2.19
+  # pinned at 4.0.0 because higher versions break the lookup plugins
   cloud.common: ">=3.0.0,<=4.0.0"
 repository: https://github.com/ansible-collections/vmware.vmware_rest
 homepage: https://github.com/ansible-collections/vmware.vmware_rest


### PR DESCRIPTION
##### SUMMARY
Reverts the cloud.common dependency and pins the highest at 4.0.0
Any higher and the lookup plugins are unstable

##### ISSUE TYPE
- Feature Pull Request
