### PR TITLE
Drop cloud.common requirement

### DIFF
--- a/changelogs/fragments/619-drop-cloud.common-requirement.yml
+++ b/changelogs/fragments/619-drop-cloud.common-requirement.yml
@@ -1,4 +1,4 @@
 ---
-minor_changes:
+major_changes:
   - Remove ``cloud.common`` as a dependency, so it will not be installed automatically anymore
     (https://github.com/ansible-collections/vmware.vmware_rest/pull/621).

--- a/changelogs/fragments/619-drop-cloud.common-requirement.yml
+++ b/changelogs/fragments/619-drop-cloud.common-requirement.yml
@@ -1,0 +1,4 @@
+---
+minor_changes:
+  - Remove ``cloud.common`` as a dependency, so it will not be installed automatically anymore
+    (https://github.com/ansible-collections/vmware.vmware_rest/pull/621).

--- a/changelogs/fragments/619-drop-cloud.common-requirement.yml
+++ b/changelogs/fragments/619-drop-cloud.common-requirement.yml
@@ -2,3 +2,6 @@
 major_changes:
   - Remove ``cloud.common`` as a dependency, so it will not be installed automatically anymore
     (https://github.com/ansible-collections/vmware.vmware_rest/pull/621).
+known_issues:
+  - The lookup plugins use ``cloud.common``, but this collection does not support ansible-core 2.19 or higher
+    (https://github.com/ansible-collections/vmware.vmware_rest/pull/621).

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -11,8 +11,6 @@ tags:
   - cloud
   - vmware
   - virtualization
-dependencies:
-  cloud.common: ">=4.1.0"
 repository: https://github.com/ansible-collections/vmware.vmware_rest
 homepage: https://github.com/ansible-collections/vmware.vmware_rest
 issues: https://github.com/ansible-collections/vmware.vmware_rest/issues?q=is%3Aissue+is%3Aopen+sort%3Aupdated-desc

--- a/plugins/lookup/cluster_moid.py
+++ b/plugins/lookup/cluster_moid.py
@@ -19,6 +19,8 @@ requirements:
   - vSphere 7.0.3 or greater
   - python >= 3.6
   - aiohttp
+notes:
+  - This plugin requires the cloud.common collection, which will not be installed automatically as a dependency.
 extends_documentation_fragment:
   - vmware.vmware_rest.moid
 """
@@ -129,9 +131,17 @@ _raw:
 """
 
 
-from ansible_collections.cloud.common.plugins.plugin_utils.turbo.lookup import (
-    TurboLookupBase as LookupBase,
-)
+from ansible.errors import AnsiblePluginError
+
+try:
+    from ansible_collections.cloud.common.plugins.plugin_utils.turbo.lookup import (
+        TurboLookupBase as LookupBase,
+    )
+except ImportError:
+    raise AnsiblePluginError(
+        message="This plugin requires the cloud.common collection."
+    )
+
 from ansible_collections.vmware.vmware_rest.plugins.plugin_utils.lookup import Lookup
 
 

--- a/plugins/lookup/datacenter_moid.py
+++ b/plugins/lookup/datacenter_moid.py
@@ -19,6 +19,8 @@ requirements:
   - vSphere 7.0.3 or greater
   - python >= 3.6
   - aiohttp
+notes:
+  - This plugin requires the cloud.common collection, which will not be installed automatically as a dependency.
 extends_documentation_fragment:
   - vmware.vmware_rest.moid
 """
@@ -128,9 +130,17 @@ _raw:
 """
 
 
-from ansible_collections.cloud.common.plugins.plugin_utils.turbo.lookup import (
-    TurboLookupBase as LookupBase,
-)
+from ansible.errors import AnsiblePluginError
+
+try:
+    from ansible_collections.cloud.common.plugins.plugin_utils.turbo.lookup import (
+        TurboLookupBase as LookupBase,
+    )
+except ImportError:
+    raise AnsiblePluginError(
+        message="This plugin requires the cloud.common collection."
+    )
+
 from ansible_collections.vmware.vmware_rest.plugins.plugin_utils.lookup import Lookup
 
 

--- a/plugins/lookup/datastore_moid.py
+++ b/plugins/lookup/datastore_moid.py
@@ -19,6 +19,8 @@ requirements:
   - vSphere 7.0.3 or greater
   - python >= 3.6
   - aiohttp
+notes:
+  - This plugin requires the cloud.common collection, which will not be installed automatically as a dependency.
 extends_documentation_fragment:
   - vmware.vmware_rest.moid
 """
@@ -137,9 +139,17 @@ _raw:
 """
 
 
-from ansible_collections.cloud.common.plugins.plugin_utils.turbo.lookup import (
-    TurboLookupBase as LookupBase,
-)
+from ansible.errors import AnsiblePluginError
+
+try:
+    from ansible_collections.cloud.common.plugins.plugin_utils.turbo.lookup import (
+        TurboLookupBase as LookupBase,
+    )
+except ImportError:
+    raise AnsiblePluginError(
+        message="This plugin requires the cloud.common collection."
+    )
+
 from ansible_collections.vmware.vmware_rest.plugins.plugin_utils.lookup import Lookup
 
 

--- a/plugins/lookup/folder_moid.py
+++ b/plugins/lookup/folder_moid.py
@@ -19,6 +19,8 @@ requirements:
   - vSphere 7.0.3 or greater
   - python >= 3.6
   - aiohttp
+notes:
+  - This plugin requires the cloud.common collection, which will not be installed automatically as a dependency.
 extends_documentation_fragment:
   - vmware.vmware_rest.moid
 """
@@ -132,9 +134,17 @@ _raw:
 """
 
 
-from ansible_collections.cloud.common.plugins.plugin_utils.turbo.lookup import (
-    TurboLookupBase as LookupBase,
-)
+from ansible.errors import AnsiblePluginError
+
+try:
+    from ansible_collections.cloud.common.plugins.plugin_utils.turbo.lookup import (
+        TurboLookupBase as LookupBase,
+    )
+except ImportError:
+    raise AnsiblePluginError(
+        message="This plugin requires the cloud.common collection."
+    )
+
 from ansible_collections.vmware.vmware_rest.plugins.plugin_utils.lookup import Lookup
 
 

--- a/plugins/lookup/host_moid.py
+++ b/plugins/lookup/host_moid.py
@@ -19,6 +19,8 @@ requirements:
   - vSphere 7.0.3 or greater
   - python >= 3.6
   - aiohttp
+notes:
+  - This plugin requires the cloud.common collection, which will not be installed automatically as a dependency.
 extends_documentation_fragment:
   - vmware.vmware_rest.moid
 """
@@ -141,9 +143,17 @@ _raw:
 """
 
 
-from ansible_collections.cloud.common.plugins.plugin_utils.turbo.lookup import (
-    TurboLookupBase as LookupBase,
-)
+from ansible.errors import AnsiblePluginError
+
+try:
+    from ansible_collections.cloud.common.plugins.plugin_utils.turbo.lookup import (
+        TurboLookupBase as LookupBase,
+    )
+except ImportError:
+    raise AnsiblePluginError(
+        message="This plugin requires the cloud.common collection."
+    )
+
 from ansible_collections.vmware.vmware_rest.plugins.plugin_utils.lookup import Lookup
 
 

--- a/plugins/lookup/network_moid.py
+++ b/plugins/lookup/network_moid.py
@@ -22,6 +22,8 @@ requirements:
   - vSphere 7.0.3 or greater
   - python >= 3.6
   - aiohttp
+notes:
+  - This plugin requires the cloud.common collection, which will not be installed automatically as a dependency.
 extends_documentation_fragment:
   - vmware.vmware_rest.moid
 """
@@ -143,9 +145,17 @@ _raw:
 """
 
 
-from ansible_collections.cloud.common.plugins.plugin_utils.turbo.lookup import (
-    TurboLookupBase as LookupBase,
-)
+from ansible.errors import AnsiblePluginError
+
+try:
+    from ansible_collections.cloud.common.plugins.plugin_utils.turbo.lookup import (
+        TurboLookupBase as LookupBase,
+    )
+except ImportError:
+    raise AnsiblePluginError(
+        message="This plugin requires the cloud.common collection."
+    )
+
 from ansible_collections.vmware.vmware_rest.plugins.plugin_utils.lookup import Lookup
 
 

--- a/plugins/lookup/resource_pool_moid.py
+++ b/plugins/lookup/resource_pool_moid.py
@@ -19,6 +19,8 @@ requirements:
   - vSphere 7.0.3 or greater
   - python >= 3.6
   - aiohttp
+notes:
+  - This plugin requires the cloud.common collection, which will not be installed automatically as a dependency.
 extends_documentation_fragment:
   - vmware.vmware_rest.moid
 """
@@ -130,9 +132,17 @@ _raw:
 """
 
 
-from ansible_collections.cloud.common.plugins.plugin_utils.turbo.lookup import (
-    TurboLookupBase as LookupBase,
-)
+from ansible.errors import AnsiblePluginError
+
+try:
+    from ansible_collections.cloud.common.plugins.plugin_utils.turbo.lookup import (
+        TurboLookupBase as LookupBase,
+    )
+except ImportError:
+    raise AnsiblePluginError(
+        message="This plugin requires the cloud.common collection."
+    )
+
 from ansible_collections.vmware.vmware_rest.plugins.plugin_utils.lookup import Lookup
 
 

--- a/plugins/lookup/vm_moid.py
+++ b/plugins/lookup/vm_moid.py
@@ -19,6 +19,8 @@ requirements:
   - vSphere 7.0.3 or greater
   - python >= 3.6
   - aiohttp
+notes:
+  - This plugin requires the cloud.common collection, which will not be installed automatically as a dependency.
 extends_documentation_fragment:
   - vmware.vmware_rest.moid
 """
@@ -115,9 +117,17 @@ _raw:
 """
 
 
-from ansible_collections.cloud.common.plugins.plugin_utils.turbo.lookup import (
-    TurboLookupBase as LookupBase,
-)
+from ansible.errors import AnsiblePluginError
+
+try:
+    from ansible_collections.cloud.common.plugins.plugin_utils.turbo.lookup import (
+        TurboLookupBase as LookupBase,
+    )
+except ImportError:
+    raise AnsiblePluginError(
+        message="This plugin requires the cloud.common collection."
+    )
+
 from ansible_collections.vmware.vmware_rest.plugins.plugin_utils.lookup import Lookup
 
 


### PR DESCRIPTION
Fixes #619

##### SUMMARY
Since [cloud.common isn't compatible with ansible-core 2.19](https://forum.ansible.com/t/41507/24), I think we should drop it as a hard dependency. That is: From `galaxy.yml`.

It would be better if the lookup plugins would work without or make this turbo stuff only optional there. But since this doesn't look easy, my solution is to 1) mention in the documentation that this collection is needed and 2) fail if it isn't installed.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
cluster_moid
datacenter_moid
datastore_moid
folder_moid
host_moid
network_moid
resource_pool_moid
vm_moid


##### ADDITIONAL INFORMATION
#620
ansible-collections/cloud.common#183