### PR TITLE
Allow cloud.common 5.0.0 and later again

### DIFF
--- a/changelogs/fragments/614-cloud.common.yml
+++ b/changelogs/fragments/614-cloud.common.yml
@@ -1,0 +1,3 @@
+bugfixes:
+  - Allow cloud.common 5.0.0 and later again
+    (https://github.com/ansible-collections/vmware.vmware_rest/pull/614).

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -12,7 +12,7 @@ tags:
   - vmware
   - virtualization
 dependencies:
-  cloud.common: ">=4.1.0,<5.0.0"
+  cloud.common: ">=4.1.0"
 repository: https://github.com/ansible-collections/vmware.vmware_rest
 homepage: https://github.com/ansible-collections/vmware.vmware_rest
 issues: https://github.com/ansible-collections/vmware.vmware_rest/issues?q=is%3Aissue+is%3Aopen+sort%3Aupdated-desc


### PR DESCRIPTION
##### SUMMARY
Allow `cloud.common` 5+.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
galaxy.yml

##### ADDITIONAL INFORMATION
#613